### PR TITLE
Add cross-library benchmarks and reduce runtime hot-path overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ x86/
 arm/
 arm64/
 artifacts/
+BenchmarkDotNet.Artifacts/
 
 # NuGet
 packages/

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Planned framework work is tracked in the [roadmap](docs/en/roadmap.md).
 
 Runtime packages currently target `net10.0`. The `IWF.TeleFlow.Generators` package targets `netstandard2.0` because analyzers and source generators run inside the compiler.
 
+## Benchmarks
+
+The repository includes an isolated BenchmarkDotNet project for no-network runtime measurements:
+
+- [Benchmark methodology and commands](benchmarks/README.md)
+
+Benchmark dependencies are intentionally kept outside `TeleFlow.sln` and do not affect normal library builds or package graphs.
+
 ## License
 
 TeleFlow is released under the MIT License.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,119 @@
+# TeleFlow Benchmarks
+
+This directory contains reproducible, no-network benchmarks for TeleFlow runtime paths and comparable Telegram bot library surfaces.
+
+The suite is intentionally separate from `TeleFlow.sln`. Benchmark dependencies must not leak into normal library builds, package graphs, or consumer projects.
+
+## Scope
+
+Current benchmark suites:
+
+- TeleFlow vs Telegram.Bot update JSON deserialization.
+- TeleFlow vs Telegram.Bot native `sendMessage` client call through fixed no-network transports.
+- TeleFlow vs Telegram.Bot native `getUpdates` client call through fixed no-network transports.
+- TeleFlow raw long polling vs a handwritten Telegram.Bot raw polling loop over the same fixed update batch.
+- TeleFlow handler dispatch for command, callback prefix, and state routes.
+- TeleFlow generated client method execution through a fixed in-memory `ITelegramTransport`.
+- TeleFlow vs Telegrator command handler dispatch through public framework routing APIs.
+- TeleFlow vs Telegrator callback handler dispatch through public framework routing APIs.
+
+Planned benchmark suites:
+
+- Generated handler registration and dispatch parity.
+- Middleware pipeline cost with one, three, and ten middleware components.
+- Callback payload serialization and deserialization.
+- State data and wizard navigation scenarios.
+- Telegrator state-like routing benchmarks after an equivalent public API path is pinned down.
+
+## Fairness Rules
+
+Benchmarks in this directory must follow these rules:
+
+- Do not call Telegram over the network.
+- Do not include real database, Redis, broker, DNS, TLS, or HTTP server latency in framework comparisons.
+- Use the same update JSON fixtures for all libraries that can consume Telegram updates.
+- Keep setup costs in `GlobalSetup` unless the scenario explicitly measures startup or registration.
+- Measure one scenario per benchmark method.
+- Prefer public APIs. Do not benchmark TeleFlow internals unless the benchmark name clearly says it is an internal diagnostic benchmark.
+- Document every competitor adapter and the exact package version used.
+- If a competitor cannot be benchmarked fairly yet, leave an explicit gap instead of adding a fake comparison.
+
+## Running
+
+Build the benchmark project:
+
+```bash
+dotnet build benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -c Release
+```
+
+Run all benchmarks:
+
+```bash
+dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*"
+```
+
+Run a smoke check:
+
+```bash
+dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*TeleFlowJsonBenchmarks*" --job Dry
+```
+
+Run a category:
+
+```bash
+dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*DispatchBenchmarks*"
+```
+
+Run the fair cross-library comparison set:
+
+```bash
+dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*Vs*"
+```
+
+Run a fast smoke check for the cross-library comparison set:
+
+```bash
+dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*Vs*" --job Dry
+```
+
+When the command is run from the repository root, BenchmarkDotNet writes reports under:
+
+```text
+BenchmarkDotNet.Artifacts/
+```
+
+Do not commit generated benchmark reports unless a release note or article intentionally references a specific captured run.
+
+## Competitor Status
+
+| Library | Package | Status | Notes |
+| --- | --- | --- | --- |
+| TeleFlow | project references | Active | Measured through public APIs and local fixtures. |
+| Telegram.Bot | `Telegram.Bot` `22.10.1` | Active baseline | Used for low-level native client, raw polling loop, and update model deserialization comparisons. |
+| Telegrator | `Telegrator` `18.7.2` | Active partial | Command and callback dispatch are measured through public routing APIs. Setup verifies that benchmark handlers actually execute. State-like scenarios are not covered yet. |
+
+## Cross-Library Matrix
+
+Use `Scenarios/Vs` when publishing or discussing comparisons. These benchmarks compare the same layer to the same layer:
+
+| Benchmark | TeleFlow path | Compared path | What it answers |
+| --- | --- | --- | --- |
+| `ClientSendMessageVsBenchmarks` | Native `ITelegramClient.SendMessageAsync` | Telegram.Bot `SendMessage` | Cost of a generated API method call without network I/O. |
+| `ClientGetUpdatesVsBenchmarks` | Native `ITelegramClient.GetUpdatesAsync` | Telegram.Bot `GetUpdates` | Cost of a generated `getUpdates` call without network I/O. |
+| `RawPollingBatchVsBenchmarks` | `ITelegramLongPollingClient.RunAsync` | Handwritten Telegram.Bot polling loop | Cost of raw polling control flow over the same update batch. |
+| `FrameworkCommandDispatchVsBenchmarks` | TeleFlow dispatcher command route | Telegrator `UpdateRouter` command route | Framework command routing overhead. |
+| `FrameworkCallbackDispatchVsBenchmarks` | TeleFlow dispatcher callback route | Telegrator callback route | Framework callback routing overhead. |
+| `JsonDeserializeVsBenchmarks` | TeleFlow schema model deserialization | Telegram.Bot model deserialization | Update JSON parsing and model materialization cost. |
+
+## Interpreting Results
+
+These benchmarks are meant to answer narrow performance questions:
+
+- How much does each library allocate to deserialize the same Telegram update fixture?
+- How much overhead does framework dispatch add for common routes?
+- How much does the generated/native client method path allocate before network I/O?
+- How much overhead does raw polling control flow add after the Telegram API response is already available?
+
+They are not a replacement for application load tests. A real bot also needs workload-specific tests for database access, cache behavior, external API calls, rate limits, backpressure, and deployment topology.
+
+Do not present one table as proof that the whole framework is faster. Raw client, JSON, raw polling, and framework dispatch are separate layers. Public claims should name the measured layer and the exact competitor version.

