### PR TITLE
docs: add Telegram Bot API badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/IWFTech/TeleFlow/actions/workflows/ci.yml/badge.svg)](https://github.com/IWFTech/TeleFlow/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/IWFTech/TeleFlow/actions/workflows/codeql.yml/badge.svg)](https://github.com/IWFTech/TeleFlow/actions/workflows/codeql.yml)
+[![Telegram Bot API](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FIWFTech%2FTeleFlow%2Fmain%2Fdocs%2Fbadges%2Ftelegram-bot-api.json)](https://core.telegram.org/bots/api-changelog)
 [![NuGet](https://img.shields.io/nuget/vpre/IWF.TeleFlow.Telegram.Framework.LongPolling?label=NuGet)](https://www.nuget.org/packages/IWF.TeleFlow.Telegram.Framework.LongPolling/)
 [![Downloads](https://img.shields.io/nuget/dt/IWF.TeleFlow.Telegram.Framework.LongPolling?label=downloads)](https://www.nuget.org/packages/IWF.TeleFlow.Telegram.Framework.LongPolling/)
 [![License](https://img.shields.io/github/license/IWFTech/TeleFlow)](LICENSE)

--- a/docs/badges/telegram-bot-api.json
+++ b/docs/badges/telegram-bot-api.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "label": "Telegram Bot API",
+  "message": "10.1",
+  "color": "26A5E4",
+  "namedLogo": "telegram"
+}


### PR DESCRIPTION
## Summary
- add a dynamic Shields endpoint JSON for the supported Telegram Bot API version
- show the Telegram Bot API badge in the repository README

## Validation
- parsed docs/badges/telegram-bot-api.json with ConvertFrom-Json
- git diff --check