### PR TITLE
Pre-index Telegram error handlers for exception-path dispatch

### DIFF
--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramErrorHandlerIndex.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramErrorHandlerIndex.cs
@@ -1,0 +1,228 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Pre-indexes Telegram error handlers so exception dispatch does not rebuild candidate groups per failure.
+/// </summary>
+internal sealed class TelegramErrorHandlerIndex
+{
+    private readonly Dictionary<string, TelegramErrorHandlerGroup> _moduleGroups;
+    private readonly TelegramErrorHandlerGroup _globalGroup;
+
+    public TelegramErrorHandlerIndex(IEnumerable<TelegramErrorHandlerDescriptor> errorHandlers)
+    {
+        ArgumentNullException.ThrowIfNull(errorHandlers);
+
+        var moduleGroups = new Dictionary<string, List<TelegramErrorHandlerDescriptor>>(StringComparer.Ordinal);
+        var globalHandlers = new List<TelegramErrorHandlerDescriptor>();
+
+        foreach (var handler in errorHandlers)
+        {
+            if (handler.ModuleName is null)
+            {
+                globalHandlers.Add(handler);
+                continue;
+            }
+
+            if (!moduleGroups.TryGetValue(handler.ModuleName, out var handlers))
+            {
+                handlers = [];
+                moduleGroups.Add(handler.ModuleName, handlers);
+            }
+
+            handlers.Add(handler);
+        }
+
+        _moduleGroups = new Dictionary<string, TelegramErrorHandlerGroup>(moduleGroups.Count, StringComparer.Ordinal);
+
+        foreach (var (moduleName, handlers) in moduleGroups)
+        {
+            _moduleGroups.Add(moduleName, new TelegramErrorHandlerGroup(handlers));
+        }
+
+        _globalGroup = new TelegramErrorHandlerGroup(globalHandlers);
+        HasHandlers = _moduleGroups.Count > 0 || _globalGroup.HasHandlers;
+    }
+
+    /// <summary>
+    /// Gets whether the index contains at least one error handler.
+    /// </summary>
+    public bool HasHandlers { get; }
+
+    /// <summary>
+    /// Enumerates compatible error handlers in dispatcher invocation order.
+    /// </summary>
+    public IEnumerable<TelegramErrorHandlerDescriptor> GetCandidates(
+        TelegramRouteSelection selection,
+        TelegramUpdateContext telegramContext,
+        Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        ArgumentNullException.ThrowIfNull(telegramContext);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (selection.Handler.ModuleName is { } moduleName &&
+            _moduleGroups.TryGetValue(moduleName, out var moduleGroup))
+        {
+            foreach (var candidate in moduleGroup.GetCandidates(selection.RouteValues, telegramContext, exception))
+            {
+                yield return candidate;
+            }
+        }
+
+        foreach (var candidate in _globalGroup.GetCandidates(selection.RouteValues, telegramContext, exception))
+        {
+            yield return candidate;
+        }
+    }
+
+    private sealed class TelegramErrorHandlerGroup
+    {
+        private readonly Dictionary<Type, TelegramErrorHandlerDescriptor[]> _typedHandlers;
+        private readonly TelegramErrorHandlerDescriptor[] _catchAllHandlers;
+
+        public TelegramErrorHandlerGroup(IEnumerable<TelegramErrorHandlerDescriptor> handlers)
+        {
+            ArgumentNullException.ThrowIfNull(handlers);
+
+            var typedHandlers = new Dictionary<Type, List<TelegramErrorHandlerDescriptor>>();
+            var catchAllHandlers = new List<TelegramErrorHandlerDescriptor>();
+
+            foreach (var handler in handlers.OrderBy(static handler => handler.RegistrationOrder))
+            {
+                if (handler.ExceptionType is null)
+                {
+                    catchAllHandlers.Add(handler);
+                    continue;
+                }
+
+                if (!typedHandlers.TryGetValue(handler.ExceptionType, out var typedGroup))
+                {
+                    typedGroup = [];
+                    typedHandlers.Add(handler.ExceptionType, typedGroup);
+                }
+
+                typedGroup.Add(handler);
+            }
+
+            _typedHandlers = new Dictionary<Type, TelegramErrorHandlerDescriptor[]>(typedHandlers.Count);
+
+            foreach (var (exceptionType, typedGroup) in typedHandlers)
+            {
+                _typedHandlers.Add(exceptionType, typedGroup.ToArray());
+            }
+
+            _catchAllHandlers = catchAllHandlers.ToArray();
+            HasHandlers = _typedHandlers.Count > 0 || _catchAllHandlers.Length > 0;
+        }
+
+        public bool HasHandlers { get; }
+
+        public IEnumerable<TelegramErrorHandlerDescriptor> GetCandidates(
+            IReadOnlyDictionary<string, object?> routeValues,
+            TelegramUpdateContext telegramContext,
+            Exception exception)
+        {
+            var exceptionType = exception.GetType();
+
+            while (exceptionType is not null)
+            {
+                if (_typedHandlers.TryGetValue(exceptionType, out var typedHandlers))
+                {
+                    foreach (var handler in typedHandlers)
+                    {
+                        if (IsCompatibleErrorHandler(handler, routeValues, telegramContext))
+                        {
+                            yield return handler;
+                        }
+                    }
+                }
+
+                exceptionType = exceptionType.BaseType;
+            }
+
+            foreach (var handler in _catchAllHandlers)
+            {
+                if (IsCompatibleErrorHandler(handler, routeValues, telegramContext))
+                {
+                    yield return handler;
+                }
+            }
+        }
+    }
+
+    private static bool IsCompatibleErrorHandler(
+        TelegramErrorHandlerDescriptor handler,
+        IReadOnlyDictionary<string, object?> routeValues,
+        TelegramUpdateContext telegramContext)
+    {
+        if (handler.TelegramContextType is not null &&
+            !handler.TelegramContextType.IsInstanceOfType(telegramContext))
+        {
+            return false;
+        }
+
+        if (!HasCompatibleRouteValues(handler, routeValues))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasCompatibleRouteValues(
+        TelegramErrorHandlerDescriptor handler,
+        IReadOnlyDictionary<string, object?> routeValues)
+    {
+        foreach (var parameter in handler.Parameters)
+        {
+            if (parameter.Kind != TelegramErrorHandlerParameterKind.RouteValue)
+            {
+                continue;
+            }
+
+            if (!HasCompatibleRouteValue(parameter, routeValues))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasCompatibleRouteValue(
+        TelegramErrorHandlerParameterDescriptor parameter,
+        IReadOnlyDictionary<string, object?> routeValues)
+    {
+        return TryGetRouteValue(parameter, routeValues, out var value) &&
+               IsRouteValueAssignable(parameter.ParameterType, value);
+    }
+
+    private static bool TryGetRouteValue(
+        TelegramErrorHandlerParameterDescriptor parameter,
+        IReadOnlyDictionary<string, object?> routeValues,
+        out object? value)
+    {
+        value = null;
+
+        return !string.IsNullOrWhiteSpace(parameter.Name) &&
+               routeValues.TryGetValue(parameter.Name, out value);
+    }
+
+    private static bool IsRouteValueAssignable(Type parameterType, object? value)
+    {
+        if (value is null)
+        {
+            return IsNullableRouteValue(parameterType);
+        }
+
+        var targetType = Nullable.GetUnderlyingType(parameterType) ?? parameterType;
+
+        return targetType.IsInstanceOfType(value);
+    }
+
+    private static bool IsNullableRouteValue(Type parameterType)
+    {
+        return !parameterType.IsValueType ||
+               Nullable.GetUnderlyingType(parameterType) is not null;
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -12,7 +12,7 @@ namespace TeleFlow.Telegram.Internal.Handlers;
 internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
 {
     private readonly TelegramHandlerSelector _selector;
-    private readonly TelegramErrorHandlerDescriptor[] _errorHandlers;
+    private readonly TelegramErrorHandlerIndex _errorHandlerIndex;
     private readonly TimeProvider _timeProvider;
     private readonly TelegramAutoAnswerCallbackDescriptor? _globalAutoAnswerCallback;
     private readonly ILogger<TelegramHandlerDispatcher> _logger;
@@ -36,7 +36,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         var table = new TelegramHandlerTable(descriptors);
 
         _selector = new TelegramHandlerSelector(table);
-        _errorHandlers = errorHandlers.ToArray();
+        _errorHandlerIndex = new TelegramErrorHandlerIndex(errorHandlers);
         _timeProvider = timeProvider;
         _globalAutoAnswerCallback = CreateGlobalAutoAnswerDescriptor(autoAnswerCallbackOptions.LastOrDefault());
         _logger = loggerFactory.CreateLogger<TelegramHandlerDispatcher>();
@@ -176,7 +176,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                     requestTimingScope);
             }
 
-            if (_errorHandlers.Length > 0 &&
+            if (_errorHandlerIndex.HasHandlers &&
                 await TryHandleErrorAsync(
                     selection,
                     telegramContext,
@@ -272,11 +272,6 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         HandlerFailureLogContext? logContext,
         CancellationToken cancellationToken)
     {
-        if (_errorHandlers.Length == 0)
-        {
-            return false;
-        }
-
         var errorContext = new TelegramErrorContext(
             exception,
             telegramContext,
@@ -286,7 +281,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             selection.Handler.SceneName,
             selection.RouteValues);
 
-        foreach (var errorHandler in GetErrorHandlerCandidates(selection, telegramContext, exception))
+        foreach (var errorHandler in _errorHandlerIndex.GetCandidates(selection, telegramContext, exception))
         {
             var result = await TelegramErrorHandlerInvoker.InvokeAsync(
                 errorHandler,
@@ -319,179 +314,6 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Enumerates module-scoped error handlers before global error handlers.
-    /// </summary>
-    private IEnumerable<TelegramErrorHandlerDescriptor> GetErrorHandlerCandidates(
-        TelegramRouteSelection selection,
-        TelegramUpdateContext telegramContext,
-        Exception exception)
-    {
-        if (selection.Handler.ModuleName is { } moduleName)
-        {
-            foreach (var candidate in RankErrorHandlerCandidates(
-                         selection.RouteValues,
-                         telegramContext,
-                         exception,
-                         _errorHandlers.Where(handler => string.Equals(handler.ModuleName, moduleName, StringComparison.Ordinal))))
-            {
-                yield return candidate;
-            }
-        }
-
-        foreach (var candidate in RankErrorHandlerCandidates(
-                     selection.RouteValues,
-                     telegramContext,
-                     exception,
-                     _errorHandlers.Where(static handler => handler.ModuleName is null)))
-        {
-            yield return candidate;
-        }
-    }
-
-    /// <summary>
-    /// Filters compatible error handlers and orders them from most specific to least specific.
-    /// </summary>
-    private static IEnumerable<TelegramErrorHandlerDescriptor> RankErrorHandlerCandidates(
-        IReadOnlyDictionary<string, object?> routeValues,
-        TelegramUpdateContext telegramContext,
-        Exception exception,
-        IEnumerable<TelegramErrorHandlerDescriptor> candidates)
-    {
-        return candidates
-            .Where(handler => IsCompatibleErrorHandler(handler, routeValues, telegramContext, exception))
-            .OrderBy(handler => GetExceptionDistance(handler.ExceptionType, exception.GetType()))
-            .ThenBy(static handler => handler.RegistrationOrder);
-    }
-
-    /// <summary>
-    /// Checks whether an error handler can receive the thrown exception, update context, and route values.
-    /// </summary>
-    private static bool IsCompatibleErrorHandler(
-        TelegramErrorHandlerDescriptor handler,
-        IReadOnlyDictionary<string, object?> routeValues,
-        TelegramUpdateContext telegramContext,
-        Exception exception)
-    {
-        if (handler.ExceptionType is not null &&
-            !handler.ExceptionType.IsAssignableFrom(exception.GetType()))
-        {
-            return false;
-        }
-
-        if (handler.TelegramContextType is not null &&
-            !handler.TelegramContextType.IsInstanceOfType(telegramContext))
-        {
-            return false;
-        }
-
-        if (!HasCompatibleRouteValues(handler, routeValues))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    /// Checks all route-value parameters required by an error handler.
-    /// </summary>
-    private static bool HasCompatibleRouteValues(
-        TelegramErrorHandlerDescriptor handler,
-        IReadOnlyDictionary<string, object?> routeValues)
-    {
-        foreach (var parameter in handler.Parameters)
-        {
-            if (parameter.Kind != TelegramErrorHandlerParameterKind.RouteValue)
-            {
-                continue;
-            }
-
-            if (!HasCompatibleRouteValue(parameter, routeValues))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    /// Checks that one route-value parameter exists and can be assigned to the handler parameter type.
-    /// </summary>
-    private static bool HasCompatibleRouteValue(
-        TelegramErrorHandlerParameterDescriptor parameter,
-        IReadOnlyDictionary<string, object?> routeValues)
-    {
-        return TryGetRouteValue(parameter, routeValues, out var value) &&
-               IsRouteValueAssignable(parameter.ParameterType, value);
-    }
-
-    /// <summary>
-    /// Gets the route value for an error-handler parameter.
-    /// </summary>
-    private static bool TryGetRouteValue(
-        TelegramErrorHandlerParameterDescriptor parameter,
-        IReadOnlyDictionary<string, object?> routeValues,
-        out object? value)
-    {
-        value = null;
-
-        return !string.IsNullOrWhiteSpace(parameter.Name) &&
-               routeValues.TryGetValue(parameter.Name, out value);
-    }
-
-    /// <summary>
-    /// Checks whether a route value can be assigned to a handler parameter, including nullable value types.
-    /// </summary>
-    private static bool IsRouteValueAssignable(Type parameterType, object? value)
-    {
-        if (value is null)
-        {
-            return IsNullableRouteValue(parameterType);
-        }
-
-        var targetType = Nullable.GetUnderlyingType(parameterType) ?? parameterType;
-
-        return targetType.IsInstanceOfType(value);
-    }
-
-    /// <summary>
-    /// Checks whether a route-value parameter type can accept a null value.
-    /// </summary>
-    private static bool IsNullableRouteValue(Type parameterType)
-    {
-        return !parameterType.IsValueType ||
-               Nullable.GetUnderlyingType(parameterType) is not null;
-    }
-
-    /// <summary>
-    /// Computes how specific an error handler exception type is for the thrown exception type.
-    /// </summary>
-    private static int GetExceptionDistance(Type? handlerExceptionType, Type thrownExceptionType)
-    {
-        if (handlerExceptionType is null)
-        {
-            return int.MaxValue;
-        }
-
-        var distance = 0;
-        var current = thrownExceptionType;
-
-        while (current is not null)
-        {
-            if (current == handlerExceptionType)
-            {
-                return distance;
-            }
-
-            distance++;
-            current = current.BaseType;
-        }
-
-        return int.MaxValue - 1;
     }
 
     /// <summary>

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -420,12 +420,89 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task ErrorHandler_MoreSpecificExceptionRunsBeforeBroadException()
+    {
+        ThrowingMessageHandler.Exception = new SpecificErrorHandlerFailureException();
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+                services.AddTelegramHandler<BroadInvalidOperationErrorHandler>();
+                services.AddTelegramHandler<SpecificFailureErrorHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("boom"));
+
+        Assert.Equal(["specific-error:specific failure"], probe.Events);
+    }
+
+    [Fact]
+    public async Task ErrorHandler_RegistrationOrderBreaksSpecificityTies()
+    {
+        ThrowingMessageHandler.Exception = new InvalidOperationException("handler failed");
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+                services.AddTelegramHandler<FirstTieErrorHandler>();
+                services.AddTelegramHandler<SecondTieErrorHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("boom"));
+
+        Assert.Equal(["first-tie:handler failed", "second-tie:handler failed"], probe.Events);
+    }
+
+    [Fact]
+    public async Task ErrorHandler_CatchAllRunsAfterTypedHandlers()
+    {
+        ThrowingMessageHandler.Exception = new InvalidOperationException("handler failed");
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ThrowingMessageHandler>();
+                services.AddTelegramHandler<TypedUnhandledErrorHandler>();
+                services.AddTelegramHandler<CatchAllHandledErrorHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("boom"));
+
+        Assert.Equal(["typed-unhandled:handler failed", "catch-all:handler failed"], probe.Events);
+    }
+
+    [Fact]
     public async Task ErrorHandler_BindsContextExceptionRouteValuesServicesAndCancellationToken()
     {
         using var serviceProvider = CreateServiceProvider(
             services =>
             {
                 services.AddTelegramHandler<RouteValueThrowingHandler>();
+                services.AddTelegramHandler<RouteValueErrorHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/orders 77"));
+
+        Assert.Equal(
+            ["bound:77:RouteValueFailureException:Handle:RouteValueThrowingHandler:MessageContext:False"],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task ErrorHandler_SkipsIncompatibleRouteValueHandler()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<RouteValueThrowingHandler>();
+                services.AddTelegramHandler<IncompatibleRouteValueErrorHandler>();
                 services.AddTelegramHandler<RouteValueErrorHandler>();
             });
 
@@ -4248,6 +4325,74 @@ public sealed class TelegramHandlerDispatcherTests
         }
     }
 
+    public sealed class SpecificErrorHandlerFailureException : InvalidOperationException
+    {
+        public SpecificErrorHandlerFailureException()
+            : base("specific failure")
+        {
+        }
+    }
+
+    public sealed class BroadInvalidOperationErrorHandler
+    {
+        [Error<InvalidOperationException>]
+        public TelegramErrorHandlingResult Handle(InvalidOperationException exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"broad-error:{exception.Message}");
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
+    public sealed class SpecificFailureErrorHandler
+    {
+        [Error<SpecificErrorHandlerFailureException>]
+        public TelegramErrorHandlingResult Handle(SpecificErrorHandlerFailureException exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"specific-error:{exception.Message}");
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
+    public sealed class FirstTieErrorHandler
+    {
+        [Error<InvalidOperationException>]
+        public TelegramErrorHandlingResult Handle(InvalidOperationException exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"first-tie:{exception.Message}");
+            return TelegramErrorHandlingResult.Unhandled;
+        }
+    }
+
+    public sealed class SecondTieErrorHandler
+    {
+        [Error<InvalidOperationException>]
+        public TelegramErrorHandlingResult Handle(InvalidOperationException exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"second-tie:{exception.Message}");
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
+    public sealed class TypedUnhandledErrorHandler
+    {
+        [Error<InvalidOperationException>]
+        public TelegramErrorHandlingResult Handle(InvalidOperationException exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"typed-unhandled:{exception.Message}");
+            return TelegramErrorHandlingResult.Unhandled;
+        }
+    }
+
+    public sealed class CatchAllHandledErrorHandler
+    {
+        [Error]
+        public TelegramErrorHandlingResult Handle(Exception exception, HandlerProbe probe)
+        {
+            probe.Events.Add($"catch-all:{exception.Message}");
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
     public sealed class RouteValueFailureException : InvalidOperationException
     {
         public RouteValueFailureException()
@@ -4278,6 +4423,19 @@ public sealed class TelegramHandlerDispatcherTests
         {
             probe.Events.Add(
                 $"bound:{orderId}:{exception.GetType().Name}:{error.HandlerMethodName}:{error.HandlerType.Name}:{context.GetType().Name}:{cancellationToken.IsCancellationRequested}");
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
+    public sealed class IncompatibleRouteValueErrorHandler
+    {
+        [Error<RouteValueFailureException>]
+        public TelegramErrorHandlingResult Handle(
+            RouteValueFailureException exception,
+            string orderId,
+            HandlerProbe probe)
+        {
+            probe.Events.Add($"incompatible:{orderId}:{exception.Message}");
             return TelegramErrorHandlingResult.Handled;
         }
     }


### PR DESCRIPTION
## Summary

Closes #60.

Pre-indexes Telegram error handlers so exception-path dispatch does not rebuild module/global candidate groups and sort compatible handlers for every handler failure.

The dispatcher now owns a `TelegramErrorHandlerIndex` built once during construction. The index keeps module-scoped handlers separate from global handlers, groups typed handlers by exact exception type, and keeps catch-all handlers in registration order.

## Touched Hot Paths

- `TelegramHandlerDispatcher.TryHandleErrorAsync` no longer calls per-exception LINQ filtering and sorting for error-handler candidates.
- Normal successful dispatch behavior is unchanged.
- Exception dispatch still preserves existing semantics:
  - module-scoped handlers run before global handlers;
  - more specific exception handlers run before broader handlers;
  - registration order breaks specificity ties;
  - catch-all handlers run after typed handlers;
  - incompatible route-value handlers are skipped;
  - unhandled results continue to the next compatible handler.

## Tests

- Added regression coverage for exception specificity, registration-order ties, catch-all ordering, and incompatible route-value handlers.
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~ErrorHandler_ModuleCandidateRunsBeforeGlobalCandidate|FullyQualifiedName~ErrorHandler_MoreSpecificExceptionRunsBeforeBroadException|FullyQualifiedName~ErrorHandler_RegistrationOrderBreaksSpecificityTies|FullyQualifiedName~ErrorHandler_CatchAllRunsAfterTypedHandlers|FullyQualifiedName~ErrorHandler_BindsContextExceptionRouteValuesServicesAndCancellationToken|FullyQualifiedName~ErrorHandler_SkipsIncompatibleRouteValueHandler|FullyQualifiedName~ErrorHandler_UnhandledResultRethrowsOriginalException" --no-restore --logger "console;verbosity=minimal"`
- `dotnet build TeleFlow.sln -c Release --no-restore /nodeReuse:false`
- `dotnet test TeleFlow.sln -c Release --no-build --no-restore /nodeReuse:false --logger "console;verbosity=minimal"`
