### PR TITLE
Clarify state hydration snapshot semantics

### DIFF
--- a/docs/en/features/state-and-wizard.md
+++ b/docs/en/features/state-and-wizard.md
@@ -72,7 +72,7 @@ Use `ResetAsync` when both state and state data should be cleared.
 | `ClearAsync()` | Clears only the current state value. |
 | `ResetAsync()` | Clears state data first, then clears the current state. |
 
-`ctx.State` caches the current state snapshot for the duration of one update. The first `GetAsync` reads storage, later current-state reads in the same update use the snapshot, and successful `SetAsync` or `ClearAsync` calls update it. Failed storage calls do not update the snapshot. Direct writes through `IStateStore` in the same update are outside this synchronization path; use `ctx.State` inside handlers and middleware.
+`ctx.State` caches a hydrated current state snapshot for the duration of one update. The first `GetAsync` reads storage, later current-state reads in the same update use the snapshot, and successful `SetAsync` or `ClearAsync` calls update it. Failed storage calls do not update the snapshot. Direct writes through `IStateStore` in the same update are outside this synchronization path; use `ctx.State` inside handlers and middleware.
 
 `ctx.State.Data` stores small JSON-serialized values by string key:
 
@@ -132,8 +132,8 @@ Wizard API:
 
 | API | Behavior |
 | --- | --- |
-| `GetCurrentAsync()` | Reads the current wizard state or returns `null`. |
-| `Current` | Returns the current state snapshot; throws if no state is active in the current update. |
+| `GetCurrentAsync()` | Reads storage when needed, hydrates the current state snapshot, and returns the current wizard state or `null`. |
+| `Current` | Returns the already-hydrated current state snapshot synchronously; does not perform storage I/O and throws if the snapshot has not been hydrated or no state is active. |
 | `GoToAsync(state)` | Sets the next state and pushes the previous state into history when one existed. |
 | `BackAsync()` | Restores the previous state; throws when history is empty. |
 | `ResetAsync()` | Clears state data, history, and the current state. |

--- a/docs/ru/features/state-and-wizard.md
+++ b/docs/ru/features/state-and-wizard.md
@@ -72,7 +72,7 @@ public sealed class RegistrationHandlers
 | `ClearAsync()` | Очищает только current state value. |
 | `ResetAsync()` | Сначала очищает state data, затем current state. |
 
-`ctx.State` кэширует snapshot текущего state на время одного update. Первый `GetAsync` читает storage, следующие current-state reads в том же update используют snapshot, а успешные `SetAsync` или `ClearAsync` обновляют его. Failed storage calls snapshot не меняют. Прямые записи через `IStateStore` внутри того же update находятся вне этого synchronization path; в handlers и middleware используй `ctx.State`.
+`ctx.State` кэширует snapshot текущего state, синхронизированный со storage, на время одного update. Первый `GetAsync` читает storage, следующие current-state reads в том же update используют snapshot, а успешные `SetAsync` или `ClearAsync` обновляют его. Failed storage calls snapshot не меняют. Прямые записи через `IStateStore` внутри того же update находятся вне этого synchronization path; в handlers и middleware используй `ctx.State`.
 
 `ctx.State.Data` хранит небольшие JSON-serialized values по string key:
 
@@ -132,8 +132,8 @@ Wizard API:
 
 | API | Поведение |
 | --- | --- |
-| `GetCurrentAsync()` | Читает current wizard state или возвращает `null`. |
-| `Current` | Возвращает current state snapshot; падает, если в current update нет active state. |
+| `GetCurrentAsync()` | Читает storage при необходимости, синхронизирует current state snapshot и возвращает current wizard state или `null`. |
+| `Current` | Синхронно возвращает уже синхронизированный current state snapshot; не делает storage I/O и падает, если snapshot ещё не загружен или active state отсутствует. |
 | `GoToAsync(state)` | Устанавливает следующий state и кладёт previous state в history, если он был. |
 | `BackAsync()` | Восстанавливает previous state; падает, если history пустой. |
 | `ResetAsync()` | Очищает state data, history и current state. |

