### PR TITLE
ci: protect NuGet publish environment

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -35,8 +35,8 @@ env:
   NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
 
 jobs:
-  publish:
-    name: Build and publish NuGet packages
+  verify:
+    name: Build and verify NuGet packages
     runs-on: windows-latest
     timeout-minutes: 60
 
@@ -62,15 +62,33 @@ jobs:
           retention-days: 30
           compression-level: 0
 
+  publish:
+    name: Publish NuGet packages
+    if: ${{ github.event.inputs.publishToNuGet == 'true' }}
+    needs: verify
+    runs-on: windows-latest
+    environment: nuget-production
+    timeout-minutes: 20
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download verified packages
+        uses: actions/download-artifact@v7
+        with:
+          name: teleflow-nuget-packages-${{ github.event.inputs.packageVersion }}
+          path: artifacts/release-packages/${{ github.event.inputs.packageVersion }}
+
       - name: NuGet login
-        if: ${{ github.event.inputs.publishToNuGet == 'true' }}
         id: nuget-login
         uses: NuGet/login@v1
         with:
           user: iriswolf
 
       - name: Publish packages to nuget.org
-        if: ${{ github.event.inputs.publishToNuGet == 'true' }}
         shell: pwsh
         run: |
           $packageDirectory = Join-Path $env:GITHUB_WORKSPACE "artifacts\release-packages\${{ github.event.inputs.packageVersion }}"

--- a/docs/en/enterprise/versioning.md
+++ b/docs/en/enterprise/versioning.md
@@ -37,9 +37,10 @@ Use the `NuGet Publish` workflow for alpha releases:
 1. Set `packageVersion` to a SemVer prerelease version such as `0.1.0-alpha.1`.
 2. Keep `publishToNuGet` disabled for a dry verification run.
 3. Enable `publishToNuGet` only when the packages should be pushed to nuget.org.
-4. Configure a NuGet Trusted Publishing policy for owner `iriswolf`, repository `IWFTech/TeleFlow`, and workflow file `nuget-publish.yml`.
+4. Configure a NuGet Trusted Publishing policy for owner `iriswolf`, repository `IWFTech/TeleFlow`, workflow file `nuget-publish.yml`, and environment `nuget-production`.
 
 The publish workflow uses `NuGet/login@v1` with GitHub OIDC. It does not require a long-lived NuGet API key in GitHub Secrets.
+The `nuget-production` GitHub environment is the release boundary for real package publishing and should allow deployments from `main` only.
 
 The publish workflow uses `eng/verify-release.ps1`, so a package is not pushed unless restore, format verification, build, strict analyzer verification, tests, pack, and package metadata checks complete first.
 

--- a/docs/ru/enterprise/versioning.md
+++ b/docs/ru/enterprise/versioning.md
@@ -37,9 +37,10 @@ Release verification и NuGet publishing намеренно разделены:
 1. Укажи `packageVersion` в SemVer prerelease формате, например `0.1.0-alpha.1`.
 2. Оставь `publishToNuGet` выключенным для dry verification run.
 3. Включай `publishToNuGet` только когда packages реально нужно отправить на nuget.org.
-4. Настрой NuGet Trusted Publishing policy для owner `iriswolf`, repository `IWFTech/TeleFlow` и workflow file `nuget-publish.yml`.
+4. Настрой NuGet Trusted Publishing policy для owner `iriswolf`, repository `IWFTech/TeleFlow`, workflow file `nuget-publish.yml` и environment `nuget-production`.
 
 Publish workflow использует `NuGet/login@v1` через GitHub OIDC. Long-lived NuGet API key в GitHub Secrets не нужен.
+GitHub environment `nuget-production` является release boundary для реальной публикации packages и должен разрешать deployments только из `main`.
 
 Publish workflow использует `eng/verify-release.ps1`, поэтому package не будет опубликован, пока не пройдут restore, format verification, build, strict analyzer verification, tests, pack и package metadata checks.
 


### PR DESCRIPTION
## Summary
- split NuGet publish workflow into verify and publish jobs
- bind real publishing to the nuget-production environment
- document Trusted Publishing environment requirements in English and Russian

## Validation
- parsed .github/workflows/nuget-publish.yml with PyYAML
- verified nuget-production allows deployments from main only

Supersedes #6 after branch rename.