--- a/benchmarks/TeleFlow.Benchmarks/BenchmarkConfiguration.cs
+++ b/benchmarks/TeleFlow.Benchmarks/BenchmarkConfiguration.cs
@@ -1,0 +1,21 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Loggers;
+
+namespace TeleFlow.Benchmarks;
+
+internal static class BenchmarkConfiguration
+{
+    public static IConfig Create()
+    {
+        return ManualConfig
+            .Create(DefaultConfig.Instance)
+            .AddDiagnoser(MemoryDiagnoser.Default)
+            .AddColumn(CategoriesColumn.Default)
+            .AddColumn(RankColumn.Arabic)
+            .AddExporter(JsonExporter.Full)
+            .AddLogger(ConsoleLogger.Default);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/TeleFlowJson.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/TeleFlowJson.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Benchmarks.Fixtures;
+
+internal static class TeleFlowJson
+{
+    private static readonly JsonSerializerOptions SerializerOptions =
+        TelegramJsonOptions.CreateDefault().SerializerOptions;
+
+    public static Update DeserializeUpdate(string json)
+    {
+        return JsonSerializer.Deserialize<Update>(json, SerializerOptions)
+               ?? throw new InvalidOperationException("The TeleFlow update fixture deserialized to null.");
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/TelegramBotJson.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/TelegramBotJson.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace TeleFlow.Benchmarks.Fixtures;
+
+internal static class TelegramBotJson
+{
+    private static readonly JsonSerializerOptions SerializerOptions = JsonBotAPI.Options;
+
+    public static Update DeserializeUpdate(string json)
+    {
+        return JsonSerializer.Deserialize<Update>(json, SerializerOptions)
+               ?? throw new InvalidOperationException("The Telegram.Bot update fixture deserialized to null.");
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/UpdateFixture.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/UpdateFixture.cs
@@ -1,0 +1,8 @@
+namespace TeleFlow.Benchmarks.Fixtures;
+
+public enum UpdateFixture
+{
+    MessageCommandStart,
+    MessageStateText,
+    CallbackTicketTake
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/UpdateFixtureFiles.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/UpdateFixtureFiles.cs
@@ -1,0 +1,18 @@
+namespace TeleFlow.Benchmarks.Fixtures;
+
+internal static class UpdateFixtureFiles
+{
+    public static string Read(UpdateFixture fixture)
+    {
+        var fileName = fixture switch
+        {
+            UpdateFixture.MessageCommandStart => "message-command-start.json",
+            UpdateFixture.MessageStateText => "message-state-text.json",
+            UpdateFixture.CallbackTicketTake => "callback-ticket-take.json",
+            _ => throw new ArgumentOutOfRangeException(nameof(fixture), fixture, null)
+        };
+
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Updates", fileName);
+        return File.ReadAllText(path);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/callback-ticket-take.json
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/callback-ticket-take.json
@@ -1,0 +1,28 @@
+{
+  "update_id": 1000003,
+  "callback_query": {
+    "id": "callback-1000003",
+    "from": {
+      "id": 3000001,
+      "is_bot": false,
+      "first_name": "Benchmark"
+    },
+    "message": {
+      "message_id": 4000003,
+      "date": 1710000002,
+      "chat": {
+        "id": 2000001,
+        "type": "private",
+        "first_name": "Benchmark"
+      },
+      "from": {
+        "id": 9000001,
+        "is_bot": true,
+        "first_name": "TeleFlow Bench Bot"
+      },
+      "text": "Ticket #42"
+    },
+    "chat_instance": "benchmark-chat-instance",
+    "data": "ticket:take:42"
+  }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/message-command-start.json
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/message-command-start.json
@@ -1,0 +1,25 @@
+{
+  "update_id": 1000001,
+  "message": {
+    "message_id": 4000001,
+    "date": 1710000000,
+    "chat": {
+      "id": 2000001,
+      "type": "private",
+      "first_name": "Benchmark"
+    },
+    "from": {
+      "id": 3000001,
+      "is_bot": false,
+      "first_name": "Benchmark"
+    },
+    "text": "/start",
+    "entities": [
+      {
+        "type": "bot_command",
+        "offset": 0,
+        "length": 6
+      }
+    ]
+  }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/message-state-text.json
+++ b/benchmarks/TeleFlow.Benchmarks/Fixtures/Updates/message-state-text.json
@@ -1,0 +1,18 @@
+{
+  "update_id": 1000002,
+  "message": {
+    "message_id": 4000002,
+    "date": 1710000001,
+    "chat": {
+      "id": 2000001,
+      "type": "private",
+      "first_name": "Benchmark"
+    },
+    "from": {
+      "id": 3000001,
+      "is_bot": false,
+      "first_name": "Benchmark"
+    },
+    "text": "Ada Lovelace"
+  }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkCallbackHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkCallbackHandler.cs
@@ -1,0 +1,19 @@
+using TeleFlow.Annotations;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Handlers;
+
+internal sealed class BenchmarkCallbackHandler
+{
+    [Callback]
+    [CallbackDataPrefix("ticket:")]
+    public Task HandleAsync(CallbackQueryContext context, BenchmarkProbe probe)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(probe);
+
+        probe.Record(context.Update.UpdateId);
+        return Task.CompletedTask;
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkCommandHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkCommandHandler.cs
@@ -1,0 +1,18 @@
+using TeleFlow.Annotations;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Handlers;
+
+internal sealed class BenchmarkCommandHandler
+{
+    [Command("start")]
+    public Task HandleAsync(MessageContext context, BenchmarkProbe probe)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(probe);
+
+        probe.Record(context.Update.UpdateId);
+        return Task.CompletedTask;
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkStateHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Handlers/BenchmarkStateHandler.cs
@@ -1,0 +1,20 @@
+using TeleFlow.Annotations;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Handlers;
+
+internal sealed class BenchmarkStateHandler
+{
+    [Message]
+    [HasText]
+    [State(BenchmarkStates.AwaitingName)]
+    public Task HandleAsync(MessageContext context, BenchmarkProbe probe)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(probe);
+
+        probe.Record(context.Update.UpdateId);
+        return Task.CompletedTask;
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Handlers/TelegratorBenchmarkCallbackHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Handlers/TelegratorBenchmarkCallbackHandler.cs
@@ -1,0 +1,28 @@
+using Telegram.Bot.Types;
+using Telegrator;
+using Telegrator.Handlers;
+
+namespace TeleFlow.Benchmarks.Handlers;
+
+internal static class TelegratorBenchmarkCallbackHandler
+{
+    private static int _calls;
+
+    public static int Calls => Volatile.Read(ref _calls);
+
+    public static void Reset()
+    {
+        Volatile.Write(ref _calls, 0);
+    }
+
+    public static Task<Result> Execute(
+        IHandlerContainer<CallbackQuery> container,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Interlocked.Increment(ref _calls);
+        return Task.FromResult(Result.Ok());
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Handlers/TelegratorBenchmarkCommandHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Handlers/TelegratorBenchmarkCommandHandler.cs
@@ -1,0 +1,28 @@
+using Telegram.Bot.Types;
+using Telegrator;
+using Telegrator.Annotations;
+using Telegrator.Handlers;
+
+namespace TeleFlow.Benchmarks.Handlers;
+
+[CommandAlias("start")]
+[CommandHandler]
+internal sealed class TelegratorBenchmarkCommandHandler : CommandHandler
+{
+    private static int _calls;
+
+    public static int Calls => Volatile.Read(ref _calls);
+
+    public static void Reset()
+    {
+        Volatile.Write(ref _calls, 0);
+    }
+
+    public override Task<Result> Execute(IHandlerContainer<Message> container, CancellationToken cancellation)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+
+        Interlocked.Increment(ref _calls);
+        return Task.FromResult(Ok);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/BenchmarkProbe.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/BenchmarkProbe.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class BenchmarkProbe
+{
+    private long _value;
+
+    public void Record(long value)
+    {
+        Volatile.Write(ref _value, value);
+    }
+
+    public long Value => Volatile.Read(ref _value);
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/FixedTelegramBotHttpMessageHandler.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/FixedTelegramBotHttpMessageHandler.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Text;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class FixedTelegramBotHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _responseJson;
+    private int _requestCount;
+
+    public FixedTelegramBotHttpMessageHandler(string responseJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseJson);
+
+        _responseJson = responseJson;
+    }
+
+    public int RequestCount => Volatile.Read(ref _requestCount);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Interlocked.Increment(ref _requestCount);
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+        };
+
+        return Task.FromResult(response);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/FixedTelegramTransport.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/FixedTelegramTransport.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class FixedTelegramTransport : ITelegramTransport
+{
+    private readonly TelegramTransportResponse _response;
+    private int _requestCount;
+
+    public FixedTelegramTransport(TelegramTransportResponse response)
+    {
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    public int RequestCount => Volatile.Read(ref _requestCount);
+
+    public Task<TelegramTransportResponse> SendAsync(
+        TelegramTransportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Interlocked.Increment(ref _requestCount);
+        return Task.FromResult(_response);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/TeleFlowBenchmarkRuntime.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/TeleFlowBenchmarkRuntime.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Annotations;
+using TeleFlow.Benchmarks.Handlers;
+using TeleFlow.Core.Dispatching;
+using TeleFlow.Core.States;
+using TeleFlow.Core.Updates;
+using TeleFlow.Storage.Memory;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class TeleFlowBenchmarkRuntime : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    private TeleFlowBenchmarkRuntime(ServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public static TeleFlowBenchmarkRuntime Create()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTelegramBot(options => options.Token = "benchmark-token");
+        services.AddMemoryStateStorage();
+        services.AddTelegramTransport<FixedTelegramTransport>();
+        services.AddSingleton(TelegramTransportResponses.SendMessageOk());
+        services.AddSingleton<BenchmarkProbe>();
+        services.AddTelegramHandler<BenchmarkCommandHandler>();
+        services.AddTelegramHandler<BenchmarkCallbackHandler>();
+        services.AddTelegramHandler<BenchmarkStateHandler>();
+
+        var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        return new TeleFlowBenchmarkRuntime(serviceProvider);
+    }
+
+    public ITelegramClient Bot => _serviceProvider.GetRequiredService<ITelegramClient>();
+
+    public async Task DispatchAsync(TelegramUpdatePayload payload, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        using var scope = _serviceProvider.CreateScope();
+        var context = new UpdateContext(scope.ServiceProvider, payload, cancellationToken);
+
+        await scope.ServiceProvider
+            .GetRequiredService<IUpdateDispatcher>()
+            .DispatchAsync(context, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public ValueTask SetBenchmarkStateAsync(string state, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(state);
+
+        return _serviceProvider
+            .GetRequiredService<IStateStore>()
+            .SetStateAsync(BenchmarkStateKeys.DefaultUserChat, state, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+    }
+}
+
+internal static class BenchmarkStateKeys
+{
+    public static readonly StateKey DefaultUserChat = StateKey.Create(
+        scope: "telegram",
+        subject: "user:3000001",
+        partition: "chat:2000001");
+}
+
+internal static class BenchmarkStates
+{
+    public const string AwaitingName = "benchmark:awaiting-name";
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/TeleFlowNativeClientBenchmarkRuntime.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/TeleFlowNativeClientBenchmarkRuntime.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class TeleFlowNativeClientBenchmarkRuntime : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    private TeleFlowNativeClientBenchmarkRuntime(ServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public static TeleFlowNativeClientBenchmarkRuntime Create(
+        TelegramTransportResponse response,
+        bool includeLongPolling = false)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var services = new ServiceCollection();
+
+        services.AddTelegramClient(options => options.Token = "123:benchmark");
+        services.AddSingleton(response);
+        services.AddTelegramTransport<FixedTelegramTransport>();
+
+        if (includeLongPolling)
+        {
+            services.AddTelegramLongPollingClient();
+        }
+
+        var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        return new TeleFlowNativeClientBenchmarkRuntime(serviceProvider);
+    }
+
+    public ITelegramClient Bot => _serviceProvider.GetRequiredService<ITelegramClient>();
+
+    public ITelegramLongPollingClient LongPolling => _serviceProvider.GetRequiredService<ITelegramLongPollingClient>();
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegramBotBenchmarkRuntime.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegramBotBenchmarkRuntime.cs
@@ -1,0 +1,38 @@
+using Telegram.Bot;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class TelegramBotBenchmarkRuntime : IDisposable
+{
+    private readonly HttpClient _httpClient;
+
+    private TelegramBotBenchmarkRuntime(
+        TelegramBotClient bot,
+        HttpClient httpClient,
+        FixedTelegramBotHttpMessageHandler handler)
+    {
+        Bot = bot;
+        _httpClient = httpClient;
+        Handler = handler;
+    }
+
+    public TelegramBotClient Bot { get; }
+
+    public FixedTelegramBotHttpMessageHandler Handler { get; }
+
+    public static TelegramBotBenchmarkRuntime Create(string responseJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseJson);
+
+        var handler = new FixedTelegramBotHttpMessageHandler(responseJson);
+        var httpClient = new HttpClient(handler, disposeHandler: true);
+        var bot = new TelegramBotClient("123:benchmark", httpClient);
+
+        return new TelegramBotBenchmarkRuntime(bot, httpClient, handler);
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegramTransportResponses.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegramTransportResponses.cs
@@ -1,0 +1,64 @@
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal static class TelegramTransportResponses
+{
+    public static string SendMessageOkJson()
+    {
+        return """
+               {
+                 "ok": true,
+                 "result": {
+                   "message_id": 5000001,
+                   "date": 1710000100,
+                   "chat": {
+                     "id": 2000001,
+                     "type": "private",
+                     "first_name": "Benchmark"
+                   },
+                   "from": {
+                     "id": 9000001,
+                     "is_bot": true,
+                     "first_name": "TeleFlow Bench Bot"
+                   },
+                   "text": "ok"
+                 }
+               }
+               """;
+    }
+
+    public static TelegramTransportResponse SendMessageOk()
+    {
+        return new TelegramTransportResponse(200, SendMessageOkJson());
+    }
+
+    public static TelegramTransportResponse GetUpdatesOk(params string[] updateJson)
+    {
+        return new TelegramTransportResponse(200, GetUpdatesOkJson(updateJson));
+    }
+
+    public static string GetUpdatesOkJson(params string[] updateJson)
+    {
+        ArgumentNullException.ThrowIfNull(updateJson);
+
+        if (updateJson.Length == 0)
+        {
+            return """
+                   {
+                     "ok": true,
+                     "result": []
+                   }
+                   """;
+        }
+
+        return $$"""
+                 {
+                   "ok": true,
+                   "result": [
+                     {{string.Join(",\n    ", updateJson)}}
+                   ]
+                 }
+                 """;
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegratorBenchmarkRuntime.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Infrastructure/TelegratorBenchmarkRuntime.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using TeleFlow.Benchmarks.Handlers;
+using TeleFlow.Benchmarks.Fixtures;
+using Telegrator;
+using Telegrator.Core.States;
+using Telegrator.Filters;
+using Telegrator.Handlers.Building;
+using Telegrator.Mediation;
+using Telegrator.Providers;
+
+namespace TeleFlow.Benchmarks.Infrastructure;
+
+internal sealed class TelegratorBenchmarkRuntime
+{
+    private readonly TelegramBotClient _bot;
+    private readonly UpdateRouter _router;
+
+    private TelegratorBenchmarkRuntime(TelegramBotClient bot, UpdateRouter router)
+    {
+        _bot = bot;
+        _router = router;
+    }
+
+    public static async Task<TelegratorBenchmarkRuntime> CreateAsync(CancellationToken cancellationToken = default)
+    {
+        var options = new TelegratorOptions
+        {
+            Token = "123:benchmark",
+            MaximumParallelWorkingHandlers = null
+        };
+
+        var handlers = new HandlersCollection(options);
+        handlers.AddHandler<TelegratorBenchmarkCommandHandler>();
+        var callbackBuilder = handlers.CreateCallbackQuery();
+        callbackBuilder.AddTargetedFilter(
+            static update => update.CallbackQuery!,
+            new CallbackDataStartsWithFilter("ticket:", StringComparison.Ordinal));
+        callbackBuilder.Build(TelegratorBenchmarkCallbackHandler.Execute);
+
+        var provider = new HandlersProvider(handlers, options);
+        var awaiting = new AwaitingProvider(options);
+        var stateStorage = new TelegratorBenchmarkStateStorage();
+        var botInfo = new TelegramBotInfo(new User
+        {
+            Id = 9000001,
+            IsBot = true,
+            FirstName = "Telegrator Bench Bot",
+            Username = "telegrator_bench_bot"
+        });
+
+        var runtime = new TelegratorBenchmarkRuntime(
+            new TelegramBotClient(options.Token),
+            new UpdateRouter(provider, awaiting, stateStorage, options, botInfo));
+
+        await runtime.VerifyCommandDispatchAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.VerifyCallbackDispatchAsync(cancellationToken).ConfigureAwait(false);
+
+        return runtime;
+    }
+
+    public Task DispatchAsync(Update update, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        return _router.HandleUpdateAsync(_bot, update, cancellationToken);
+    }
+
+    private async Task VerifyCommandDispatchAsync(CancellationToken cancellationToken)
+    {
+        TelegratorBenchmarkCommandHandler.Reset();
+
+        await DispatchAsync(CreateUpdate(UpdateFixture.MessageCommandStart), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (TelegratorBenchmarkCommandHandler.Calls != 1)
+        {
+            throw new InvalidOperationException("Telegrator command dispatch benchmark is invalid: the handler was not executed.");
+        }
+
+        TelegratorBenchmarkCommandHandler.Reset();
+    }
+
+    private async Task VerifyCallbackDispatchAsync(CancellationToken cancellationToken)
+    {
+        TelegratorBenchmarkCallbackHandler.Reset();
+
+        await DispatchAsync(CreateUpdate(UpdateFixture.CallbackTicketTake), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (TelegratorBenchmarkCallbackHandler.Calls != 1)
+        {
+            throw new InvalidOperationException("Telegrator callback dispatch benchmark is invalid: the handler was not executed.");
+        }
+
+        TelegratorBenchmarkCallbackHandler.Reset();
+    }
+
+    public static Update CreateUpdate(UpdateFixture fixture)
+    {
+        var json = UpdateFixtureFiles.Read(fixture);
+        return JsonSerializer.Deserialize<Update>(json, JsonBotAPI.Options)
+               ?? throw new InvalidOperationException("The Telegrator update fixture deserialized to null.");
+    }
+}
+
+internal sealed class TelegratorBenchmarkStateStorage : IStateStorage
+{
+    private readonly ConcurrentDictionary<string, object?> _values = new();
+
+    public Task SetAsync<T>(string key, T data, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        _values[key] = data;
+        return Task.CompletedTask;
+    }
+
+    public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        return Task.FromResult(_values.TryGetValue(key, out var value) ? (T?)value : default);
+    }
+
+    public Task DeleteAsync(string key, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        _values.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Program.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Program.cs
@@ -1,0 +1,6 @@
+using BenchmarkDotNet.Running;
+using TeleFlow.Benchmarks;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args, BenchmarkConfiguration.Create());

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowClientBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowClientBenchmarks.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Benchmarks.Scenarios.TeleFlow;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("teleflow", "client")]
+public class TeleFlowClientBenchmarks
+{
+    private TeleFlowBenchmarkRuntime _runtime = null!;
+    private ITelegramClient _bot = null!;
+    private IntegerString _chatId = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _runtime = TeleFlowBenchmarkRuntime.Create();
+        _bot = _runtime.Bot;
+        _chatId = IntegerString.From(2000001);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _runtime.Dispose();
+    }
+
+    [Benchmark]
+    public Task<Message> SendMessageThroughFakeTransport()
+    {
+        return _bot.SendMessageAsync(_chatId, "benchmark message");
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowDispatchBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowDispatchBenchmarks.cs
@@ -1,0 +1,59 @@
+using BenchmarkDotNet.Attributes;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Scenarios.TeleFlow;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("teleflow", "dispatch")]
+public class TeleFlowDispatchBenchmarks
+{
+    private TeleFlowBenchmarkRuntime _runtime = null!;
+    private TelegramUpdatePayload _startCommandPayload = null!;
+    private TelegramUpdatePayload _callbackPayload = null!;
+    private TelegramUpdatePayload _statePayload = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _runtime = TeleFlowBenchmarkRuntime.Create();
+        _startCommandPayload = CreatePayload(UpdateFixture.MessageCommandStart);
+        _callbackPayload = CreatePayload(UpdateFixture.CallbackTicketTake);
+        _statePayload = CreatePayload(UpdateFixture.MessageStateText);
+
+        await _runtime
+            .SetBenchmarkStateAsync(BenchmarkStates.AwaitingName)
+            .ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _runtime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task CommandRoute()
+    {
+        return _runtime.DispatchAsync(_startCommandPayload);
+    }
+
+    [Benchmark]
+    public Task CallbackPrefixRoute()
+    {
+        return _runtime.DispatchAsync(_callbackPayload);
+    }
+
+    [Benchmark]
+    public Task StateRoute()
+    {
+        return _runtime.DispatchAsync(_statePayload);
+    }
+
+    private static TelegramUpdatePayload CreatePayload(UpdateFixture fixture)
+    {
+        var json = UpdateFixtureFiles.Read(fixture);
+        return new TelegramUpdatePayload(TeleFlowJson.DeserializeUpdate(json));
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowJsonBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/TeleFlow/TeleFlowJsonBenchmarks.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Benchmarks.Scenarios.TeleFlow;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("teleflow", "json")]
+public class TeleFlowJsonBenchmarks
+{
+    private string _messageJson = string.Empty;
+    private string _callbackJson = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _messageJson = UpdateFixtureFiles.Read(UpdateFixture.MessageCommandStart);
+        _callbackJson = UpdateFixtureFiles.Read(UpdateFixture.CallbackTicketTake);
+    }
+
+    [Benchmark(Baseline = true)]
+    public Update DeserializeMessageUpdate()
+    {
+        return TeleFlowJson.DeserializeUpdate(_messageJson);
+    }
+
+    [Benchmark]
+    public Update DeserializeCallbackUpdate()
+    {
+        return TeleFlowJson.DeserializeUpdate(_callbackJson);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/TelegramBot/TelegramBotJsonBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/TelegramBot/TelegramBotJsonBenchmarks.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using TeleFlow.Benchmarks.Fixtures;
+using Telegram.Bot.Types;
+
+namespace TeleFlow.Benchmarks.Scenarios.TelegramBot;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("telegram-bot", "json")]
+public class TelegramBotJsonBenchmarks
+{
+    private string _messageJson = string.Empty;
+    private string _callbackJson = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _messageJson = UpdateFixtureFiles.Read(UpdateFixture.MessageCommandStart);
+        _callbackJson = UpdateFixtureFiles.Read(UpdateFixture.CallbackTicketTake);
+    }
+
+    [Benchmark(Baseline = true)]
+    public Update DeserializeMessageUpdate()
+    {
+        return TelegramBotJson.DeserializeUpdate(_messageJson);
+    }
+
+    [Benchmark]
+    public Update DeserializeCallbackUpdate()
+    {
+        return TelegramBotJson.DeserializeUpdate(_callbackJson);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Telegrator/TelegratorDispatchBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Telegrator/TelegratorDispatchBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+using Telegram.Bot.Types;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+
+namespace TeleFlow.Benchmarks.Scenarios.Telegrator;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("telegrator", "dispatch")]
+public class TelegratorDispatchBenchmarks
+{
+    private TelegratorBenchmarkRuntime _runtime = null!;
+    private Update _startCommandUpdate = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _runtime = await TelegratorBenchmarkRuntime.CreateAsync().ConfigureAwait(false);
+        _startCommandUpdate = TelegratorBenchmarkRuntime.CreateUpdate(UpdateFixture.MessageCommandStart);
+    }
+
+    [Benchmark]
+    public Task CommandRoute()
+    {
+        return _runtime.DispatchAsync(_startCommandUpdate);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/ClientGetUpdatesVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/ClientGetUpdatesVsBenchmarks.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using Telegram.Bot;
+using Telegram.Bot.Types.Enums;
+using TelegramBotUpdate = Telegram.Bot.Types.Update;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+using TeleFlowUpdate = TeleFlow.Telegram.Schema.Types.Update;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "client", "getUpdates")]
+public class ClientGetUpdatesVsBenchmarks
+{
+    private static readonly string[] TeleFlowAllowedUpdates = ["message"];
+    private static readonly UpdateType[] TelegramBotAllowedUpdates = [UpdateType.Message];
+
+    private TeleFlowNativeClientBenchmarkRuntime _teleFlowRuntime = null!;
+    private TelegramBotBenchmarkRuntime _telegramBotRuntime = null!;
+    private ITelegramClient _teleFlowBot = null!;
+    private TelegramBotClient _telegramBot = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var responseJson = TelegramTransportResponses.GetUpdatesOkJson(
+            UpdateFixtureFiles.Read(UpdateFixture.MessageCommandStart));
+
+        _teleFlowRuntime = TeleFlowNativeClientBenchmarkRuntime.Create(new TelegramTransportResponse(200, responseJson));
+        _telegramBotRuntime = TelegramBotBenchmarkRuntime.Create(responseJson);
+
+        _teleFlowBot = _teleFlowRuntime.Bot;
+        _telegramBot = _telegramBotRuntime.Bot;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _teleFlowRuntime.Dispose();
+        _telegramBotRuntime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<IReadOnlyList<TeleFlowUpdate>> TeleFlow_GetUpdates()
+    {
+        return _teleFlowBot.GetUpdatesAsync(
+            offset: 1000001,
+            limit: 1,
+            timeout: 0,
+            allowedUpdates: TeleFlowAllowedUpdates);
+    }
+
+    [Benchmark]
+    public Task<TelegramBotUpdate[]> TelegramBot_GetUpdates()
+    {
+        return _telegramBot.GetUpdates(
+            offset: 1000001,
+            limit: 1,
+            timeout: 0,
+            allowedUpdates: TelegramBotAllowedUpdates);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/ClientSendMessageVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/ClientSendMessageVsBenchmarks.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using Telegram.Bot;
+using TelegramBotMessage = Telegram.Bot.Types.Message;
+using TelegramBotChatId = Telegram.Bot.Types.ChatId;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlowMessage = TeleFlow.Telegram.Schema.Types.Message;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "client", "sendMessage")]
+public class ClientSendMessageVsBenchmarks
+{
+    private TeleFlowNativeClientBenchmarkRuntime _teleFlowRuntime = null!;
+    private TelegramBotBenchmarkRuntime _telegramBotRuntime = null!;
+    private ITelegramClient _teleFlowBot = null!;
+    private TelegramBotClient _telegramBot = null!;
+    private IntegerString _teleFlowChatId = null!;
+    private TelegramBotChatId _telegramBotChatId = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _teleFlowRuntime = TeleFlowNativeClientBenchmarkRuntime.Create(TelegramTransportResponses.SendMessageOk());
+        _telegramBotRuntime = TelegramBotBenchmarkRuntime.Create(TelegramTransportResponses.SendMessageOkJson());
+
+        _teleFlowBot = _teleFlowRuntime.Bot;
+        _telegramBot = _telegramBotRuntime.Bot;
+        _teleFlowChatId = IntegerString.From(2000001);
+        _telegramBotChatId = new TelegramBotChatId(2000001);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _teleFlowRuntime.Dispose();
+        _telegramBotRuntime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<TeleFlowMessage> TeleFlow_SendMessage()
+    {
+        return _teleFlowBot.SendMessageAsync(_teleFlowChatId, "benchmark message");
+    }
+
+    [Benchmark]
+    public Task<TelegramBotMessage> TelegramBot_SendMessage()
+    {
+        return _telegramBot.SendMessage(_telegramBotChatId, "benchmark message");
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/FrameworkCallbackDispatchVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/FrameworkCallbackDispatchVsBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+using TelegramBotUpdate = Telegram.Bot.Types.Update;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "framework", "dispatch", "callback")]
+public class FrameworkCallbackDispatchVsBenchmarks
+{
+    private TeleFlowBenchmarkRuntime _teleFlowRuntime = null!;
+    private TelegratorBenchmarkRuntime _telegratorRuntime = null!;
+    private TelegramUpdatePayload _teleFlowCallbackPayload = null!;
+    private TelegramBotUpdate _telegratorCallbackUpdate = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _teleFlowRuntime = TeleFlowBenchmarkRuntime.Create();
+        _telegratorRuntime = await TelegratorBenchmarkRuntime.CreateAsync().ConfigureAwait(false);
+
+        var callbackJson = UpdateFixtureFiles.Read(UpdateFixture.CallbackTicketTake);
+        _teleFlowCallbackPayload = new TelegramUpdatePayload(TeleFlowJson.DeserializeUpdate(callbackJson));
+        _telegratorCallbackUpdate = TelegratorBenchmarkRuntime.CreateUpdate(UpdateFixture.CallbackTicketTake);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _teleFlowRuntime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task TeleFlow_CallbackRoute()
+    {
+        return _teleFlowRuntime.DispatchAsync(_teleFlowCallbackPayload);
+    }
+
+    [Benchmark]
+    public Task Telegrator_CallbackRoute()
+    {
+        return _telegratorRuntime.DispatchAsync(_telegratorCallbackUpdate);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/FrameworkCommandDispatchVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/FrameworkCommandDispatchVsBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+using TelegramBotUpdate = Telegram.Bot.Types.Update;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "framework", "dispatch", "command")]
+public class FrameworkCommandDispatchVsBenchmarks
+{
+    private TeleFlowBenchmarkRuntime _teleFlowRuntime = null!;
+    private TelegratorBenchmarkRuntime _telegratorRuntime = null!;
+    private TelegramUpdatePayload _teleFlowStartCommandPayload = null!;
+    private TelegramBotUpdate _telegratorStartCommandUpdate = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _teleFlowRuntime = TeleFlowBenchmarkRuntime.Create();
+        _telegratorRuntime = await TelegratorBenchmarkRuntime.CreateAsync().ConfigureAwait(false);
+
+        var startCommandJson = UpdateFixtureFiles.Read(UpdateFixture.MessageCommandStart);
+        _teleFlowStartCommandPayload = new TelegramUpdatePayload(TeleFlowJson.DeserializeUpdate(startCommandJson));
+        _telegratorStartCommandUpdate = TelegratorBenchmarkRuntime.CreateUpdate(UpdateFixture.MessageCommandStart);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _teleFlowRuntime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task TeleFlow_CommandRoute()
+    {
+        return _teleFlowRuntime.DispatchAsync(_teleFlowStartCommandPayload);
+    }
+
+    [Benchmark]
+    public Task Telegrator_CommandRoute()
+    {
+        return _telegratorRuntime.DispatchAsync(_telegratorStartCommandUpdate);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/JsonDeserializeVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/JsonDeserializeVsBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using TelegramBotUpdate = Telegram.Bot.Types.Update;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlowUpdate = TeleFlow.Telegram.Schema.Types.Update;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "json", "deserialize")]
+public class JsonDeserializeVsBenchmarks
+{
+    private string _json = null!;
+
+    [Params(
+        UpdateFixture.MessageCommandStart,
+        UpdateFixture.CallbackTicketTake,
+        UpdateFixture.MessageStateText)]
+    public UpdateFixture Fixture { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _json = UpdateFixtureFiles.Read(Fixture);
+    }
+
+    [Benchmark(Baseline = true)]
+    public TeleFlowUpdate TeleFlow_DeserializeUpdate()
+    {
+        return TeleFlowJson.DeserializeUpdate(_json);
+    }
+
+    [Benchmark]
+    public TelegramBotUpdate TelegramBot_DeserializeUpdate()
+    {
+        return TelegramBotJson.DeserializeUpdate(_json);
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/RawPollingBatchVsBenchmarks.cs
+++ b/benchmarks/TeleFlow.Benchmarks/Scenarios/Vs/RawPollingBatchVsBenchmarks.cs
@@ -1,0 +1,129 @@
+using BenchmarkDotNet.Attributes;
+using Telegram.Bot;
+using Telegram.Bot.Types.Enums;
+using TeleFlow.Benchmarks.Fixtures;
+using TeleFlow.Benchmarks.Infrastructure;
+using TeleFlow.Telegram;
+
+namespace TeleFlow.Benchmarks.Scenarios.Vs;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("vs", "polling", "raw")]
+public class RawPollingBatchVsBenchmarks
+{
+    private const int ExpectedUpdateCount = 3;
+    private static readonly string[] TeleFlowAllowedUpdates = ["message", "callback_query"];
+    private static readonly UpdateType[] TelegramBotAllowedUpdates = [UpdateType.Message, UpdateType.CallbackQuery];
+
+    private TeleFlowNativeClientBenchmarkRuntime _teleFlowRuntime = null!;
+    private TelegramBotBenchmarkRuntime _telegramBotRuntime = null!;
+    private ITelegramLongPollingClient _teleFlowLongPolling = null!;
+    private TelegramBotClient _telegramBot = null!;
+    private TelegramRawLongPollingOptions _teleFlowOptions = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var responseJson = TelegramTransportResponses.GetUpdatesOkJson(
+            UpdateFixtureFiles.Read(UpdateFixture.MessageCommandStart),
+            UpdateFixtureFiles.Read(UpdateFixture.CallbackTicketTake),
+            UpdateFixtureFiles.Read(UpdateFixture.MessageStateText));
+
+        _teleFlowRuntime = TeleFlowNativeClientBenchmarkRuntime.Create(
+            new TelegramTransportResponse(200, responseJson),
+            includeLongPolling: true);
+        _telegramBotRuntime = TelegramBotBenchmarkRuntime.Create(responseJson);
+
+        _teleFlowLongPolling = _teleFlowRuntime.LongPolling;
+        _telegramBot = _telegramBotRuntime.Bot;
+        _teleFlowOptions = new TelegramRawLongPollingOptions
+        {
+            Limit = ExpectedUpdateCount,
+            TimeoutSeconds = 1,
+            AllowedUpdates = TeleFlowAllowedUpdates
+        };
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _teleFlowRuntime.Dispose();
+        _telegramBotRuntime.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> TeleFlow_RawPollingBatch()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var state = new RawPollingState(cancellation);
+
+        await _teleFlowLongPolling
+            .RunAsync(
+                (_, cancellationToken) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    state.Handled++;
+                    if (state.Handled == ExpectedUpdateCount)
+                    {
+                        state.Cancellation.Cancel();
+                    }
+
+                    return Task.CompletedTask;
+                },
+                _teleFlowOptions,
+                cancellation.Token)
+            .ConfigureAwait(false);
+
+        return state.Handled;
+    }
+
+    [Benchmark]
+    public async Task<int> TelegramBot_RawPollingBatch()
+    {
+        var handled = 0;
+        var offset = 1000001;
+
+        using var cancellation = new CancellationTokenSource();
+
+        while (!cancellation.IsCancellationRequested)
+        {
+            var updates = await _telegramBot
+                .GetUpdates(
+                    offset: offset,
+                    limit: ExpectedUpdateCount,
+                    timeout: 1,
+                    allowedUpdates: TelegramBotAllowedUpdates,
+                    cancellationToken: cancellation.Token)
+                .ConfigureAwait(false);
+
+            for (var index = 0; index < updates.Length; index++)
+            {
+                cancellation.Token.ThrowIfCancellationRequested();
+
+                handled++;
+                offset = updates[index].Id + 1;
+
+                if (handled == ExpectedUpdateCount)
+                {
+                    cancellation.Cancel();
+                    break;
+                }
+            }
+        }
+
+        return handled;
+    }
+
+    private sealed class RawPollingState
+    {
+        public RawPollingState(CancellationTokenSource cancellation)
+        {
+            Cancellation = cancellation;
+        }
+
+        public CancellationTokenSource Cancellation { get; }
+
+        public int Handled { get; set; }
+    }
+}

--- a/benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj
+++ b/benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Telegrator" Version="18.7.2" />
+    <PackageReference Include="Telegram.Bot" Version="22.10.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TeleFlow.Annotations\TeleFlow.Annotations.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Core\TeleFlow.Core.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Storage.Memory\TeleFlow.Storage.Memory.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Telegram.Client\TeleFlow.Telegram.Client.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Telegram.Framework\TeleFlow.Telegram.Framework.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Telegram.LongPolling\TeleFlow.Telegram.LongPolling.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Telegram.Schema\TeleFlow.Telegram.Schema.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Fixtures\Updates\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/docs/en/enterprise/performance.md
+++ b/docs/en/enterprise/performance.md
@@ -131,3 +131,4 @@ Useful benchmark groups:
 
 Do not optimize by guessing. Keep the first benchmark simple and repeatable.
 
+The repository benchmark suite lives in [benchmarks/README.md](../../../benchmarks/README.md). It currently includes a fair `Scenarios/Vs` comparison set for TeleFlow vs Telegram.Bot low-level client calls, TeleFlow raw long polling vs a handwritten Telegram.Bot polling loop, TeleFlow vs Telegram.Bot update deserialization, and TeleFlow vs Telegrator command/callback framework dispatch. Competitor adapters are only accepted when they can prove that the benchmarked path actually executed without network I/O.

--- a/docs/ru/enterprise/performance.md
+++ b/docs/ru/enterprise/performance.md
@@ -131,3 +131,4 @@ Memory storage process-local. Это не scaling strategy.
 
 Не оптимизируй на догадках. Первый benchmark должен быть simple и repeatable.
 
+Репозиторный benchmark suite находится в [benchmarks/README.md](../../../benchmarks/README.md). Сейчас он включает честный набор `Scenarios/Vs`: TeleFlow vs Telegram.Bot low-level client calls, TeleFlow raw long polling vs handwritten Telegram.Bot polling loop, TeleFlow vs Telegram.Bot update deserialization и TeleFlow vs Telegrator command/callback framework dispatch. Adapter для конкурента добавляется только тогда, когда можно доказать, что benchmark реально исполнил измеряемый path без network I/O.

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramHandlerRequestTimingScope.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramHandlerRequestTimingScope.cs
@@ -22,6 +22,8 @@ internal sealed class TelegramHandlerRequestTimingScope : IDisposable
         return scope;
     }
 
+    public static bool HasCurrent => CurrentSlot.Value is not null;
+
     public static void Record(long startTimestamp, long endTimestamp)
     {
         if (endTimestamp < startTimestamp)

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestContentBuilder.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestContentBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
@@ -10,6 +11,8 @@ namespace TeleFlow.Telegram.Internal;
 
 internal sealed class TelegramRequestContentBuilder
 {
+    private static readonly ConcurrentDictionary<Type, TypeMetadata> TypeMetadataCache = new();
+
     private readonly JsonSerializerOptions _serializerOptions;
 
     public TelegramRequestContentBuilder(JsonSerializerOptions serializerOptions)
@@ -22,7 +25,7 @@ internal sealed class TelegramRequestContentBuilder
     {
         ArgumentNullException.ThrowIfNull(payload);
 
-        if (!ContainsInputFile(payload, []))
+        if (!ContainsInputFile(payload, new HashSet<object>(ReferenceEqualityComparer.Instance)))
         {
             var json = JsonSerializer.Serialize(payload, payload.GetType(), _serializerOptions);
             return new TelegramJsonTransportContent(json);
@@ -35,7 +38,7 @@ internal sealed class TelegramRequestContentBuilder
     {
         var context = new MultipartBuildContext(_serializerOptions);
 
-        foreach (var property in GetTelegramProperties(payload.GetType()))
+        foreach (var property in GetTypeMetadata(payload.GetType()).TelegramProperties)
         {
             var value = property.GetValue(payload);
             if (value is null)
@@ -43,7 +46,7 @@ internal sealed class TelegramRequestContentBuilder
                 continue;
             }
 
-            var fieldName = GetTelegramName(property);
+            var fieldName = property.TelegramName;
             if (TryGetDirectInputFile(value, out var inputFile))
             {
                 context.AddFile(fieldName, inputFile);
@@ -74,12 +77,15 @@ internal sealed class TelegramRequestContentBuilder
             return true;
         }
 
-        if (IsScalar(value.GetType()) || value is Stream)
+        var type = value.GetType();
+        var metadata = GetTypeMetadata(type);
+
+        if (metadata.IsScalar || value is Stream)
         {
             return false;
         }
 
-        if (!value.GetType().IsValueType && !visited.Add(value))
+        if (!type.IsValueType && !visited.Add(value))
         {
             return false;
         }
@@ -97,7 +103,7 @@ internal sealed class TelegramRequestContentBuilder
             return false;
         }
 
-        foreach (var property in GetReadableProperties(value.GetType()))
+        foreach (var property in metadata.ReadableProperties)
         {
             if (ContainsInputFile(property.GetValue(value), visited))
             {
@@ -129,13 +135,13 @@ internal sealed class TelegramRequestContentBuilder
 
     private static ActiveUnionCase? GetActiveUnionCase(object value)
     {
-        var type = value.GetType();
-        if (GetTelegramProperties(type).Length > 0)
+        var metadata = GetTypeMetadata(value.GetType());
+        if (metadata.TelegramProperties.Length > 0)
         {
             return null;
         }
 
-        var activeCases = GetReadableProperties(type)
+        var activeCases = metadata.ReadableProperties
             .Select(property => new ActiveUnionCase(property.Name, property.GetValue(value)))
             .Where(static item => item.Value is not null)
             .ToArray();
@@ -143,38 +149,34 @@ internal sealed class TelegramRequestContentBuilder
         return activeCases.Length == 1 ? activeCases[0] : null;
     }
 
-    private static PropertyInfo[] GetTelegramProperties(Type type)
+    private static TypeMetadata GetTypeMetadata(Type type)
     {
-        return GetReadableProperties(type)
-            .Where(static property => property.GetCustomAttribute<JsonPropertyNameAttribute>() is not null)
-            .ToArray();
+        return TypeMetadataCache.GetOrAdd(type, CreateTypeMetadata);
     }
 
-    private static PropertyInfo[] GetReadableProperties(Type type)
+    private static TypeMetadata CreateTypeMetadata(Type type)
     {
-        return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+        var readableProperties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
             .Where(static property => property.CanRead && property.GetIndexParameters().Length == 0)
+            .Select(static property => new PropertyMetadata(
+                property,
+                property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name))
             .ToArray();
-    }
 
-    private static string GetTelegramName(PropertyInfo property)
-    {
-        return property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
-               ?? throw new InvalidOperationException(
-                   $"Telegram payload property '{property.DeclaringType?.FullName}.{property.Name}' is missing JsonPropertyName metadata.");
-    }
+        var telegramProperties = readableProperties
+            .Where(static property => property.JsonPropertyName is not null)
+            .ToArray();
 
-    private static bool IsScalar(Type type)
-    {
-        type = Nullable.GetUnderlyingType(type) ?? type;
+        var scalarType = Nullable.GetUnderlyingType(type) ?? type;
+        var isScalar = scalarType.IsPrimitive ||
+                       scalarType.IsEnum ||
+                       scalarType == typeof(string) ||
+                       scalarType == typeof(decimal) ||
+                       scalarType == typeof(DateTime) ||
+                       scalarType == typeof(DateTimeOffset) ||
+                       scalarType == typeof(Guid);
 
-        return type.IsPrimitive ||
-               type.IsEnum ||
-               type == typeof(string) ||
-               type == typeof(decimal) ||
-               type == typeof(DateTime) ||
-               type == typeof(DateTimeOffset) ||
-               type == typeof(Guid);
+        return new TypeMetadata(isScalar, readableProperties, telegramProperties);
     }
 
     private sealed class MultipartBuildContext
@@ -241,14 +243,14 @@ internal sealed class TelegramRequestContentBuilder
                 return ToJsonNode(unionCase.Value);
             }
 
-            var telegramProperties = GetTelegramProperties(value.GetType());
-            if (telegramProperties.Length == 0)
+            var metadata = GetTypeMetadata(value.GetType());
+            if (metadata.TelegramProperties.Length == 0)
             {
                 return JsonSerializer.SerializeToNode(value, value.GetType(), _serializerOptions);
             }
 
             var jsonObject = new JsonObject();
-            foreach (var property in telegramProperties)
+            foreach (var property in metadata.TelegramProperties)
             {
                 var propertyValue = property.GetValue(value);
                 if (propertyValue is null)
@@ -259,7 +261,7 @@ internal sealed class TelegramRequestContentBuilder
                 var node = ToJsonNode(propertyValue);
                 if (node is not null)
                 {
-                    jsonObject[GetTelegramName(property)] = node;
+                    jsonObject[property.TelegramName] = node;
                 }
             }
 
@@ -298,4 +300,24 @@ internal sealed class TelegramRequestContentBuilder
     }
 
     private sealed record ActiveUnionCase(string Name, object? Value);
+
+    private sealed record TypeMetadata(
+        bool IsScalar,
+        PropertyMetadata[] ReadableProperties,
+        PropertyMetadata[] TelegramProperties);
+
+    private sealed record PropertyMetadata(PropertyInfo Property, string? JsonPropertyName)
+    {
+        public string Name => Property.Name;
+
+        public string TelegramName =>
+            JsonPropertyName ??
+            throw new InvalidOperationException(
+                $"Telegram payload property '{Property.DeclaringType?.FullName}.{Property.Name}' is missing JsonPropertyName metadata.");
+
+        public object? GetValue(object value)
+        {
+            return Property.GetValue(value);
+        }
+    }
 }

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
@@ -52,35 +52,45 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
         {
             attempt++;
             TelegramTransportResponse response;
-            var attemptStarted = _timeProvider.GetTimestamp();
+            var requestDebugEnabled = !isPollingRequest && _logger.IsEnabled(LogLevel.Debug);
+            var requestErrorEnabled = !isPollingRequest && _logger.IsEnabled(LogLevel.Error);
+            var requestTimingEnabled = !isPollingRequest && TelegramHandlerRequestTimingScope.HasCurrent;
+            var requestDiagnosticsEnabled = requestDebugEnabled || requestErrorEnabled || requestTimingEnabled;
+            var attemptStarted = requestDiagnosticsEnabled ? _timeProvider.GetTimestamp() : 0;
 
             try
             {
                 var transportRequest = _sender.CreateRequest(executableRequest);
-                var contentKind = GetContentKind(transportRequest.Content);
 
-                if (!isPollingRequest)
+                if (requestDebugEnabled)
                 {
                     LogRequestStarted(
                         _logger,
                         executableRequest.MethodName,
                         attempt,
-                        contentKind);
+                        GetContentKind(transportRequest.Content));
                 }
 
                 response = await _sender.SendAsync(transportRequest, cancellationToken).ConfigureAwait(false);
-                var attemptEnded = _timeProvider.GetTimestamp();
 
-                if (!isPollingRequest)
+                if (requestDiagnosticsEnabled)
                 {
-                    TelegramHandlerRequestTimingScope.Record(attemptStarted, attemptEnded);
+                    var attemptEnded = _timeProvider.GetTimestamp();
 
-                    LogRequestCompleted(
-                        _logger,
-                        executableRequest.MethodName,
-                        attempt,
-                        response.StatusCode,
-                        GetElapsedMilliseconds(attemptStarted, attemptEnded));
+                    if (requestTimingEnabled)
+                    {
+                        TelegramHandlerRequestTimingScope.Record(attemptStarted, attemptEnded);
+                    }
+
+                    if (requestDebugEnabled)
+                    {
+                        LogRequestCompleted(
+                            _logger,
+                            executableRequest.MethodName,
+                            attempt,
+                            response.StatusCode,
+                            GetElapsedMilliseconds(attemptStarted, attemptEnded));
+                    }
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -92,17 +102,25 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                 var httpStatusCode = exception is TelegramRequestException requestException
                     ? requestException.HttpStatusCode
                     : null;
-                if (!isPollingRequest)
+                if (requestDiagnosticsEnabled)
                 {
                     var attemptEnded = _timeProvider.GetTimestamp();
-                    TelegramHandlerRequestTimingScope.Record(attemptStarted, attemptEnded);
-                    LogRequestFailure(
-                        executableRequest.MethodName,
-                        attempt,
-                        httpStatusCode,
-                        attemptStarted,
-                        attemptEnded,
-                        exception);
+
+                    if (requestTimingEnabled)
+                    {
+                        TelegramHandlerRequestTimingScope.Record(attemptStarted, attemptEnded);
+                    }
+
+                    if (requestErrorEnabled)
+                    {
+                        LogRequestFailure(
+                            executableRequest.MethodName,
+                            attempt,
+                            httpStatusCode,
+                            attemptStarted,
+                            attemptEnded,
+                            exception);
+                    }
                 }
 
                 throw;
@@ -119,7 +137,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                 {
                     if (retryAfterHeaderDelay is not null)
                     {
-                        if (!isPollingRequest)
+                        if (!isPollingRequest && _logger.IsEnabled(LogLevel.Warning))
                         {
                             LogRequestThrottled(executableRequest.MethodName, attempt, retryAfterHeaderDelay.Value);
                         }
@@ -136,7 +154,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                         executableRequest.MethodName,
                         httpStatusCode: response.StatusCode,
                         description: "Telegram throttling response did not provide retry timing metadata.");
-                    if (!isPollingRequest)
+                    if (requestErrorEnabled)
                     {
                         LogRequestFailure(
                             executableRequest.MethodName,
@@ -156,7 +174,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                     executableRequest.MethodName,
                     httpStatusCode: response.StatusCode,
                     retryAfterHeaderDelay?.Seconds);
-                if (!isPollingRequest)
+                if (requestErrorEnabled)
                 {
                     LogRequestFailure(
                         executableRequest.MethodName,
@@ -178,7 +196,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                         $"Telegram response for method '{executableRequest.MethodName}' did not contain a result payload.",
                         methodName: executableRequest.MethodName,
                         httpStatusCode: response.StatusCode);
-                    if (!isPollingRequest)
+                    if (requestErrorEnabled)
                     {
                         LogRequestFailure(
                             executableRequest.MethodName,
@@ -207,7 +225,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                         exception,
                         executableRequest.MethodName,
                         httpStatusCode: response.StatusCode);
-                    if (!isPollingRequest)
+                    if (requestErrorEnabled)
                     {
                         LogRequestFailure(
                             executableRequest.MethodName,
@@ -225,7 +243,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
             var retryAfterDelay = TelegramRetryAfterPolicy.ResolveDelay(response, envelope, _timeProvider);
             if (TelegramApiExceptionFactory.IsThrottling(response.StatusCode, envelope) && retryAfterDelay is not null)
             {
-                if (!isPollingRequest)
+                if (!isPollingRequest && _logger.IsEnabled(LogLevel.Warning))
                 {
                     LogRequestThrottled(executableRequest.MethodName, attempt, retryAfterDelay.Value);
                 }
@@ -244,7 +262,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                     response.StatusCode,
                     envelope,
                     "Telegram throttling response did not provide retry timing metadata.");
-                if (!isPollingRequest)
+                if (requestErrorEnabled)
                 {
                     LogRequestFailure(
                         executableRequest.MethodName,
@@ -262,7 +280,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                 executableRequest.MethodName,
                 response.StatusCode,
                 envelope);
-            if (!isPollingRequest)
+            if (requestErrorEnabled)
             {
                 LogRequestFailure(
                     executableRequest.MethodName,

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -45,12 +45,18 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             return;
         }
 
-        var updateType = TelegramUpdateLogFormatter.GetUpdateType(payload.Update);
+        var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
+        var errorEnabled = _logger.IsEnabled(LogLevel.Error);
+        string? updateType = null;
+        string GetUpdateType() => updateType ??= TelegramUpdateLogFormatter.GetUpdateType(payload.Update);
+
         var effectiveCancellationToken = cancellationToken.CanBeCanceled
             ? cancellationToken
             : context.CancellationToken;
-        var currentState = await GetCurrentStateAsync(context, effectiveCancellationToken).ConfigureAwait(false);
-        var matchStarted = _timeProvider.GetTimestamp();
+        var currentState = _selector.HasStatefulHandlers
+            ? await GetCurrentStateAsync(context, effectiveCancellationToken).ConfigureAwait(false)
+            : null;
+        var matchStarted = debugEnabled ? _timeProvider.GetTimestamp() : 0;
         TelegramRouteSelection? selection = null;
         TelegramUpdateContext? telegramContext = null;
 
@@ -88,33 +94,45 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             telegramContext = chatMemberContext;
         }
 
-        var matchElapsedMilliseconds = GetElapsedMilliseconds(matchStarted);
+        var matchElapsedMilliseconds = debugEnabled ? GetElapsedMilliseconds(matchStarted) : 0;
 
         if (selection is null || telegramContext is null)
         {
-            LogNoHandlerMatched(
-                _logger,
-                payload.Update.UpdateId,
-                updateType,
-                matchElapsedMilliseconds);
+            if (debugEnabled)
+            {
+                LogNoHandlerMatched(
+                    _logger,
+                    payload.Update.UpdateId,
+                    GetUpdateType(),
+                    matchElapsedMilliseconds);
+            }
+
             return;
         }
 
-        var handlerName = TelegramUpdateLogFormatter.FormatHandler(selection.Handler);
-        var routeName = TelegramUpdateLogFormatter.FormatRoute(selection.Route);
+        string? handlerName = null;
+        string? routeName = null;
+        string GetHandlerName() => handlerName ??= TelegramUpdateLogFormatter.FormatHandler(selection.Handler);
+        string GetRouteName() => routeName ??= TelegramUpdateLogFormatter.FormatRoute(selection.Route);
 
-        LogHandlerMatched(
-            _logger,
-            payload.Update.UpdateId,
-            updateType,
-            handlerName,
-            routeName,
-            selection.Handler.ModuleName ?? string.Empty,
-            selection.Handler.SceneName ?? string.Empty,
-            matchElapsedMilliseconds);
+        if (debugEnabled)
+        {
+            LogHandlerMatched(
+                _logger,
+                payload.Update.UpdateId,
+                GetUpdateType(),
+                GetHandlerName(),
+                GetRouteName(),
+                selection.Handler.ModuleName ?? string.Empty,
+                selection.Handler.SceneName ?? string.Empty,
+                matchElapsedMilliseconds);
+        }
 
-        var handlerStarted = _timeProvider.GetTimestamp();
-        using var requestTimingScope = TelegramHandlerRequestTimingScope.Begin();
+        var handlerDiagnosticsEnabled = debugEnabled || errorEnabled;
+        var handlerStarted = handlerDiagnosticsEnabled ? _timeProvider.GetTimestamp() : 0;
+        using var requestTimingScope = handlerDiagnosticsEnabled
+            ? TelegramHandlerRequestTimingScope.Begin()
+            : null;
 
         try
         {
@@ -125,32 +143,38 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
         catch (Exception exception) when (!IsUpdateCancellation(exception, effectiveCancellationToken))
         {
-            var handlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
-            var timing = requestTimingScope.CreateSummary(_timeProvider, handlerElapsed);
+            var handlerElapsed = handlerDiagnosticsEnabled
+                ? _timeProvider.GetElapsedTime(handlerStarted)
+                : TimeSpan.Zero;
+            var timing = requestTimingScope?.CreateSummary(_timeProvider, handlerElapsed) ?? default;
 
-            LogHandlerFailed(
-                _logger,
-                exception,
-                payload.Update.UpdateId,
-                updateType,
-                handlerName,
-                routeName,
-                selection.Handler.ModuleName ?? string.Empty,
-                selection.Handler.SceneName ?? string.Empty,
-                exception.GetType().FullName ?? exception.GetType().Name,
-                handlerElapsed.TotalMilliseconds,
-                timing.RequestCount,
-                timing.RequestElapsedMilliseconds,
-                timing.HandlerLogicElapsedMilliseconds);
+            if (errorEnabled)
+            {
+                LogHandlerFailed(
+                    _logger,
+                    exception,
+                    payload.Update.UpdateId,
+                    GetUpdateType(),
+                    GetHandlerName(),
+                    GetRouteName(),
+                    selection.Handler.ModuleName ?? string.Empty,
+                    selection.Handler.SceneName ?? string.Empty,
+                    exception.GetType().FullName ?? exception.GetType().Name,
+                    handlerElapsed.TotalMilliseconds,
+                    timing.RequestCount,
+                    timing.RequestElapsedMilliseconds,
+                    timing.HandlerLogicElapsedMilliseconds);
+            }
 
-            if (await TryHandleErrorAsync(
+            if (_errorHandlers.Length > 0 &&
+                await TryHandleErrorAsync(
                     selection,
                     telegramContext,
                     exception,
                     payload.Update.UpdateId,
-                    updateType,
-                    handlerName,
-                    routeName,
+                    GetUpdateType(),
+                    GetHandlerName(),
+                    GetRouteName(),
                     effectiveCancellationToken).ConfigureAwait(false))
             {
                 return;
@@ -164,15 +188,20 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             telegramContext,
             effectiveCancellationToken).ConfigureAwait(false);
 
+        if (!debugEnabled)
+        {
+            return;
+        }
+
         var completedHandlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
-        var completedTiming = requestTimingScope.CreateSummary(_timeProvider, completedHandlerElapsed);
+        var completedTiming = requestTimingScope!.CreateSummary(_timeProvider, completedHandlerElapsed);
 
         LogHandlerCompleted(
             _logger,
             payload.Update.UpdateId,
-            updateType,
-            handlerName,
-            routeName,
+            GetUpdateType(),
+            GetHandlerName(),
+            GetRouteName(),
             completedHandlerElapsed.TotalMilliseconds,
             completedTiming.RequestCount,
             completedTiming.RequestElapsedMilliseconds,
@@ -252,17 +281,20 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 cancellationToken).ConfigureAwait(false);
             var handled = result == TelegramErrorHandlingResult.Handled;
 
-            LogErrorHandlerCompleted(
-                _logger,
-                updateId,
-                updateType,
-                handlerName,
-                routeName,
-                selection.Handler.ModuleName ?? string.Empty,
-                selection.Handler.SceneName ?? string.Empty,
-                exception.GetType().FullName ?? exception.GetType().Name,
-                FormatErrorHandler(errorHandler),
-                handled);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                LogErrorHandlerCompleted(
+                    _logger,
+                    updateId,
+                    updateType,
+                    handlerName,
+                    routeName,
+                    selection.Handler.ModuleName ?? string.Empty,
+                    selection.Handler.SceneName ?? string.Empty,
+                    exception.GetType().FullName ?? exception.GetType().Name,
+                    FormatErrorHandler(errorHandler),
+                    handled);
+            }
 
             if (handled)
             {

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -1,7 +1,7 @@
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using TeleFlow.Core.Callbacks;
@@ -15,6 +15,7 @@ internal sealed class TelegramHandlerSelector
     private static readonly IReadOnlyDictionary<string, object?> EmptyRouteValues =
         new ReadOnlyDictionary<string, object?>(
             new Dictionary<string, object?>(StringComparer.Ordinal));
+    private static readonly ConcurrentDictionary<Type, CallbackPayloadDeserializer> CallbackPayloadDeserializers = new();
 
     private readonly TelegramHandlerTable _table;
 
@@ -23,6 +24,8 @@ internal sealed class TelegramHandlerSelector
         ArgumentNullException.ThrowIfNull(table);
         _table = table;
     }
+
+    public bool HasStatefulHandlers => _table.HasStatefulHandlers;
 
     public async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
         MessageContext context,
@@ -190,7 +193,7 @@ internal sealed class TelegramHandlerSelector
     {
         if (!string.IsNullOrWhiteSpace(currentState))
         {
-            foreach (var handler in OrderForRouteSelection(handlers))
+            foreach (var handler in handlers)
             {
                 if (MatchesState(handler, currentState))
                 {
@@ -199,7 +202,7 @@ internal sealed class TelegramHandlerSelector
             }
         }
 
-        foreach (var handler in OrderForRouteSelection(handlers))
+        foreach (var handler in handlers)
         {
             if (handler.States.Count == 0)
             {
@@ -258,27 +261,12 @@ internal sealed class TelegramHandlerSelector
         Type payloadType,
         out object? payload)
     {
-        var deserializeMethod = typeof(ICallbackDataSerializer)
-            .GetMethod(nameof(ICallbackDataSerializer.Deserialize))!
-            .MakeGenericMethod(payloadType);
+        var deserializer = CallbackPayloadDeserializers.GetOrAdd(payloadType, CreateCallbackPayloadDeserializer);
 
         try
         {
-            payload = deserializeMethod.Invoke(
-                context.CallbackData,
-                [context.TelegramCallbackQuery.Data]);
+            payload = deserializer(context.CallbackData, context.TelegramCallbackQuery.Data!);
             return true;
-        }
-        catch (TargetInvocationException exception) when (exception.InnerException is not null)
-        {
-            if (IsCallbackPayloadNoMatchException(exception.InnerException))
-            {
-                payload = null;
-                return false;
-            }
-
-            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
-            throw;
         }
         catch (Exception exception) when (IsCallbackPayloadNoMatchException(exception))
         {
@@ -290,6 +278,22 @@ internal sealed class TelegramHandlerSelector
     private static bool IsCallbackPayloadNoMatchException(Exception exception)
     {
         return exception is JsonException or FormatException or OverflowException;
+    }
+
+    private static CallbackPayloadDeserializer CreateCallbackPayloadDeserializer(Type payloadType)
+    {
+        var deserializeMethod = typeof(TelegramHandlerSelector)
+            .GetMethod(nameof(DeserializeCallbackPayload), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(payloadType);
+
+        return deserializeMethod.CreateDelegate<CallbackPayloadDeserializer>();
+    }
+
+    private static object? DeserializeCallbackPayload<TPayload>(
+        ICallbackDataSerializer serializer,
+        string data)
+    {
+        return serializer.Deserialize<TPayload>(data);
     }
 
     private static bool TryGetCommandBody(
@@ -518,32 +522,5 @@ internal sealed class TelegramHandlerSelector
             (transition.NewStatus & newStatus) != 0);
     }
 
-    private static IEnumerable<TelegramHandlerDescriptor> OrderForRouteSelection(
-        IReadOnlyList<TelegramHandlerDescriptor> handlers)
-    {
-        return handlers
-            .OrderBy(static handler => GetRoutePriority(handler.Route))
-            .ThenByDescending(static handler => handler.Route.Specificity)
-            .ThenBy(static handler => handler.RegistrationOrder);
-    }
-
-    private static int GetRoutePriority(TelegramRouteDescriptor route)
-    {
-        return route.RouteKind switch
-        {
-            TelegramRouteKind.CommandExact => 0,
-            TelegramRouteKind.CommandTemplate => 1,
-            TelegramRouteKind.CommandRegex => 2,
-            TelegramRouteKind.TextExact => 10,
-            TelegramRouteKind.MessageAny when route.TextFilters.Count > 0 => 10,
-            TelegramRouteKind.TextTemplate => 11,
-            TelegramRouteKind.TextRegex => 12,
-            TelegramRouteKind.MessageAny => 13,
-            TelegramRouteKind.ChatMemberUpdated or
-                TelegramRouteKind.MyChatMemberUpdated when route.ChatMemberTransitions.Count > 0 => 0,
-            TelegramRouteKind.ChatMemberUpdated or
-                TelegramRouteKind.MyChatMemberUpdated => 1,
-            _ => 100
-        };
-    }
+    private delegate object? CallbackPayloadDeserializer(ICallbackDataSerializer serializer, string data);
 }

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerTable.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerTable.cs
@@ -10,18 +10,19 @@ internal sealed class TelegramHandlerTable
             .OrderBy(static descriptor => descriptor.RegistrationOrder)
             .ToArray();
 
-        CommandHandlers = orderedDescriptors
+        CommandHandlers = OrderForRouteSelection(orderedDescriptors
             .Where(static descriptor => descriptor.Kind == TelegramHandlerKind.Command)
-            .ToArray();
-        MessageHandlers = orderedDescriptors
+            .ToArray());
+        MessageHandlers = OrderForRouteSelection(orderedDescriptors
             .Where(static descriptor => descriptor.Kind == TelegramHandlerKind.Message)
-            .ToArray();
+            .ToArray());
         CallbackHandlers = orderedDescriptors
             .Where(static descriptor => descriptor.Kind == TelegramHandlerKind.Callback)
             .ToArray();
-        ChatMemberHandlers = orderedDescriptors
+        ChatMemberHandlers = OrderForRouteSelection(orderedDescriptors
             .Where(static descriptor => descriptor.Kind == TelegramHandlerKind.ChatMember)
-            .ToArray();
+            .ToArray());
+        HasStatefulHandlers = orderedDescriptors.Any(static descriptor => descriptor.States.Count > 0);
 
         EnsureNoDuplicateCallbackPrefixes(CallbackHandlers);
     }
@@ -33,6 +34,8 @@ internal sealed class TelegramHandlerTable
     public IReadOnlyList<TelegramHandlerDescriptor> CallbackHandlers { get; }
 
     public IReadOnlyList<TelegramHandlerDescriptor> ChatMemberHandlers { get; }
+
+    public bool HasStatefulHandlers { get; }
 
     private static void EnsureNoDuplicateCallbackPrefixes(IReadOnlyList<TelegramHandlerDescriptor> callbackHandlers)
     {
@@ -59,5 +62,34 @@ internal sealed class TelegramHandlerTable
 
         throw new InvalidOperationException(
             $"Duplicate Telegram callback data prefix '{duplicatePrefix.Key}' is used by multiple handlers: {handlers}.");
+    }
+
+    private static TelegramHandlerDescriptor[] OrderForRouteSelection(IEnumerable<TelegramHandlerDescriptor> handlers)
+    {
+        return handlers
+            .OrderBy(static handler => GetRoutePriority(handler.Route))
+            .ThenByDescending(static handler => handler.Route.Specificity)
+            .ThenBy(static handler => handler.RegistrationOrder)
+            .ToArray();
+    }
+
+    private static int GetRoutePriority(TelegramRouteDescriptor route)
+    {
+        return route.RouteKind switch
+        {
+            TelegramRouteKind.CommandExact => 0,
+            TelegramRouteKind.CommandTemplate => 1,
+            TelegramRouteKind.CommandRegex => 2,
+            TelegramRouteKind.TextExact => 10,
+            TelegramRouteKind.MessageAny when route.TextFilters.Count > 0 => 10,
+            TelegramRouteKind.TextTemplate => 11,
+            TelegramRouteKind.TextRegex => 12,
+            TelegramRouteKind.MessageAny => 13,
+            TelegramRouteKind.ChatMemberUpdated or
+                TelegramRouteKind.MyChatMemberUpdated when route.ChatMemberTransitions.Count > 0 => 0,
+            TelegramRouteKind.ChatMemberUpdated or
+                TelegramRouteKind.MyChatMemberUpdated => 1,
+            _ => 100
+        };
     }
 }

--- a/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
+++ b/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
@@ -71,24 +71,32 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
             for (var index = 0; index < updates.Count; index++)
             {
                 var update = updates[index];
-                var updateType = TelegramRawLongPollingLogFormatter.GetUpdateType(update);
-                var processingStarted = _timeProvider.GetTimestamp();
 
-                LogUpdateReceived(
-                    _logger,
-                    update.UpdateId,
-                    updateType,
-                    index + 1,
-                    updates.Count);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    var updateType = TelegramRawLongPollingLogFormatter.GetUpdateType(update);
+                    var processingStarted = _timeProvider.GetTimestamp();
+
+                    LogUpdateReceived(
+                        _logger,
+                        update.UpdateId,
+                        updateType,
+                        index + 1,
+                        updates.Count);
+
+                    await updateHandler(update, cancellationToken).ConfigureAwait(false);
+                    offset = update.UpdateId + 1;
+
+                    LogUpdateAcknowledgedByHandler(
+                        _logger,
+                        update.UpdateId,
+                        updateType,
+                        GetElapsedMilliseconds(processingStarted));
+                    continue;
+                }
 
                 await updateHandler(update, cancellationToken).ConfigureAwait(false);
                 offset = update.UpdateId + 1;
-
-                LogUpdateAcknowledgedByHandler(
-                    _logger,
-                    update.UpdateId,
-                    updateType,
-                    GetElapsedMilliseconds(processingStarted));
             }
         }
     }
@@ -137,10 +145,18 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
                 var update = updates[index];
                 var polledUpdate = new TelegramPolledUpdate(update, index + 1, updates.Count);
 
-                LogStreamUpdateReceived(
-                    _logger,
-                    update.UpdateId,
-                    TelegramRawLongPollingLogFormatter.GetUpdateType(update));
+                var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
+                var updateType = debugEnabled
+                    ? TelegramRawLongPollingLogFormatter.GetUpdateType(update)
+                    : string.Empty;
+
+                if (debugEnabled)
+                {
+                    LogStreamUpdateReceived(
+                        _logger,
+                        update.UpdateId,
+                        updateType);
+                }
 
                 yield return polledUpdate;
 
@@ -152,10 +168,13 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
 
                 offset = update.UpdateId + 1;
 
-                LogStreamUpdateAcknowledged(
-                    _logger,
-                    update.UpdateId,
-                    TelegramRawLongPollingLogFormatter.GetUpdateType(update));
+                if (debugEnabled)
+                {
+                    LogStreamUpdateAcknowledged(
+                        _logger,
+                        update.UpdateId,
+                        updateType);
+                }
             }
         }
     }
@@ -206,6 +225,11 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
         TelegramRawLongPollingOptions options,
         IReadOnlyList<string>? allowedUpdates)
     {
+        if (!_logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
         LogStarting(
             _logger,
             TelegramRawLongPollingLogFormatter.FormatAllowedUpdates(allowedUpdates),

--- a/src/TeleFlow.Telegram.Schema/Abstractions/InputFileString.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Abstractions/InputFileString.g.cs
@@ -104,7 +104,6 @@ file sealed class InputFileStringJsonConverter : JsonConverter<InputFileString>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         throw new JsonException("Unable to deserialize InputFileString from the provided Telegram payload.");
     }

--- a/src/TeleFlow.Telegram.Schema/Abstractions/InputMediaGroupItem.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Abstractions/InputMediaGroupItem.g.cs
@@ -189,7 +189,6 @@ file sealed class InputMediaGroupItemJsonConverter : JsonConverter<InputMediaGro
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -197,19 +196,19 @@ file sealed class InputMediaGroupItemJsonConverter : JsonConverter<InputMediaGro
             switch (discriminator)
             {
                 case "audio":
-                    return InputMediaGroupItem.From(JsonSerializer.Deserialize<InputMediaAudio>(json, options)
+                    return InputMediaGroupItem.From(document.RootElement.Deserialize<InputMediaAudio>(options)
                         ?? throw new JsonException("Unable to deserialize InputMediaGroupItem as InputMediaAudio."));
                 case "document":
-                    return InputMediaGroupItem.From(JsonSerializer.Deserialize<InputMediaDocument>(json, options)
+                    return InputMediaGroupItem.From(document.RootElement.Deserialize<InputMediaDocument>(options)
                         ?? throw new JsonException("Unable to deserialize InputMediaGroupItem as InputMediaDocument."));
                 case "live_photo":
-                    return InputMediaGroupItem.From(JsonSerializer.Deserialize<InputMediaLivePhoto>(json, options)
+                    return InputMediaGroupItem.From(document.RootElement.Deserialize<InputMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputMediaGroupItem as InputMediaLivePhoto."));
                 case "photo":
-                    return InputMediaGroupItem.From(JsonSerializer.Deserialize<InputMediaPhoto>(json, options)
+                    return InputMediaGroupItem.From(document.RootElement.Deserialize<InputMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputMediaGroupItem as InputMediaPhoto."));
                 case "video":
-                    return InputMediaGroupItem.From(JsonSerializer.Deserialize<InputMediaVideo>(json, options)
+                    return InputMediaGroupItem.From(document.RootElement.Deserialize<InputMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputMediaGroupItem as InputMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputMediaGroupItem.");

--- a/src/TeleFlow.Telegram.Schema/Abstractions/IntegerString.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Abstractions/IntegerString.g.cs
@@ -108,7 +108,6 @@ file sealed class IntegerStringJsonConverter : JsonConverter<IntegerString>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         throw new JsonException("Unable to deserialize IntegerString from the provided Telegram payload.");
     }

--- a/src/TeleFlow.Telegram.Schema/Abstractions/MessageBoolean.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Abstractions/MessageBoolean.g.cs
@@ -103,11 +103,10 @@ file sealed class MessageBooleanJsonConverter : JsonConverter<MessageBoolean>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("chat", out _) && document.RootElement.TryGetProperty("date", out _) && document.RootElement.TryGetProperty("message_id", out _))
         {
-            return MessageBoolean.From(JsonSerializer.Deserialize<Message>(json, options)
+            return MessageBoolean.From(document.RootElement.Deserialize<Message>(options)
                 ?? throw new JsonException("Unable to deserialize MessageBoolean as Message."));
         }
 

--- a/src/TeleFlow.Telegram.Schema/Abstractions/ReplyMarkup.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Abstractions/ReplyMarkup.g.cs
@@ -159,29 +159,28 @@ file sealed class ReplyMarkupJsonConverter : JsonConverter<ReplyMarkup>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("force_reply", out _))
         {
-            return ReplyMarkup.From(JsonSerializer.Deserialize<ForceReply>(json, options)
+            return ReplyMarkup.From(document.RootElement.Deserialize<ForceReply>(options)
                 ?? throw new JsonException("Unable to deserialize ReplyMarkup as ForceReply."));
         }
 
         if (document.RootElement.TryGetProperty("inline_keyboard", out _))
         {
-            return ReplyMarkup.From(JsonSerializer.Deserialize<InlineKeyboardMarkup>(json, options)
+            return ReplyMarkup.From(document.RootElement.Deserialize<InlineKeyboardMarkup>(options)
                 ?? throw new JsonException("Unable to deserialize ReplyMarkup as InlineKeyboardMarkup."));
         }
 
         if (document.RootElement.TryGetProperty("keyboard", out _))
         {
-            return ReplyMarkup.From(JsonSerializer.Deserialize<ReplyKeyboardMarkup>(json, options)
+            return ReplyMarkup.From(document.RootElement.Deserialize<ReplyKeyboardMarkup>(options)
                 ?? throw new JsonException("Unable to deserialize ReplyMarkup as ReplyKeyboardMarkup."));
         }
 
         if (document.RootElement.TryGetProperty("remove_keyboard", out _))
         {
-            return ReplyMarkup.From(JsonSerializer.Deserialize<ReplyKeyboardRemove>(json, options)
+            return ReplyMarkup.From(document.RootElement.Deserialize<ReplyKeyboardRemove>(options)
                 ?? throw new JsonException("Unable to deserialize ReplyMarkup as ReplyKeyboardRemove."));
         }
 

--- a/src/TeleFlow.Telegram.Schema/Types/BackgroundFill.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/BackgroundFill.g.cs
@@ -134,7 +134,6 @@ file sealed class BackgroundFillJsonConverter : JsonConverter<BackgroundFill>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -142,13 +141,13 @@ file sealed class BackgroundFillJsonConverter : JsonConverter<BackgroundFill>
             switch (discriminator)
             {
                 case "freeform_gradient":
-                    return BackgroundFill.From(JsonSerializer.Deserialize<BackgroundFillFreeformGradient>(json, options)
+                    return BackgroundFill.From(document.RootElement.Deserialize<BackgroundFillFreeformGradient>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundFill as BackgroundFillFreeformGradient."));
                 case "gradient":
-                    return BackgroundFill.From(JsonSerializer.Deserialize<BackgroundFillGradient>(json, options)
+                    return BackgroundFill.From(document.RootElement.Deserialize<BackgroundFillGradient>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundFill as BackgroundFillGradient."));
                 case "solid":
-                    return BackgroundFill.From(JsonSerializer.Deserialize<BackgroundFillSolid>(json, options)
+                    return BackgroundFill.From(document.RootElement.Deserialize<BackgroundFillSolid>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundFill as BackgroundFillSolid."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for BackgroundFill.");

--- a/src/TeleFlow.Telegram.Schema/Types/BackgroundType.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/BackgroundType.g.cs
@@ -165,7 +165,6 @@ file sealed class BackgroundTypeJsonConverter : JsonConverter<BackgroundType>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -173,16 +172,16 @@ file sealed class BackgroundTypeJsonConverter : JsonConverter<BackgroundType>
             switch (discriminator)
             {
                 case "chat_theme":
-                    return BackgroundType.From(JsonSerializer.Deserialize<BackgroundTypeChatTheme>(json, options)
+                    return BackgroundType.From(document.RootElement.Deserialize<BackgroundTypeChatTheme>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundType as BackgroundTypeChatTheme."));
                 case "fill":
-                    return BackgroundType.From(JsonSerializer.Deserialize<BackgroundTypeFill>(json, options)
+                    return BackgroundType.From(document.RootElement.Deserialize<BackgroundTypeFill>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundType as BackgroundTypeFill."));
                 case "pattern":
-                    return BackgroundType.From(JsonSerializer.Deserialize<BackgroundTypePattern>(json, options)
+                    return BackgroundType.From(document.RootElement.Deserialize<BackgroundTypePattern>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundType as BackgroundTypePattern."));
                 case "wallpaper":
-                    return BackgroundType.From(JsonSerializer.Deserialize<BackgroundTypeWallpaper>(json, options)
+                    return BackgroundType.From(document.RootElement.Deserialize<BackgroundTypeWallpaper>(options)
                         ?? throw new JsonException("Unable to deserialize BackgroundType as BackgroundTypeWallpaper."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for BackgroundType.");

--- a/src/TeleFlow.Telegram.Schema/Types/BotCommandScope.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/BotCommandScope.g.cs
@@ -258,7 +258,6 @@ file sealed class BotCommandScopeJsonConverter : JsonConverter<BotCommandScope>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -266,25 +265,25 @@ file sealed class BotCommandScopeJsonConverter : JsonConverter<BotCommandScope>
             switch (discriminator)
             {
                 case "all_chat_administrators":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeAllChatAdministrators>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeAllChatAdministrators>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeAllChatAdministrators."));
                 case "all_group_chats":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeAllGroupChats>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeAllGroupChats>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeAllGroupChats."));
                 case "all_private_chats":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeAllPrivateChats>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeAllPrivateChats>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeAllPrivateChats."));
                 case "chat":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeChat>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeChat>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeChat."));
                 case "chat_administrators":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeChatAdministrators>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeChatAdministrators>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeChatAdministrators."));
                 case "chat_member":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeChatMember>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeChatMember>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeChatMember."));
                 case "default":
-                    return BotCommandScope.From(JsonSerializer.Deserialize<BotCommandScopeDefault>(json, options)
+                    return BotCommandScope.From(document.RootElement.Deserialize<BotCommandScopeDefault>(options)
                         ?? throw new JsonException("Unable to deserialize BotCommandScope as BotCommandScopeDefault."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for BotCommandScope.");

--- a/src/TeleFlow.Telegram.Schema/Types/ChatBoostSource.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/ChatBoostSource.g.cs
@@ -134,7 +134,6 @@ file sealed class ChatBoostSourceJsonConverter : JsonConverter<ChatBoostSource>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("source", out var sourceElement) && sourceElement.ValueKind == JsonValueKind.String)
         {
@@ -142,13 +141,13 @@ file sealed class ChatBoostSourceJsonConverter : JsonConverter<ChatBoostSource>
             switch (discriminator)
             {
                 case "gift_code":
-                    return ChatBoostSource.From(JsonSerializer.Deserialize<ChatBoostSourceGiftCode>(json, options)
+                    return ChatBoostSource.From(document.RootElement.Deserialize<ChatBoostSourceGiftCode>(options)
                         ?? throw new JsonException("Unable to deserialize ChatBoostSource as ChatBoostSourceGiftCode."));
                 case "giveaway":
-                    return ChatBoostSource.From(JsonSerializer.Deserialize<ChatBoostSourceGiveaway>(json, options)
+                    return ChatBoostSource.From(document.RootElement.Deserialize<ChatBoostSourceGiveaway>(options)
                         ?? throw new JsonException("Unable to deserialize ChatBoostSource as ChatBoostSourceGiveaway."));
                 case "premium":
-                    return ChatBoostSource.From(JsonSerializer.Deserialize<ChatBoostSourcePremium>(json, options)
+                    return ChatBoostSource.From(document.RootElement.Deserialize<ChatBoostSourcePremium>(options)
                         ?? throw new JsonException("Unable to deserialize ChatBoostSource as ChatBoostSourcePremium."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for ChatBoostSource.");

--- a/src/TeleFlow.Telegram.Schema/Types/ChatMember.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/ChatMember.g.cs
@@ -227,7 +227,6 @@ file sealed class ChatMemberJsonConverter : JsonConverter<ChatMember>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("status", out var statusElement) && statusElement.ValueKind == JsonValueKind.String)
         {
@@ -235,22 +234,22 @@ file sealed class ChatMemberJsonConverter : JsonConverter<ChatMember>
             switch (discriminator)
             {
                 case "administrator":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberAdministrator>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberAdministrator>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberAdministrator."));
                 case "creator":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberOwner>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberOwner>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberOwner."));
                 case "kicked":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberBanned>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberBanned>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberBanned."));
                 case "left":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberLeft>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberLeft>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberLeft."));
                 case "member":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberMember>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberMember>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberMember."));
                 case "restricted":
-                    return ChatMember.From(JsonSerializer.Deserialize<ChatMemberRestricted>(json, options)
+                    return ChatMember.From(document.RootElement.Deserialize<ChatMemberRestricted>(options)
                         ?? throw new JsonException("Unable to deserialize ChatMember as ChatMemberRestricted."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for ChatMember.");

--- a/src/TeleFlow.Telegram.Schema/Types/InlineQueryResult.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InlineQueryResult.g.cs
@@ -662,7 +662,6 @@ file sealed class InlineQueryResultJsonConverter : JsonConverter<InlineQueryResu
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -670,104 +669,104 @@ file sealed class InlineQueryResultJsonConverter : JsonConverter<InlineQueryResu
             switch (discriminator)
             {
                 case "article":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultArticle>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultArticle>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultArticle."));
                 case "audio":
                     if (document.RootElement.TryGetProperty("audio_url", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultAudio>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultAudio>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultAudio."));
                     }
                     if (document.RootElement.TryGetProperty("audio_file_id", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedAudio>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedAudio>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedAudio."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'audio' for InlineQueryResult using required properties.");
                 case "contact":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultContact>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultContact>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultContact."));
                 case "document":
                     if (document.RootElement.TryGetProperty("document_url", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("mime_type", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultDocument>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultDocument>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultDocument."));
                     }
                     if (document.RootElement.TryGetProperty("document_file_id", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedDocument>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedDocument>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedDocument."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'document' for InlineQueryResult using required properties.");
                 case "game":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultGame>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultGame>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultGame."));
                 case "gif":
                     if (document.RootElement.TryGetProperty("gif_url", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("thumbnail_url", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultGif>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultGif>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultGif."));
                     }
                     if (document.RootElement.TryGetProperty("gif_file_id", out _) && document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedGif>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedGif>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedGif."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'gif' for InlineQueryResult using required properties.");
                 case "location":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultLocation>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultLocation>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultLocation."));
                 case "mpeg4_gif":
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("mpeg4_url", out _) && document.RootElement.TryGetProperty("thumbnail_url", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultMpeg4Gif>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultMpeg4Gif>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultMpeg4Gif."));
                     }
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("mpeg4_file_id", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedMpeg4Gif>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedMpeg4Gif>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedMpeg4Gif."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'mpeg4_gif' for InlineQueryResult using required properties.");
                 case "photo":
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("photo_url", out _) && document.RootElement.TryGetProperty("thumbnail_url", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultPhoto>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultPhoto>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultPhoto."));
                     }
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("photo_file_id", out _) && document.RootElement.TryGetProperty("type", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedPhoto>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedPhoto>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedPhoto."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'photo' for InlineQueryResult using required properties.");
                 case "sticker":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedSticker>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedSticker>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedSticker."));
                 case "venue":
-                    return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultVenue>(json, options)
+                    return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultVenue>(options)
                         ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultVenue."));
                 case "video":
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("mime_type", out _) && document.RootElement.TryGetProperty("thumbnail_url", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _) && document.RootElement.TryGetProperty("video_url", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultVideo>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultVideo>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultVideo."));
                     }
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _) && document.RootElement.TryGetProperty("video_file_id", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedVideo>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedVideo>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedVideo."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'video' for InlineQueryResult using required properties.");
                 case "voice":
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _) && document.RootElement.TryGetProperty("voice_file_id", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultCachedVoice>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultCachedVoice>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultCachedVoice."));
                     }
                     if (document.RootElement.TryGetProperty("id", out _) && document.RootElement.TryGetProperty("title", out _) && document.RootElement.TryGetProperty("type", out _) && document.RootElement.TryGetProperty("voice_url", out _))
                     {
-                        return InlineQueryResult.From(JsonSerializer.Deserialize<InlineQueryResultVoice>(json, options)
+                        return InlineQueryResult.From(document.RootElement.Deserialize<InlineQueryResultVoice>(options)
                             ?? throw new JsonException("Unable to deserialize InlineQueryResult as InlineQueryResultVoice."));
                     }
                     throw new JsonException("Unable to refine discriminator value 'voice' for InlineQueryResult using required properties.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputMedia.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputMedia.g.cs
@@ -227,7 +227,6 @@ file sealed class InputMediaJsonConverter : JsonConverter<InputMedia>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -235,22 +234,22 @@ file sealed class InputMediaJsonConverter : JsonConverter<InputMedia>
             switch (discriminator)
             {
                 case "animation":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaAnimation>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaAnimation>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaAnimation."));
                 case "audio":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaAudio>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaAudio>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaAudio."));
                 case "document":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaDocument>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaDocument>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaDocument."));
                 case "live_photo":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaLivePhoto>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaLivePhoto."));
                 case "photo":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaPhoto>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaPhoto."));
                 case "video":
-                    return InputMedia.From(JsonSerializer.Deserialize<InputMediaVideo>(json, options)
+                    return InputMedia.From(document.RootElement.Deserialize<InputMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputMedia as InputMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputMedia.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputMessageContent.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputMessageContent.g.cs
@@ -227,41 +227,40 @@ file sealed class InputMessageContentJsonConverter : JsonConverter<InputMessageC
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("currency", out _) && document.RootElement.TryGetProperty("description", out _) && document.RootElement.TryGetProperty("payload", out _) && document.RootElement.TryGetProperty("prices", out _) && document.RootElement.TryGetProperty("title", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputInvoiceMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputInvoiceMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputInvoiceMessageContent."));
         }
 
         if (document.RootElement.TryGetProperty("address", out _) && document.RootElement.TryGetProperty("latitude", out _) && document.RootElement.TryGetProperty("longitude", out _) && document.RootElement.TryGetProperty("title", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputVenueMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputVenueMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputVenueMessageContent."));
         }
 
         if (document.RootElement.TryGetProperty("first_name", out _) && document.RootElement.TryGetProperty("phone_number", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputContactMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputContactMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputContactMessageContent."));
         }
 
         if (document.RootElement.TryGetProperty("latitude", out _) && document.RootElement.TryGetProperty("longitude", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputLocationMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputLocationMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputLocationMessageContent."));
         }
 
         if (document.RootElement.TryGetProperty("rich_message", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputRichMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputRichMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputRichMessageContent."));
         }
 
         if (document.RootElement.TryGetProperty("message_text", out _))
         {
-            return InputMessageContent.From(JsonSerializer.Deserialize<InputTextMessageContent>(json, options)
+            return InputMessageContent.From(document.RootElement.Deserialize<InputTextMessageContent>(options)
                 ?? throw new JsonException("Unable to deserialize InputMessageContent as InputTextMessageContent."));
         }
 

--- a/src/TeleFlow.Telegram.Schema/Types/InputPaidMedia.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputPaidMedia.g.cs
@@ -134,7 +134,6 @@ file sealed class InputPaidMediaJsonConverter : JsonConverter<InputPaidMedia>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -142,13 +141,13 @@ file sealed class InputPaidMediaJsonConverter : JsonConverter<InputPaidMedia>
             switch (discriminator)
             {
                 case "live_photo":
-                    return InputPaidMedia.From(JsonSerializer.Deserialize<InputPaidMediaLivePhoto>(json, options)
+                    return InputPaidMedia.From(document.RootElement.Deserialize<InputPaidMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPaidMedia as InputPaidMediaLivePhoto."));
                 case "photo":
-                    return InputPaidMedia.From(JsonSerializer.Deserialize<InputPaidMediaPhoto>(json, options)
+                    return InputPaidMedia.From(document.RootElement.Deserialize<InputPaidMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPaidMedia as InputPaidMediaPhoto."));
                 case "video":
-                    return InputPaidMedia.From(JsonSerializer.Deserialize<InputPaidMediaVideo>(json, options)
+                    return InputPaidMedia.From(document.RootElement.Deserialize<InputPaidMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputPaidMedia as InputPaidMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputPaidMedia.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputPollMedia.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputPollMedia.g.cs
@@ -289,7 +289,6 @@ file sealed class InputPollMediaJsonConverter : JsonConverter<InputPollMedia>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -297,28 +296,28 @@ file sealed class InputPollMediaJsonConverter : JsonConverter<InputPollMedia>
             switch (discriminator)
             {
                 case "animation":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaAnimation>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaAnimation>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaAnimation."));
                 case "audio":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaAudio>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaAudio>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaAudio."));
                 case "document":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaDocument>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaDocument>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaDocument."));
                 case "live_photo":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaLivePhoto>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaLivePhoto."));
                 case "location":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaLocation>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaLocation>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaLocation."));
                 case "photo":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaPhoto>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaPhoto."));
                 case "venue":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaVenue>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaVenue>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaVenue."));
                 case "video":
-                    return InputPollMedia.From(JsonSerializer.Deserialize<InputMediaVideo>(json, options)
+                    return InputPollMedia.From(document.RootElement.Deserialize<InputMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollMedia as InputMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputPollMedia.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputPollOptionMedia.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputPollOptionMedia.g.cs
@@ -289,7 +289,6 @@ file sealed class InputPollOptionMediaJsonConverter : JsonConverter<InputPollOpt
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -297,28 +296,28 @@ file sealed class InputPollOptionMediaJsonConverter : JsonConverter<InputPollOpt
             switch (discriminator)
             {
                 case "animation":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaAnimation>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaAnimation>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaAnimation."));
                 case "link":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaLink>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaLink>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaLink."));
                 case "live_photo":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaLivePhoto>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaLivePhoto."));
                 case "location":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaLocation>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaLocation>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaLocation."));
                 case "photo":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaPhoto>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaPhoto."));
                 case "sticker":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaSticker>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaSticker>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaSticker."));
                 case "venue":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaVenue>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaVenue>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaVenue."));
                 case "video":
-                    return InputPollOptionMedia.From(JsonSerializer.Deserialize<InputMediaVideo>(json, options)
+                    return InputPollOptionMedia.From(document.RootElement.Deserialize<InputMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputPollOptionMedia as InputMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputPollOptionMedia.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputProfilePhoto.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputProfilePhoto.g.cs
@@ -103,7 +103,6 @@ file sealed class InputProfilePhotoJsonConverter : JsonConverter<InputProfilePho
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -111,10 +110,10 @@ file sealed class InputProfilePhotoJsonConverter : JsonConverter<InputProfilePho
             switch (discriminator)
             {
                 case "animated":
-                    return InputProfilePhoto.From(JsonSerializer.Deserialize<InputProfilePhotoAnimated>(json, options)
+                    return InputProfilePhoto.From(document.RootElement.Deserialize<InputProfilePhotoAnimated>(options)
                         ?? throw new JsonException("Unable to deserialize InputProfilePhoto as InputProfilePhotoAnimated."));
                 case "static":
-                    return InputProfilePhoto.From(JsonSerializer.Deserialize<InputProfilePhotoStatic>(json, options)
+                    return InputProfilePhoto.From(document.RootElement.Deserialize<InputProfilePhotoStatic>(options)
                         ?? throw new JsonException("Unable to deserialize InputProfilePhoto as InputProfilePhotoStatic."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputProfilePhoto.");

--- a/src/TeleFlow.Telegram.Schema/Types/InputStoryContent.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputStoryContent.g.cs
@@ -103,7 +103,6 @@ file sealed class InputStoryContentJsonConverter : JsonConverter<InputStoryConte
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -111,10 +110,10 @@ file sealed class InputStoryContentJsonConverter : JsonConverter<InputStoryConte
             switch (discriminator)
             {
                 case "photo":
-                    return InputStoryContent.From(JsonSerializer.Deserialize<InputStoryContentPhoto>(json, options)
+                    return InputStoryContent.From(document.RootElement.Deserialize<InputStoryContentPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize InputStoryContent as InputStoryContentPhoto."));
                 case "video":
-                    return InputStoryContent.From(JsonSerializer.Deserialize<InputStoryContentVideo>(json, options)
+                    return InputStoryContent.From(document.RootElement.Deserialize<InputStoryContentVideo>(options)
                         ?? throw new JsonException("Unable to deserialize InputStoryContent as InputStoryContentVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for InputStoryContent.");

--- a/src/TeleFlow.Telegram.Schema/Types/MaybeInaccessibleMessage.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/MaybeInaccessibleMessage.g.cs
@@ -103,18 +103,17 @@ file sealed class MaybeInaccessibleMessageJsonConverter : JsonConverter<MaybeIna
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("date", out var dateElement) &&
             dateElement.ValueKind == JsonValueKind.Number &&
             dateElement.TryGetInt64(out var date) &&
             date == 0)
         {
-            return MaybeInaccessibleMessage.From(JsonSerializer.Deserialize<InaccessibleMessage>(json, options)
+            return MaybeInaccessibleMessage.From(document.RootElement.Deserialize<InaccessibleMessage>(options)
                 ?? throw new JsonException("Unable to deserialize MaybeInaccessibleMessage as InaccessibleMessage."));
         }
 
-        return MaybeInaccessibleMessage.From(JsonSerializer.Deserialize<Message>(json, options)
+        return MaybeInaccessibleMessage.From(document.RootElement.Deserialize<Message>(options)
             ?? throw new JsonException("Unable to deserialize MaybeInaccessibleMessage as Message."));
         throw new JsonException("Unable to deserialize MaybeInaccessibleMessage from the provided Telegram payload.");
     }

--- a/src/TeleFlow.Telegram.Schema/Types/MenuButton.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/MenuButton.g.cs
@@ -135,7 +135,6 @@ file sealed class MenuButtonJsonConverter : JsonConverter<MenuButton>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -143,13 +142,13 @@ file sealed class MenuButtonJsonConverter : JsonConverter<MenuButton>
             switch (discriminator)
             {
                 case "commands":
-                    return MenuButton.From(JsonSerializer.Deserialize<MenuButtonCommands>(json, options)
+                    return MenuButton.From(document.RootElement.Deserialize<MenuButtonCommands>(options)
                         ?? throw new JsonException("Unable to deserialize MenuButton as MenuButtonCommands."));
                 case "default":
-                    return MenuButton.From(JsonSerializer.Deserialize<MenuButtonDefault>(json, options)
+                    return MenuButton.From(document.RootElement.Deserialize<MenuButtonDefault>(options)
                         ?? throw new JsonException("Unable to deserialize MenuButton as MenuButtonDefault."));
                 case "web_app":
-                    return MenuButton.From(JsonSerializer.Deserialize<MenuButtonWebApp>(json, options)
+                    return MenuButton.From(document.RootElement.Deserialize<MenuButtonWebApp>(options)
                         ?? throw new JsonException("Unable to deserialize MenuButton as MenuButtonWebApp."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for MenuButton.");

--- a/src/TeleFlow.Telegram.Schema/Types/MessageOrigin.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/MessageOrigin.g.cs
@@ -165,7 +165,6 @@ file sealed class MessageOriginJsonConverter : JsonConverter<MessageOrigin>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -173,16 +172,16 @@ file sealed class MessageOriginJsonConverter : JsonConverter<MessageOrigin>
             switch (discriminator)
             {
                 case "channel":
-                    return MessageOrigin.From(JsonSerializer.Deserialize<MessageOriginChannel>(json, options)
+                    return MessageOrigin.From(document.RootElement.Deserialize<MessageOriginChannel>(options)
                         ?? throw new JsonException("Unable to deserialize MessageOrigin as MessageOriginChannel."));
                 case "chat":
-                    return MessageOrigin.From(JsonSerializer.Deserialize<MessageOriginChat>(json, options)
+                    return MessageOrigin.From(document.RootElement.Deserialize<MessageOriginChat>(options)
                         ?? throw new JsonException("Unable to deserialize MessageOrigin as MessageOriginChat."));
                 case "hidden_user":
-                    return MessageOrigin.From(JsonSerializer.Deserialize<MessageOriginHiddenUser>(json, options)
+                    return MessageOrigin.From(document.RootElement.Deserialize<MessageOriginHiddenUser>(options)
                         ?? throw new JsonException("Unable to deserialize MessageOrigin as MessageOriginHiddenUser."));
                 case "user":
-                    return MessageOrigin.From(JsonSerializer.Deserialize<MessageOriginUser>(json, options)
+                    return MessageOrigin.From(document.RootElement.Deserialize<MessageOriginUser>(options)
                         ?? throw new JsonException("Unable to deserialize MessageOrigin as MessageOriginUser."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for MessageOrigin.");

--- a/src/TeleFlow.Telegram.Schema/Types/OwnedGift.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/OwnedGift.g.cs
@@ -103,7 +103,6 @@ file sealed class OwnedGiftJsonConverter : JsonConverter<OwnedGift>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -111,10 +110,10 @@ file sealed class OwnedGiftJsonConverter : JsonConverter<OwnedGift>
             switch (discriminator)
             {
                 case "regular":
-                    return OwnedGift.From(JsonSerializer.Deserialize<OwnedGiftRegular>(json, options)
+                    return OwnedGift.From(document.RootElement.Deserialize<OwnedGiftRegular>(options)
                         ?? throw new JsonException("Unable to deserialize OwnedGift as OwnedGiftRegular."));
                 case "unique":
-                    return OwnedGift.From(JsonSerializer.Deserialize<OwnedGiftUnique>(json, options)
+                    return OwnedGift.From(document.RootElement.Deserialize<OwnedGiftUnique>(options)
                         ?? throw new JsonException("Unable to deserialize OwnedGift as OwnedGiftUnique."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for OwnedGift.");

--- a/src/TeleFlow.Telegram.Schema/Types/PaidMedia.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/PaidMedia.g.cs
@@ -165,7 +165,6 @@ file sealed class PaidMediaJsonConverter : JsonConverter<PaidMedia>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -173,16 +172,16 @@ file sealed class PaidMediaJsonConverter : JsonConverter<PaidMedia>
             switch (discriminator)
             {
                 case "live_photo":
-                    return PaidMedia.From(JsonSerializer.Deserialize<PaidMediaLivePhoto>(json, options)
+                    return PaidMedia.From(document.RootElement.Deserialize<PaidMediaLivePhoto>(options)
                         ?? throw new JsonException("Unable to deserialize PaidMedia as PaidMediaLivePhoto."));
                 case "photo":
-                    return PaidMedia.From(JsonSerializer.Deserialize<PaidMediaPhoto>(json, options)
+                    return PaidMedia.From(document.RootElement.Deserialize<PaidMediaPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize PaidMedia as PaidMediaPhoto."));
                 case "preview":
-                    return PaidMedia.From(JsonSerializer.Deserialize<PaidMediaPreview>(json, options)
+                    return PaidMedia.From(document.RootElement.Deserialize<PaidMediaPreview>(options)
                         ?? throw new JsonException("Unable to deserialize PaidMedia as PaidMediaPreview."));
                 case "video":
-                    return PaidMedia.From(JsonSerializer.Deserialize<PaidMediaVideo>(json, options)
+                    return PaidMedia.From(document.RootElement.Deserialize<PaidMediaVideo>(options)
                         ?? throw new JsonException("Unable to deserialize PaidMedia as PaidMediaVideo."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for PaidMedia.");

--- a/src/TeleFlow.Telegram.Schema/Types/PassportElementError.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/PassportElementError.g.cs
@@ -320,7 +320,6 @@ file sealed class PassportElementErrorJsonConverter : JsonConverter<PassportElem
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("source", out var sourceElement) && sourceElement.ValueKind == JsonValueKind.String)
         {
@@ -328,31 +327,31 @@ file sealed class PassportElementErrorJsonConverter : JsonConverter<PassportElem
             switch (discriminator)
             {
                 case "data":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorDataField>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorDataField>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorDataField."));
                 case "file":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorFile>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorFile>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorFile."));
                 case "files":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorFiles>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorFiles>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorFiles."));
                 case "front_side":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorFrontSide>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorFrontSide>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorFrontSide."));
                 case "reverse_side":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorReverseSide>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorReverseSide>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorReverseSide."));
                 case "selfie":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorSelfie>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorSelfie>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorSelfie."));
                 case "translation_file":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorTranslationFile>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorTranslationFile>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorTranslationFile."));
                 case "translation_files":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorTranslationFiles>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorTranslationFiles>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorTranslationFiles."));
                 case "unspecified":
-                    return PassportElementError.From(JsonSerializer.Deserialize<PassportElementErrorUnspecified>(json, options)
+                    return PassportElementError.From(document.RootElement.Deserialize<PassportElementErrorUnspecified>(options)
                         ?? throw new JsonException("Unable to deserialize PassportElementError as PassportElementErrorUnspecified."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for PassportElementError.");

--- a/src/TeleFlow.Telegram.Schema/Types/ReactionType.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/ReactionType.g.cs
@@ -134,7 +134,6 @@ file sealed class ReactionTypeJsonConverter : JsonConverter<ReactionType>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -142,13 +141,13 @@ file sealed class ReactionTypeJsonConverter : JsonConverter<ReactionType>
             switch (discriminator)
             {
                 case "custom_emoji":
-                    return ReactionType.From(JsonSerializer.Deserialize<ReactionTypeCustomEmoji>(json, options)
+                    return ReactionType.From(document.RootElement.Deserialize<ReactionTypeCustomEmoji>(options)
                         ?? throw new JsonException("Unable to deserialize ReactionType as ReactionTypeCustomEmoji."));
                 case "emoji":
-                    return ReactionType.From(JsonSerializer.Deserialize<ReactionTypeEmoji>(json, options)
+                    return ReactionType.From(document.RootElement.Deserialize<ReactionTypeEmoji>(options)
                         ?? throw new JsonException("Unable to deserialize ReactionType as ReactionTypeEmoji."));
                 case "paid":
-                    return ReactionType.From(JsonSerializer.Deserialize<ReactionTypePaid>(json, options)
+                    return ReactionType.From(document.RootElement.Deserialize<ReactionTypePaid>(options)
                         ?? throw new JsonException("Unable to deserialize ReactionType as ReactionTypePaid."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for ReactionType.");

--- a/src/TeleFlow.Telegram.Schema/Types/RevenueWithdrawalState.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/RevenueWithdrawalState.g.cs
@@ -134,7 +134,6 @@ file sealed class RevenueWithdrawalStateJsonConverter : JsonConverter<RevenueWit
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -142,13 +141,13 @@ file sealed class RevenueWithdrawalStateJsonConverter : JsonConverter<RevenueWit
             switch (discriminator)
             {
                 case "failed":
-                    return RevenueWithdrawalState.From(JsonSerializer.Deserialize<RevenueWithdrawalStateFailed>(json, options)
+                    return RevenueWithdrawalState.From(document.RootElement.Deserialize<RevenueWithdrawalStateFailed>(options)
                         ?? throw new JsonException("Unable to deserialize RevenueWithdrawalState as RevenueWithdrawalStateFailed."));
                 case "pending":
-                    return RevenueWithdrawalState.From(JsonSerializer.Deserialize<RevenueWithdrawalStatePending>(json, options)
+                    return RevenueWithdrawalState.From(document.RootElement.Deserialize<RevenueWithdrawalStatePending>(options)
                         ?? throw new JsonException("Unable to deserialize RevenueWithdrawalState as RevenueWithdrawalStatePending."));
                 case "succeeded":
-                    return RevenueWithdrawalState.From(JsonSerializer.Deserialize<RevenueWithdrawalStateSucceeded>(json, options)
+                    return RevenueWithdrawalState.From(document.RootElement.Deserialize<RevenueWithdrawalStateSucceeded>(options)
                         ?? throw new JsonException("Unable to deserialize RevenueWithdrawalState as RevenueWithdrawalStateSucceeded."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for RevenueWithdrawalState.");

--- a/src/TeleFlow.Telegram.Schema/Types/RichBlock.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/RichBlock.g.cs
@@ -692,7 +692,6 @@ file sealed class RichBlockJsonConverter : JsonConverter<RichBlock>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -700,67 +699,67 @@ file sealed class RichBlockJsonConverter : JsonConverter<RichBlock>
             switch (discriminator)
             {
                 case "anchor":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockAnchor>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockAnchor>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockAnchor."));
                 case "animation":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockAnimation>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockAnimation>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockAnimation."));
                 case "audio":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockAudio>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockAudio>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockAudio."));
                 case "blockquote":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockBlockQuotation>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockBlockQuotation>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockBlockQuotation."));
                 case "collage":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockCollage>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockCollage>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockCollage."));
                 case "details":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockDetails>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockDetails>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockDetails."));
                 case "divider":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockDivider>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockDivider>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockDivider."));
                 case "footer":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockFooter>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockFooter>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockFooter."));
                 case "heading":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockSectionHeading>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockSectionHeading>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockSectionHeading."));
                 case "list":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockList>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockList>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockList."));
                 case "map":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockMap>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockMap>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockMap."));
                 case "mathematical_expression":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockMathematicalExpression>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockMathematicalExpression>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockMathematicalExpression."));
                 case "paragraph":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockParagraph>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockParagraph>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockParagraph."));
                 case "photo":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockPhoto>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockPhoto>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockPhoto."));
                 case "pre":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockPreformatted>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockPreformatted>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockPreformatted."));
                 case "pullquote":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockPullQuotation>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockPullQuotation>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockPullQuotation."));
                 case "slideshow":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockSlideshow>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockSlideshow>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockSlideshow."));
                 case "table":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockTable>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockTable>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockTable."));
                 case "thinking":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockThinking>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockThinking>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockThinking."));
                 case "video":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockVideo>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockVideo>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockVideo."));
                 case "voice_note":
-                    return RichBlock.From(JsonSerializer.Deserialize<RichBlockVoiceNote>(json, options)
+                    return RichBlock.From(document.RootElement.Deserialize<RichBlockVoiceNote>(options)
                         ?? throw new JsonException("Unable to deserialize RichBlock as RichBlockVoiceNote."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for RichBlock.");

--- a/src/TeleFlow.Telegram.Schema/Types/RichText.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/RichText.g.cs
@@ -882,7 +882,6 @@ file sealed class RichTextJsonConverter : JsonConverter<RichText>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -890,79 +889,79 @@ file sealed class RichTextJsonConverter : JsonConverter<RichText>
             switch (discriminator)
             {
                 case "anchor":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextAnchor>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextAnchor>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextAnchor."));
                 case "anchor_link":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextAnchorLink>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextAnchorLink>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextAnchorLink."));
                 case "bank_card_number":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextBankCardNumber>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextBankCardNumber>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextBankCardNumber."));
                 case "bold":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextBold>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextBold>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextBold."));
                 case "bot_command":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextBotCommand>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextBotCommand>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextBotCommand."));
                 case "cashtag":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextCashtag>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextCashtag>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextCashtag."));
                 case "code":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextCode>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextCode>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextCode."));
                 case "custom_emoji":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextCustomEmoji>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextCustomEmoji>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextCustomEmoji."));
                 case "date_time":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextDateTime>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextDateTime>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextDateTime."));
                 case "email_address":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextEmailAddress>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextEmailAddress>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextEmailAddress."));
                 case "hashtag":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextHashtag>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextHashtag>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextHashtag."));
                 case "italic":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextItalic>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextItalic>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextItalic."));
                 case "marked":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextMarked>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextMarked>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextMarked."));
                 case "mathematical_expression":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextMathematicalExpression>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextMathematicalExpression>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextMathematicalExpression."));
                 case "mention":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextMention>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextMention>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextMention."));
                 case "phone_number":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextPhoneNumber>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextPhoneNumber>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextPhoneNumber."));
                 case "reference":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextReference>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextReference>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextReference."));
                 case "reference_link":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextReferenceLink>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextReferenceLink>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextReferenceLink."));
                 case "spoiler":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextSpoiler>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextSpoiler>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextSpoiler."));
                 case "strikethrough":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextStrikethrough>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextStrikethrough>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextStrikethrough."));
                 case "subscript":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextSubscript>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextSubscript>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextSubscript."));
                 case "superscript":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextSuperscript>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextSuperscript>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextSuperscript."));
                 case "text_mention":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextTextMention>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextTextMention>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextTextMention."));
                 case "underline":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextUnderline>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextUnderline>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextUnderline."));
                 case "url":
-                    return RichText.From(JsonSerializer.Deserialize<RichTextUrl>(json, options)
+                    return RichText.From(document.RootElement.Deserialize<RichTextUrl>(options)
                         ?? throw new JsonException("Unable to deserialize RichText as RichTextUrl."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for RichText.");

--- a/src/TeleFlow.Telegram.Schema/Types/StoryAreaType.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/StoryAreaType.g.cs
@@ -196,7 +196,6 @@ file sealed class StoryAreaTypeJsonConverter : JsonConverter<StoryAreaType>
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -204,19 +203,19 @@ file sealed class StoryAreaTypeJsonConverter : JsonConverter<StoryAreaType>
             switch (discriminator)
             {
                 case "link":
-                    return StoryAreaType.From(JsonSerializer.Deserialize<StoryAreaTypeLink>(json, options)
+                    return StoryAreaType.From(document.RootElement.Deserialize<StoryAreaTypeLink>(options)
                         ?? throw new JsonException("Unable to deserialize StoryAreaType as StoryAreaTypeLink."));
                 case "location":
-                    return StoryAreaType.From(JsonSerializer.Deserialize<StoryAreaTypeLocation>(json, options)
+                    return StoryAreaType.From(document.RootElement.Deserialize<StoryAreaTypeLocation>(options)
                         ?? throw new JsonException("Unable to deserialize StoryAreaType as StoryAreaTypeLocation."));
                 case "suggested_reaction":
-                    return StoryAreaType.From(JsonSerializer.Deserialize<StoryAreaTypeSuggestedReaction>(json, options)
+                    return StoryAreaType.From(document.RootElement.Deserialize<StoryAreaTypeSuggestedReaction>(options)
                         ?? throw new JsonException("Unable to deserialize StoryAreaType as StoryAreaTypeSuggestedReaction."));
                 case "unique_gift":
-                    return StoryAreaType.From(JsonSerializer.Deserialize<StoryAreaTypeUniqueGift>(json, options)
+                    return StoryAreaType.From(document.RootElement.Deserialize<StoryAreaTypeUniqueGift>(options)
                         ?? throw new JsonException("Unable to deserialize StoryAreaType as StoryAreaTypeUniqueGift."));
                 case "weather":
-                    return StoryAreaType.From(JsonSerializer.Deserialize<StoryAreaTypeWeather>(json, options)
+                    return StoryAreaType.From(document.RootElement.Deserialize<StoryAreaTypeWeather>(options)
                         ?? throw new JsonException("Unable to deserialize StoryAreaType as StoryAreaTypeWeather."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for StoryAreaType.");

--- a/src/TeleFlow.Telegram.Schema/Types/TransactionPartner.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/TransactionPartner.g.cs
@@ -258,7 +258,6 @@ file sealed class TransactionPartnerJsonConverter : JsonConverter<TransactionPar
         }
 
         using var document = JsonDocument.ParseValue(ref reader);
-        var json = document.RootElement.GetRawText();
 
         if (document.RootElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
         {
@@ -266,25 +265,25 @@ file sealed class TransactionPartnerJsonConverter : JsonConverter<TransactionPar
             switch (discriminator)
             {
                 case "affiliate_program":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerAffiliateProgram>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerAffiliateProgram>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerAffiliateProgram."));
                 case "chat":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerChat>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerChat>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerChat."));
                 case "fragment":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerFragment>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerFragment>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerFragment."));
                 case "other":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerOther>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerOther>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerOther."));
                 case "telegram_ads":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerTelegramAds>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerTelegramAds>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerTelegramAds."));
                 case "telegram_api":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerTelegramApi>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerTelegramApi>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerTelegramApi."));
                 case "user":
-                    return TransactionPartner.From(JsonSerializer.Deserialize<TransactionPartnerUser>(json, options)
+                    return TransactionPartner.From(document.RootElement.Deserialize<TransactionPartnerUser>(options)
                         ?? throw new JsonException("Unable to deserialize TransactionPartner as TransactionPartnerUser."));
                 default:
                     throw new JsonException($"Unknown discriminator value '{discriminator}' for TransactionPartner.");

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2293,6 +2293,24 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task Dispatcher_DoesNotReadStateStoreForStatelessHandlers()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddSingleton<IStateStore, ThrowingStateStore>();
+                services.AddMemoryStateStorage();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchThroughMiddlewareAsync(serviceProvider, CreateMessageUpdate("stateless"));
+
+        Assert.Equal(["message:stateless"], probe.Events);
+    }
+
+    [Fact]
     public async Task TypedStateAttribute_DispatchesUsingStateGroupProperty()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -3790,6 +3808,24 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(CallbackQueryContext context)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingStateStore : IStateStore
+    {
+        public ValueTask<string?> GetStateAsync(StateKey key, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("State store should not be read for stateless handlers.");
+        }
+
+        public ValueTask SetStateAsync(StateKey key, string state, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("State store should not be written for stateless handlers.");
+        }
+
+        public ValueTask ClearStateAsync(StateKey key, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("State store should not be cleared for stateless handlers.");
         }
     }
 


### PR DESCRIPTION
## Summary

- add an isolated BenchmarkDotNet suite for no-network cross-library measurements
- reduce Telegram runtime hot-path overhead in request execution, dispatch, callback payload selection, and raw long polling diagnostics
- refresh generated union converters to deserialize from `JsonElement` instead of materializing intermediate JSON strings

## Verification

- `dotnet build TeleFlow.sln --no-restore`
- `dotnet test TeleFlow.sln --no-build`
- `dotnet format TeleFlow.sln --verify-no-changes --no-restore`
- `dotnet run -c Release --project benchmarks\TeleFlow.Benchmarks\TeleFlow.Benchmarks.csproj -- --filter "*Vs*" --join`

## Notes

The generator-side template change has already been pushed to `IWFTech/TelegramSchemaGenerator` in `e90a69e`.