--- a/src/TeleFlow.Core/States/UpdateState.cs
+++ b/src/TeleFlow.Core/States/UpdateState.cs
@@ -6,7 +6,7 @@ public sealed class UpdateState
     private readonly UpdateStateData? _data;
     private readonly UpdateWizard? _wizard;
     private string? _currentState;
-    private bool _currentStateCached;
+    private bool _isHydrated;
 
     public UpdateState(
         IStateStore stateStore,
@@ -33,7 +33,19 @@ public sealed class UpdateState
 
     public StateKey Key { get; }
 
-    internal string? CurrentStateSnapshot => _currentState;
+    internal string? CurrentStateSnapshot
+    {
+        get
+        {
+            if (!_isHydrated)
+            {
+                throw new InvalidOperationException(
+                    "State snapshot is not hydrated for the current update. Call GetAsync, SetAsync, ClearAsync, Wizard.GetCurrentAsync, or Wizard.GoToAsync before reading Wizard.Current.");
+            }
+
+            return _currentState;
+        }
+    }
 
     public UpdateStateData Data => _data ??
         throw new InvalidOperationException(
@@ -45,13 +57,7 @@ public sealed class UpdateState
 
     public async ValueTask<string?> GetAsync(CancellationToken cancellationToken = default)
     {
-        if (_currentStateCached)
-        {
-            return _currentState;
-        }
-
-        _currentState = await _stateStore.GetStateAsync(Key, cancellationToken).ConfigureAwait(false);
-        _currentStateCached = true;
+        await EnsureHydratedAsync(cancellationToken).ConfigureAwait(false);
         return _currentState;
     }
 
@@ -60,7 +66,7 @@ public sealed class UpdateState
         ArgumentException.ThrowIfNullOrWhiteSpace(state);
         await _stateStore.SetStateAsync(Key, state, cancellationToken).ConfigureAwait(false);
         _currentState = state;
-        _currentStateCached = true;
+        _isHydrated = true;
     }
 
     public ValueTask SetAsync(State state, CancellationToken cancellationToken = default)
@@ -68,22 +74,43 @@ public sealed class UpdateState
         return SetAsync(state.Id, cancellationToken);
     }
 
-    public async ValueTask<bool> IsAsync(State state, CancellationToken cancellationToken = default)
+    public ValueTask<bool> IsAsync(State state, CancellationToken cancellationToken = default)
     {
-        var currentState = await GetAsync(cancellationToken).ConfigureAwait(false);
-        return string.Equals(currentState, state.Id, StringComparison.Ordinal);
+        if (_isHydrated)
+        {
+            return ValueTask.FromResult(string.Equals(_currentState, state.Id, StringComparison.Ordinal));
+        }
+
+        return IsAsyncSlowAsync(state, cancellationToken);
     }
 
     public async ValueTask ClearAsync(CancellationToken cancellationToken = default)
     {
         await _stateStore.ClearStateAsync(Key, cancellationToken).ConfigureAwait(false);
         _currentState = null;
-        _currentStateCached = true;
+        _isHydrated = true;
     }
 
     public async ValueTask ResetAsync(CancellationToken cancellationToken = default)
     {
         await Data.ClearAsync(cancellationToken).ConfigureAwait(false);
         await ClearAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask EnsureHydratedAsync(CancellationToken cancellationToken)
+    {
+        if (_isHydrated)
+        {
+            return;
+        }
+
+        _currentState = await _stateStore.GetStateAsync(Key, cancellationToken).ConfigureAwait(false);
+        _isHydrated = true;
+    }
+
+    private async ValueTask<bool> IsAsyncSlowAsync(State state, CancellationToken cancellationToken)
+    {
+        await EnsureHydratedAsync(cancellationToken).ConfigureAwait(false);
+        return string.Equals(_currentState, state.Id, StringComparison.Ordinal);
     }
 }

