### PR TITLE
Collect handler timing only for debug logs

### DIFF
--- a/docs/en/features/errors-and-diagnostics.md
+++ b/docs/en/features/errors-and-diagnostics.md
@@ -89,6 +89,12 @@ builder.Services.AddLogging(logging =>
 
 For enterprise deployments, route logs to your existing platform and keep update id, chat id, handler, and exception type searchable.
 
+## Handler Timing Logs
+
+Detailed handler timing is collected only when `LogLevel.Debug` is enabled for the Telegram framework logger. In Debug logs TeleFlow can report handler duration, Telegram request count, Telegram request time, and handler logic time.
+
+When Debug logging is disabled, the normal successful handler path does not create handler request timing scopes. Error logs still include update id, update type, handler, route, module, scene, and exception type, but they do not include detailed timing fields that were not collected.
+
 ## Diagnostics Recommendation
 
 Start with:

--- a/docs/ru/features/errors-and-diagnostics.md
+++ b/docs/ru/features/errors-and-diagnostics.md
@@ -89,6 +89,12 @@ builder.Services.AddLogging(logging =>
 
 Для enterprise deployments отправляй logs в существующую platform и держи update id, chat id, handler и exception type searchable.
 
+## Логи времени выполнения обработчиков
+
+Подробные замеры времени выполнения обработчиков собираются только когда для логгера Telegram framework включён `LogLevel.Debug`. В логах уровня Debug TeleFlow может показать общее время обработчика, количество Telegram-запросов, время Telegram-запросов и время собственной логики обработчика.
+
+Когда Debug logging выключен, обычный успешный путь обработки не создаёт области замера Telegram-запросов. Логи ошибок по-прежнему содержат update id, update type, handler, route, module, scene и exception type, но не содержат подробные поля времени, которые не собирались.
+
 ## Рекомендации по диагностике
 
 Начни с:

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+internal sealed partial class TelegramHandlerDispatcher
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Debug,
+        Message = "No Telegram handler matched. update_id={UpdateId}, type={UpdateType}, match_ms={MatchElapsedMilliseconds:F2}.")]
+    private static partial void LogNoHandlerMatched(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        double matchElapsedMilliseconds);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Debug,
+        Message = "Telegram handler matched. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, match_ms={MatchElapsedMilliseconds:F2}.")]
+    private static partial void LogHandlerMatched(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        string moduleName,
+        string sceneName,
+        double matchElapsedMilliseconds);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}.")]
+    private static partial void LogHandlerFailed(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        string moduleName,
+        string sceneName,
+        string exceptionType);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
+    private static partial void LogHandlerFailedWithTiming(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        string moduleName,
+        string sceneName,
+        string exceptionType,
+        double handlerElapsedMilliseconds,
+        int telegramRequestCount,
+        double telegramRequestElapsedMilliseconds,
+        double handlerLogicElapsedMilliseconds);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Debug,
+        Message = "Telegram handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
+    private static partial void LogHandlerCompleted(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        double handlerElapsedMilliseconds,
+        int telegramRequestCount,
+        double telegramRequestElapsedMilliseconds,
+        double handlerLogicElapsedMilliseconds);
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Debug,
+        Message = "Telegram error handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, error_handler={ErrorHandler}, handled={Handled}.")]
+    private static partial void LogErrorHandlerCompleted(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        string moduleName,
+        string sceneName,
+        string exceptionType,
+        string errorHandler,
+        bool handled);
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
@@ -13,6 +13,58 @@ internal sealed partial class TelegramHandlerDispatcher
         public const int ErrorHandlerCompleted = 5;
     }
 