--- a/src/TeleFlow.Core/States/UpdateWizard.cs
+++ b/src/TeleFlow.Core/States/UpdateWizard.cs
@@ -20,13 +20,14 @@ public sealed class UpdateWizard
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(_state.CurrentStateSnapshot))
+            var currentState = _state.CurrentStateSnapshot;
+            if (string.IsNullOrWhiteSpace(currentState))
             {
                 throw new InvalidOperationException(
                     "Wizard current state is not available because the current update has no active state.");
             }
 
-            return State.Create(_state.CurrentStateSnapshot);
+            return State.Create(currentState);
         }
     }
 

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -115,6 +115,20 @@ public sealed class StageSixStateAndMiddlewareTests
     }
 
     [Fact]
+    public async Task UpdateState_IsAsync_UsesHydratedSnapshotWithoutExtraRead()
+    {
+        var store = new CountingStateStore(initialState: RegistrationNameState);
+        var state = new UpdateState(store, StateKey.Create("telegram", "user:1", "chat:10"));
+
+        Assert.Equal(RegistrationNameState, await state.GetAsync());
+
+        store.ThrowOnNextGet = true;
+
+        Assert.True(await state.IsAsync(State.Create(RegistrationNameState)));
+        Assert.Equal(1, store.GetCount);
+    }
+
+    [Fact]
     public async Task UpdateState_FailedGetAsync_DoesNotCacheFailure()
     {
         var store = new CountingStateStore(initialState: RegistrationNameState)
@@ -219,6 +233,28 @@ public sealed class StageSixStateAndMiddlewareTests
 
         Assert.Equal(State.Create("registration:name"), state.Wizard.Current);
         Assert.Empty(await historyStore.GetHistoryAsync(key));
+    }
+
+    [Fact]
+    public void UpdateWizard_Current_FailsClearlyBeforeCurrentStateIsHydrated()
+    {
+        var state = CreateUpdateStateWithWizard();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => state.Wizard.Current);
+
+        Assert.Contains("not hydrated", exception.Message);
+    }
+
+    [Fact]
+    public async Task UpdateWizard_Current_FailsClearlyWhenHydratedStateIsMissing()
+    {
+        var state = CreateUpdateStateWithWizard();
+
+        Assert.Null(await state.Wizard.GetCurrentAsync());
+
+        var exception = Assert.Throws<InvalidOperationException>(() => state.Wizard.Current);
+
+        Assert.Contains("no active state", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Clarifies the per-update state snapshot lifecycle introduced in #19.

- renames the cache flag to hydration terminology;
- centralizes storage reads in `EnsureHydratedAsync`;
- keeps `SetAsync` and `ClearAsync` updating the snapshot only after successful storage writes;
- adds an `IsAsync` fast path when the snapshot is already hydrated;
- makes `Wizard.Current` fail clearly when used before hydration;
- documents the difference between `Wizard.Current` and `Wizard.GetCurrentAsync`.

Closes #56.

## Touched hot paths

- `UpdateState.GetAsync` now delegates to `EnsureHydratedAsync` and still reads storage at most once per update.
- `UpdateState.IsAsync` avoids an async state machine when the snapshot is already hydrated.
- `Wizard.Current` remains synchronous and snapshot-only; it does not perform storage I/O.

## Review context

This follows the hydration semantics review from #19:

- https://github.com/IWFTech/TeleFlow/pull/19#discussion_r3487720218
- https://github.com/IWFTech/TeleFlow/pull/19#discussion_r3487720582
- https://github.com/IWFTech/TeleFlow/pull/19#discussion_r3487721242

## Tests

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~UpdateState_|FullyQualifiedName~UpdateWizard_" --no-restore --logger "console;verbosity=minimal"`
- `dotnet build TeleFlow.sln -c Release --no-restore /nodeReuse:false`
- `dotnet test TeleFlow.sln -c Release --no-build --no-restore /nodeReuse:false --logger "console;verbosity=minimal"`