+    private readonly record struct HandlerFailureLogContext(
+        long UpdateId,
+        string UpdateType,
+        string Handler,
+        string Route,
+        string ModuleName,
+        string SceneName,
+        string ExceptionType);
+
+    private void LogHandlerFailure(
+        Exception exception,
+        HandlerFailureLogContext context,
+        bool includeTiming,
+        long handlerStarted,
+        TelegramHandlerRequestTimingScope? requestTimingScope)
+    {
+        if (!includeTiming)
+        {
+            LogHandlerFailed(
+                _logger,
+                exception,
+                context.UpdateId,
+                context.UpdateType,
+                context.Handler,
+                context.Route,
+                context.ModuleName,
+                context.SceneName,
+                context.ExceptionType);
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(requestTimingScope);
+
+        var handlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
+        var timing = requestTimingScope.CreateSummary(_timeProvider, handlerElapsed);
+
+        LogHandlerFailedWithTiming(
+            _logger,
+            exception,
+            context.UpdateId,
+            context.UpdateType,
+            context.Handler,
+            context.Route,
+            context.ModuleName,
+            context.SceneName,
+            context.ExceptionType,
+            handlerElapsed.TotalMilliseconds,
+            timing.RequestCount,
+            timing.RequestElapsedMilliseconds,
+            timing.HandlerLogicElapsedMilliseconds);
+    }
+
     [LoggerMessage(
         EventId = LogEventIds.NoHandlerMatched,
         Level = LogLevel.Debug,

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
@@ -4,8 +4,17 @@ namespace TeleFlow.Telegram.Internal.Handlers;
 
 internal sealed partial class TelegramHandlerDispatcher
 {
+    private static class LogEventIds
+    {
+        public const int NoHandlerMatched = 1;
+        public const int HandlerMatched = 2;
+        public const int HandlerFailed = 3;
+        public const int HandlerCompleted = 4;
+        public const int ErrorHandlerCompleted = 5;
+    }
+
     [LoggerMessage(
-        EventId = 1,
+        EventId = LogEventIds.NoHandlerMatched,
         Level = LogLevel.Debug,
         Message = "No Telegram handler matched. update_id={UpdateId}, type={UpdateType}, match_ms={MatchElapsedMilliseconds:F2}.")]
     private static partial void LogNoHandlerMatched(
@@ -15,7 +24,7 @@ internal sealed partial class TelegramHandlerDispatcher
         double matchElapsedMilliseconds);
 
     [LoggerMessage(
-        EventId = 2,
+        EventId = LogEventIds.HandlerMatched,
         Level = LogLevel.Debug,
         Message = "Telegram handler matched. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, match_ms={MatchElapsedMilliseconds:F2}.")]
     private static partial void LogHandlerMatched(
@@ -29,7 +38,7 @@ internal sealed partial class TelegramHandlerDispatcher
         double matchElapsedMilliseconds);
 
     [LoggerMessage(
-        EventId = 3,
+        EventId = LogEventIds.HandlerFailed,
         Level = LogLevel.Error,
         Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}.")]
     private static partial void LogHandlerFailed(
@@ -44,7 +53,7 @@ internal sealed partial class TelegramHandlerDispatcher
         string exceptionType);
 
     [LoggerMessage(
-        EventId = 3,
+        EventId = LogEventIds.HandlerFailed,
         Level = LogLevel.Error,
         Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
     private static partial void LogHandlerFailedWithTiming(
@@ -63,7 +72,7 @@ internal sealed partial class TelegramHandlerDispatcher
         double handlerLogicElapsedMilliseconds);
 
     [LoggerMessage(
-        EventId = 4,
+        EventId = LogEventIds.HandlerCompleted,
         Level = LogLevel.Debug,
         Message = "Telegram handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
     private static partial void LogHandlerCompleted(
@@ -78,7 +87,7 @@ internal sealed partial class TelegramHandlerDispatcher
         double handlerLogicElapsedMilliseconds);
 
     [LoggerMessage(
-        EventId = 5,
+        EventId = LogEventIds.ErrorHandlerCompleted,
         Level = LogLevel.Debug,
         Message = "Telegram error handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, error_handler={ErrorHandler}, handled={Handled}.")]
     private static partial void LogErrorHandlerCompleted(

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
@@ -4,15 +4,40 @@ namespace TeleFlow.Telegram.Internal.Handlers;
 
 internal sealed partial class TelegramHandlerDispatcher
 {
+    /// <summary>
+    /// Stable event ids emitted by the Telegram handler dispatcher.
+    /// </summary>
     private static class LogEventIds
     {
+        /// <summary>
+        /// No route matched the incoming Telegram update.
+        /// </summary>
         public const int NoHandlerMatched = 1;
+
+        /// <summary>
+        /// A route matched the incoming Telegram update.
+        /// </summary>
         public const int HandlerMatched = 2;
+
+        /// <summary>
+        /// A selected Telegram handler failed.
+        /// </summary>
         public const int HandlerFailed = 3;
+
+        /// <summary>
+        /// A selected Telegram handler completed successfully.
+        /// </summary>
         public const int HandlerCompleted = 4;
+
+        /// <summary>
+        /// A Telegram error handler completed after a selected handler failed.
+        /// </summary>
         public const int ErrorHandlerCompleted = 5;
     }
 
+    /// <summary>
+    /// Captures log fields shared by handler failure logs and error-handler completion logs.
+    /// </summary>
     private readonly record struct HandlerFailureLogContext(
         long UpdateId,
         string UpdateType,
@@ -22,6 +47,9 @@ internal sealed partial class TelegramHandlerDispatcher
         string SceneName,
         string ExceptionType);
 
+    /// <summary>
+    /// Logs a handler failure with optional timing details collected only for debug diagnostics.
+    /// </summary>
     private void LogHandlerFailure(
         Exception exception,
         HandlerFailureLogContext context,
@@ -65,6 +93,9 @@ internal sealed partial class TelegramHandlerDispatcher
             timing.HandlerLogicElapsedMilliseconds);
     }
 
+    /// <summary>
+    /// Logs that no Telegram handler matched an update.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.NoHandlerMatched,
         Level = LogLevel.Debug,
@@ -75,6 +106,9 @@ internal sealed partial class TelegramHandlerDispatcher
         string updateType,
         double matchElapsedMilliseconds);
 
+    /// <summary>
+    /// Logs the Telegram handler selected for an update.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.HandlerMatched,
         Level = LogLevel.Debug,
@@ -89,6 +123,9 @@ internal sealed partial class TelegramHandlerDispatcher
         string sceneName,
         double matchElapsedMilliseconds);
 
+    /// <summary>
+    /// Logs a Telegram handler failure without debug-only timing fields.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.HandlerFailed,
         Level = LogLevel.Error,
@@ -104,6 +141,9 @@ internal sealed partial class TelegramHandlerDispatcher
         string sceneName,
         string exceptionType);
 
+    /// <summary>
+    /// Logs a Telegram handler failure with debug-only timing fields.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.HandlerFailed,
         Level = LogLevel.Error,
@@ -123,6 +163,9 @@ internal sealed partial class TelegramHandlerDispatcher
         double telegramRequestElapsedMilliseconds,
         double handlerLogicElapsedMilliseconds);
 
+    /// <summary>
+    /// Logs a successfully completed Telegram handler with debug timing fields.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.HandlerCompleted,
         Level = LogLevel.Debug,
@@ -138,6 +181,9 @@ internal sealed partial class TelegramHandlerDispatcher
         double telegramRequestElapsedMilliseconds,
         double handlerLogicElapsedMilliseconds);
 
+    /// <summary>
+    /// Logs the result returned by a Telegram error handler.
+    /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.ErrorHandlerCompleted,
         Level = LogLevel.Debug,

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -6,6 +6,9 @@ using TeleFlow.Telegram.Internal;
 
 namespace TeleFlow.Telegram.Internal.Handlers;
 
+/// <summary>
+/// Selects and invokes the Telegram handler for a single update payload.
+/// </summary>
 internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
 {
     private readonly TelegramHandlerSelector _selector;
@@ -14,6 +17,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
     private readonly TelegramAutoAnswerCallbackDescriptor? _globalAutoAnswerCallback;
     private readonly ILogger<TelegramHandlerDispatcher> _logger;
 
+    /// <summary>
+    /// Creates a dispatcher from registered handler descriptors and framework services.
+    /// </summary>
     public TelegramHandlerDispatcher(
         IEnumerable<TelegramHandlerDescriptor> descriptors,
         IEnumerable<TelegramErrorHandlerDescriptor> errorHandlers,
@@ -36,6 +42,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         _logger = loggerFactory.CreateLogger<TelegramHandlerDispatcher>();
     }
 
+    /// <summary>
+    /// Dispatches one update through handler selection, invocation, error handlers, and callback auto-answering.
+    /// </summary>
     public async Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -207,6 +216,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             completedTiming.HandlerLogicElapsedMilliseconds);
     }
 
+    /// <summary>
+    /// Reads current state only when the selector contains stateful handlers.
+    /// </summary>
     private static async ValueTask<string?> GetCurrentStateAsync(
         UpdateContext context,
         CancellationToken cancellationToken)
@@ -216,11 +228,17 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             : null;
     }
 
+    /// <summary>
+    /// Returns elapsed milliseconds from a timestamp captured by the dispatcher time provider.
+    /// </summary>
     private double GetElapsedMilliseconds(long startingTimestamp)
     {
         return _timeProvider.GetElapsedTime(startingTimestamp).TotalMilliseconds;
     }
 
+    /// <summary>
+    /// Sends the configured callback answer after a callback handler when the handler did not answer it explicitly.
+    /// </summary>
     private async Task AutoAnswerCallbackAsync(
         TelegramHandlerDescriptor handler,
         TelegramUpdateContext context,
@@ -245,6 +263,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Tries registered Telegram error handlers in deterministic priority order.
+    /// </summary>
     private async ValueTask<bool> TryHandleErrorAsync(
         TelegramRouteSelection selection,
         TelegramUpdateContext telegramContext,
@@ -301,6 +322,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         return false;
     }
 
+    /// <summary>
+    /// Enumerates module-scoped error handlers before global error handlers.
+    /// </summary>
     private IEnumerable<TelegramErrorHandlerDescriptor> GetErrorHandlerCandidates(
         TelegramRouteSelection selection,
         TelegramUpdateContext telegramContext,
@@ -328,6 +352,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
     }
 
+    /// <summary>
+    /// Filters compatible error handlers and orders them from most specific to least specific.
+    /// </summary>
     private static IEnumerable<TelegramErrorHandlerDescriptor> RankErrorHandlerCandidates(
         IReadOnlyDictionary<string, object?> routeValues,
         TelegramUpdateContext telegramContext,
@@ -340,6 +367,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             .ThenBy(static handler => handler.RegistrationOrder);
     }
 
+    /// <summary>
+    /// Checks whether an error handler can receive the thrown exception, update context, and route values.
+    /// </summary>
     private static bool IsCompatibleErrorHandler(
         TelegramErrorHandlerDescriptor handler,
         IReadOnlyDictionary<string, object?> routeValues,
@@ -366,6 +396,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         return true;
     }
 
+    /// <summary>
+    /// Checks all route-value parameters required by an error handler.
+    /// </summary>
     private static bool HasCompatibleRouteValues(
         TelegramErrorHandlerDescriptor handler,
         IReadOnlyDictionary<string, object?> routeValues)
@@ -386,6 +419,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         return true;
     }
 
+    /// <summary>
+    /// Checks that one route-value parameter exists and can be assigned to the handler parameter type.
+    /// </summary>
     private static bool HasCompatibleRouteValue(
         TelegramErrorHandlerParameterDescriptor parameter,
         IReadOnlyDictionary<string, object?> routeValues)
@@ -394,6 +430,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                IsRouteValueAssignable(parameter.ParameterType, value);
     }
 
+    /// <summary>
+    /// Gets the route value for an error-handler parameter.
+    /// </summary>
     private static bool TryGetRouteValue(
         TelegramErrorHandlerParameterDescriptor parameter,
         IReadOnlyDictionary<string, object?> routeValues,
@@ -405,6 +444,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                routeValues.TryGetValue(parameter.Name, out value);
     }
 
+    /// <summary>
+    /// Checks whether a route value can be assigned to a handler parameter, including nullable value types.
+    /// </summary>
     private static bool IsRouteValueAssignable(Type parameterType, object? value)
     {
         if (value is null)
@@ -417,12 +459,18 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         return targetType.IsInstanceOfType(value);
     }
 
+    /// <summary>
+    /// Checks whether a route-value parameter type can accept a null value.
+    /// </summary>
     private static bool IsNullableRouteValue(Type parameterType)
     {
         return !parameterType.IsValueType ||
                Nullable.GetUnderlyingType(parameterType) is not null;
     }
 
+    /// <summary>
+    /// Computes how specific an error handler exception type is for the thrown exception type.
+    /// </summary>
     private static int GetExceptionDistance(Type? handlerExceptionType, Type thrownExceptionType)
     {
         if (handlerExceptionType is null)
@@ -447,16 +495,25 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         return int.MaxValue - 1;
     }
 
+    /// <summary>
+    /// Determines whether an exception represents cancellation requested for the current update.
+    /// </summary>
     private static bool IsUpdateCancellation(Exception exception, CancellationToken cancellationToken)
     {
         return exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
     }
 
+    /// <summary>
+    /// Formats an error handler name for diagnostic logs.
+    /// </summary>
     private static string FormatErrorHandler(TelegramErrorHandlerDescriptor handler)
     {
         return $"{handler.HandlerType.Name}.{handler.MethodName}";
     }
 
+    /// <summary>
+    /// Converts global callback auto-answer options to the descriptor used by the dispatcher.
+    /// </summary>
     private static TelegramAutoAnswerCallbackDescriptor? CreateGlobalAutoAnswerDescriptor(
         TelegramAutoAnswerCallbackOptions? options)
     {

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -128,9 +128,9 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 matchElapsedMilliseconds);
         }
 
-        var handlerDiagnosticsEnabled = debugEnabled || errorEnabled;
-        var handlerStarted = handlerDiagnosticsEnabled ? _timeProvider.GetTimestamp() : 0;
-        using var requestTimingScope = handlerDiagnosticsEnabled
+        var handlerTimingEnabled = debugEnabled;
+        var handlerStarted = handlerTimingEnabled ? _timeProvider.GetTimestamp() : 0;
+        using var requestTimingScope = handlerTimingEnabled
             ? TelegramHandlerRequestTimingScope.Begin()
             : null;
 
@@ -143,27 +143,41 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
         catch (Exception exception) when (!IsUpdateCancellation(exception, effectiveCancellationToken))
         {
-            var handlerElapsed = handlerDiagnosticsEnabled
-                ? _timeProvider.GetElapsedTime(handlerStarted)
-                : TimeSpan.Zero;
-            var timing = requestTimingScope?.CreateSummary(_timeProvider, handlerElapsed) ?? default;
-
             if (errorEnabled)
             {
-                LogHandlerFailed(
-                    _logger,
-                    exception,
-                    payload.Update.UpdateId,
-                    GetUpdateType(),
-                    GetHandlerName(),
-                    GetRouteName(),
-                    selection.Handler.ModuleName ?? string.Empty,
-                    selection.Handler.SceneName ?? string.Empty,
-                    exception.GetType().FullName ?? exception.GetType().Name,
-                    handlerElapsed.TotalMilliseconds,
-                    timing.RequestCount,
-                    timing.RequestElapsedMilliseconds,
-                    timing.HandlerLogicElapsedMilliseconds);
+                if (handlerTimingEnabled)
+                {
+                    var handlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
+                    var timing = requestTimingScope!.CreateSummary(_timeProvider, handlerElapsed);
+
+                    LogHandlerFailedWithTiming(
+                        _logger,
+                        exception,
+                        payload.Update.UpdateId,
+                        GetUpdateType(),
+                        GetHandlerName(),
+                        GetRouteName(),
+                        selection.Handler.ModuleName ?? string.Empty,
+                        selection.Handler.SceneName ?? string.Empty,
+                        exception.GetType().FullName ?? exception.GetType().Name,
+                        handlerElapsed.TotalMilliseconds,
+                        timing.RequestCount,
+                        timing.RequestElapsedMilliseconds,
+                        timing.HandlerLogicElapsedMilliseconds);
+                }
+                else
+                {
+                    LogHandlerFailed(
+                        _logger,
+                        exception,
+                        payload.Update.UpdateId,
+                        GetUpdateType(),
+                        GetHandlerName(),
+                        GetRouteName(),
+                        selection.Handler.ModuleName ?? string.Empty,
+                        selection.Handler.SceneName ?? string.Empty,
+                        exception.GetType().FullName ?? exception.GetType().Name);
+                }
             }
 
             if (_errorHandlers.Length > 0 &&
@@ -188,7 +202,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             telegramContext,
             effectiveCancellationToken).ConfigureAwait(false);
 
-        if (!debugEnabled)
+        if (!handlerTimingEnabled)
         {
             return;
         }
@@ -455,77 +469,4 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             : new TelegramAutoAnswerCallbackDescriptor(options.Enabled, options.Text, options.ShowAlert);
     }
 
-    [LoggerMessage(
-        EventId = 1,
-        Level = LogLevel.Debug,
-        Message = "No Telegram handler matched. update_id={UpdateId}, type={UpdateType}, match_ms={MatchElapsedMilliseconds:F2}.")]
-    private static partial void LogNoHandlerMatched(
-        ILogger logger,
-        long updateId,
-        string updateType,
-        double matchElapsedMilliseconds);
-
-    [LoggerMessage(
-        EventId = 2,
-        Level = LogLevel.Debug,
-        Message = "Telegram handler matched. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, match_ms={MatchElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerMatched(
-        ILogger logger,
-        long updateId,
-        string updateType,
-        string handler,
-        string route,
-        string moduleName,
-        string sceneName,
-        double matchElapsedMilliseconds);
-
-    [LoggerMessage(
-        EventId = 3,
-        Level = LogLevel.Error,
-        Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerFailed(
-        ILogger logger,
-        Exception exception,
-        long updateId,
-        string updateType,
-        string handler,
-        string route,
-        string moduleName,
-        string sceneName,
-        string exceptionType,
-        double handlerElapsedMilliseconds,
-        int telegramRequestCount,
-        double telegramRequestElapsedMilliseconds,
-        double handlerLogicElapsedMilliseconds);
-
-    [LoggerMessage(
-        EventId = 4,
-        Level = LogLevel.Debug,
-        Message = "Telegram handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerCompleted(
-        ILogger logger,
-        long updateId,
-        string updateType,
-        string handler,
-        string route,
-        double handlerElapsedMilliseconds,
-        int telegramRequestCount,
-        double telegramRequestElapsedMilliseconds,
-        double handlerLogicElapsedMilliseconds);
-
-    [LoggerMessage(
-        EventId = 5,
-        Level = LogLevel.Debug,
-        Message = "Telegram error handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, error_handler={ErrorHandler}, handled={Handled}.")]
-    private static partial void LogErrorHandlerCompleted(
-        ILogger logger,
-        long updateId,
-        string updateType,
-        string handler,
-        string route,
-        string moduleName,
-        string sceneName,
-        string exceptionType,
-        string errorHandler,
-        bool handled);
 }

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -55,7 +55,6 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
 
         var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
-        var errorEnabled = _logger.IsEnabled(LogLevel.Error);
         string? updateType = null;
         string GetUpdateType() => updateType ??= TelegramUpdateLogFormatter.GetUpdateType(payload.Update);
 
@@ -167,7 +166,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 return logContext.Value;
             }
 
-            if (errorEnabled)
+            if (_logger.IsEnabled(LogLevel.Error))
             {
                 LogHandlerFailure(
                     exception,

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -143,41 +143,29 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
         catch (Exception exception) when (!IsUpdateCancellation(exception, effectiveCancellationToken))
         {
+            HandlerFailureLogContext? logContext = null;
+            HandlerFailureLogContext GetLogContext()
+            {
+                logContext ??= new HandlerFailureLogContext(
+                    payload.Update.UpdateId,
+                    GetUpdateType(),
+                    GetHandlerName(),
+                    GetRouteName(),
+                    selection.Handler.ModuleName ?? string.Empty,
+                    selection.Handler.SceneName ?? string.Empty,
+                    exception.GetType().FullName ?? exception.GetType().Name);
+
+                return logContext.Value;
+            }
+
             if (errorEnabled)
             {
-                if (handlerTimingEnabled)
-                {
-                    var handlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
-                    var timing = requestTimingScope!.CreateSummary(_timeProvider, handlerElapsed);
-
-                    LogHandlerFailedWithTiming(
-                        _logger,
-                        exception,
-                        payload.Update.UpdateId,
-                        GetUpdateType(),
-                        GetHandlerName(),
-                        GetRouteName(),
-                        selection.Handler.ModuleName ?? string.Empty,
-                        selection.Handler.SceneName ?? string.Empty,
-                        exception.GetType().FullName ?? exception.GetType().Name,
-                        handlerElapsed.TotalMilliseconds,
-                        timing.RequestCount,
-                        timing.RequestElapsedMilliseconds,
-                        timing.HandlerLogicElapsedMilliseconds);
-                }
-                else
-                {
-                    LogHandlerFailed(
-                        _logger,
-                        exception,
-                        payload.Update.UpdateId,
-                        GetUpdateType(),
-                        GetHandlerName(),
-                        GetRouteName(),
-                        selection.Handler.ModuleName ?? string.Empty,
-                        selection.Handler.SceneName ?? string.Empty,
-                        exception.GetType().FullName ?? exception.GetType().Name);
-                }
+                LogHandlerFailure(
+                    exception,
+                    GetLogContext(),
+                    handlerTimingEnabled,
+                    handlerStarted,
+                    requestTimingScope);
             }
 
             if (_errorHandlers.Length > 0 &&
@@ -185,10 +173,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                     selection,
                     telegramContext,
                     exception,
-                    payload.Update.UpdateId,
-                    GetUpdateType(),
-                    GetHandlerName(),
-                    GetRouteName(),
+                    debugEnabled ? GetLogContext() : null,
                     effectiveCancellationToken).ConfigureAwait(false))
             {
                 return;
@@ -264,10 +249,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         TelegramRouteSelection selection,
         TelegramUpdateContext telegramContext,
         Exception exception,
-        long updateId,
-        string updateType,
-        string handlerName,
-        string routeName,
+        HandlerFailureLogContext? logContext,
         CancellationToken cancellationToken)
     {
         if (_errorHandlers.Length == 0)
@@ -295,17 +277,17 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 cancellationToken).ConfigureAwait(false);
             var handled = result == TelegramErrorHandlingResult.Handled;
 
-            if (_logger.IsEnabled(LogLevel.Debug))
+            if (logContext is { } context)
             {
                 LogErrorHandlerCompleted(
                     _logger,
-                    updateId,
-                    updateType,
-                    handlerName,
-                    routeName,
-                    selection.Handler.ModuleName ?? string.Empty,
-                    selection.Handler.SceneName ?? string.Empty,
-                    exception.GetType().FullName ?? exception.GetType().Name,
+                    context.UpdateId,
+                    context.UpdateType,
+                    context.Handler,
+                    context.Route,
+                    context.ModuleName,
+                    context.SceneName,
+                    context.ExceptionType,
                     FormatErrorHandler(errorHandler),
                     handled);
             }

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -370,43 +370,57 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         TelegramErrorHandlerDescriptor handler,
         IReadOnlyDictionary<string, object?> routeValues)
     {
-        foreach (var parameter in handler.Parameters.Where(static parameter => parameter.Kind == TelegramErrorHandlerParameterKind.RouteValue))
+        foreach (var parameter in handler.Parameters)
         {
-            if (string.IsNullOrWhiteSpace(parameter.Name) ||
-                !routeValues.TryGetValue(parameter.Name, out var value))
+            if (parameter.Kind != TelegramErrorHandlerParameterKind.RouteValue)
             {
-                return false;
-            }
-
-            if (value is null)
-            {
-                if (parameter.ParameterType.IsValueType && Nullable.GetUnderlyingType(parameter.ParameterType) is null)
-                {
-                    return false;
-                }
-
                 continue;
             }
 
-            var underlyingParameterType = Nullable.GetUnderlyingType(parameter.ParameterType);
-
-            if (underlyingParameterType is not null)
-            {
-                if (!underlyingParameterType.IsInstanceOfType(value))
-                {
-                    return false;
-                }
-
-                continue;
-            }
-
-            if (!parameter.ParameterType.IsInstanceOfType(value))
+            if (!HasCompatibleRouteValue(parameter, routeValues))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool HasCompatibleRouteValue(
+        TelegramErrorHandlerParameterDescriptor parameter,
+        IReadOnlyDictionary<string, object?> routeValues)
+    {
+        return TryGetRouteValue(parameter, routeValues, out var value) &&
+               IsRouteValueAssignable(parameter.ParameterType, value);
+    }
+
+    private static bool TryGetRouteValue(
+        TelegramErrorHandlerParameterDescriptor parameter,
+        IReadOnlyDictionary<string, object?> routeValues,
+        out object? value)
+    {
+        value = null;
+
+        return !string.IsNullOrWhiteSpace(parameter.Name) &&
+               routeValues.TryGetValue(parameter.Name, out value);
+    }
+
+    private static bool IsRouteValueAssignable(Type parameterType, object? value)
+    {
+        if (value is null)
+        {
+            return IsNullableRouteValue(parameterType);
+        }
+
+        var targetType = Nullable.GetUnderlyingType(parameterType) ?? parameterType;
+
+        return targetType.IsInstanceOfType(value);
+    }
+
+    private static bool IsNullableRouteValue(Type parameterType)
+    {
+        return !parameterType.IsValueType ||
+               Nullable.GetUnderlyingType(parameterType) is not null;
     }
 
     private static int GetExceptionDistance(Type? handlerExceptionType, Type thrownExceptionType)

--- a/tests/TeleFlow.ArchitectureTests/RecordingLoggerFactory.cs
+++ b/tests/TeleFlow.ArchitectureTests/RecordingLoggerFactory.cs
@@ -2,13 +2,13 @@ using Microsoft.Extensions.Logging;
 
 namespace TeleFlow.ArchitectureTests;
 
-internal sealed class RecordingLoggerFactory : ILoggerFactory
+internal sealed class RecordingLoggerFactory(LogLevel minimumLevel = LogLevel.Trace) : ILoggerFactory
 {
     public List<TestLogEntry> Entries { get; } = [];
 
     public ILogger CreateLogger(string categoryName)
     {
-        return new RecordingLogger(categoryName, Entries);
+        return new RecordingLogger(categoryName, minimumLevel, Entries);
     }
 
     public void AddProvider(ILoggerProvider provider)
@@ -21,6 +21,7 @@ internal sealed class RecordingLoggerFactory : ILoggerFactory
 
     private sealed class RecordingLogger(
         string categoryName,
+        LogLevel minimumLevel,
         List<TestLogEntry> entries) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
@@ -31,7 +32,7 @@ internal sealed class RecordingLoggerFactory : ILoggerFactory
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            return true;
+            return logLevel >= minimumLevel && minimumLevel != LogLevel.None;
         }
 
         public void Log<TState>(

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -333,6 +333,54 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task ErrorHandler_LogsCompletionWhenDebugEnabled()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        var expected = new InvalidOperationException("handler failed");
+        ThrowingMessageHandler.Exception = expected;
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+                services.AddTelegramHandler<HandledErrorHandler>();
+            });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("boom"));
+
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Debug &&
+                     entry.Message.Contains("Telegram error handler completed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("handler=ThrowingMessageHandler.Handle", StringComparison.Ordinal) &&
+                     entry.Message.Contains("error_handler=HandledErrorHandler.Handle", StringComparison.Ordinal) &&
+                     entry.Message.Contains("handled=True", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ErrorHandler_DoesNotLogCompletionWhenDebugDisabled()
+    {
+        var loggerFactory = new RecordingLoggerFactory(LogLevel.Information);
+        var expected = new InvalidOperationException("handler failed");
+        ThrowingMessageHandler.Exception = expected;
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+                services.AddTelegramHandler<HandledErrorHandler>();
+            });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("boom"));
+
+        Assert.DoesNotContain(
+            loggerFactory.Entries,
+            entry => entry.Message.Contains("Telegram error handler completed", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ErrorHandler_UnhandledResultRethrowsOriginalException()
     {
         var expected = new InvalidOperationException("handler failed");

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -201,6 +201,36 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task Dispatcher_DoesNotLogHandlerTimingWhenDebugDisabled()
+    {
+        var loggerFactory = new RecordingLoggerFactory(LogLevel.Information);
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.RemoveAll<ITelegramTransport>();
+                services.AddSingleton<ITelegramTransport>(
+                    new SequencedTelegramTransport(CreateGetMeResponse()));
+                services.AddTelegramHandler<OneTelegramRequestMessageHandler>();
+            });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("hello"));
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        Assert.Equal(["one-request:42"], probe.Events);
+        Assert.DoesNotContain(
+            loggerFactory.Entries,
+            entry => entry.Category.EndsWith("TelegramHandlerDispatcher", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            loggerFactory.Entries,
+            entry => entry.Category.EndsWith("TelegramHandlerDispatcher", StringComparison.Ordinal) &&
+                     entry.Message.Contains("telegram_request_count=", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Dispatcher_LogsNoMatchedHandler()
     {
         var loggerFactory = new RecordingLoggerFactory();
@@ -250,6 +280,37 @@ public sealed class TelegramHandlerDispatcherTests
                      entry.Message.Contains("telegram_request_count=0", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_ms=0", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler_logic_ms=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Dispatcher_LogsFailedHandlerWithoutTimingWhenDebugDisabled()
+    {
+        var loggerFactory = new RecordingLoggerFactory(LogLevel.Information);
+        var expected = new InvalidOperationException("handler failed");
+        ThrowingMessageHandler.Exception = expected;
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+            });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => DispatchAsync(serviceProvider, CreateMessageUpdate("boom")));
+
+        Assert.Same(expected, exception);
+        var entry = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Error &&
+                     ReferenceEquals(entry.Exception, expected) &&
+                     entry.Message.Contains("Telegram handler failed", StringComparison.Ordinal));
+
+        Assert.Contains("handler=ThrowingMessageHandler.Handle", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("handler_ms=", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("telegram_request_count=", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("telegram_request_ms=", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("handler_logic_ms=", entry.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Collect detailed handler request timing only when `LogLevel.Debug` is enabled.

- successful handler dispatch no longer creates `TelegramHandlerRequestTimingScope` just because Error logging is enabled;
- handler failure logs remain available at Error level without pretending that request timing was collected;
- Debug logs keep handler duration, Telegram request count, Telegram request time, and handler logic time;
- diagnostics docs now describe the Debug-only timing policy.

Closes #47.

## Touched hot paths

- `TelegramHandlerDispatcher.DispatchAsync` now creates the handler request timing scope only for Debug-enabled diagnostics.
- Normal Information/Error logging no longer pays for handler request timing collection on the successful dispatch path.
- Telegram request timing aggregation remains available for Debug handler diagnostics.

## Tests

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~Dispatcher_DoesNotLogHandlerTimingWhenDebugDisabled|FullyQualifiedName~Dispatcher_LogsFailedHandlerWithoutTimingWhenDebugDisabled|FullyQualifiedName~Dispatcher_LogsFailedHandlerAndRethrowsOriginalException|FullyQualifiedName~Dispatcher_LogsHandlerTiming" --no-restore --logger "console;verbosity=minimal"`
- `dotnet build TeleFlow.sln -c Release --no-restore /nodeReuse:false`
- `dotnet test TeleFlow.sln -c Release --no-build --no-restore /nodeReuse:false --logger "console;verbosity=minimal"`