### PR TITLE
perf(framework): reduce handler selection allocations

### DIFF
--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramFilterEvaluator.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramFilterEvaluator.cs
@@ -13,17 +13,31 @@ internal static class TelegramFilterEvaluator
         IReadOnlyList<TelegramRoleRequirementDescriptor> roleRequirements,
         CancellationToken cancellationToken)
     {
-        foreach (var filter in filters.Where(static filter => filter.CustomFilterType is null))
+        for (var index = 0; index < filters.Count; index++)
         {
+            var filter = filters[index];
+
+            if (filter.CustomFilterType is not null)
+            {
+                continue;
+            }
+
             if (!MatchesBuiltInFilter(context, filter))
             {
                 return false;
             }
         }
 
-        foreach (var filter in filters.Where(static filter => filter.CustomFilterType is not null))
+        for (var index = 0; index < filters.Count; index++)
         {
-            if (!await MatchesCustomFilterAsync(context, filter.CustomFilterType!, cancellationToken).ConfigureAwait(false))
+            var filterType = filters[index].CustomFilterType;
+
+            if (filterType is null)
+            {
+                continue;
+            }
+
+            if (!await MatchesCustomFilterAsync(context, filterType, cancellationToken).ConfigureAwait(false))
             {
                 return false;
             }
@@ -54,19 +68,25 @@ internal static class TelegramFilterEvaluator
         return filter.Kind switch
         {
             TelegramFilterKind.ChatType => facts.Chat is not null &&
-                                           filter.StringValues.Contains(facts.Chat.Type, StringComparer.Ordinal),
+                                           ContainsString(
+                                               filter.StringValues,
+                                               facts.Chat.Type,
+                                               StringComparison.Ordinal),
             TelegramFilterKind.ChatId => facts.Chat is not null &&
-                                         filter.LongValues.Contains(facts.Chat.Id),
+                                         ContainsLong(filter.LongValues, facts.Chat.Id),
             TelegramFilterKind.ChatUsername => facts.Chat?.Username is { } username &&
-                                               filter.StringValues.Contains(username, StringComparer.OrdinalIgnoreCase),
+                                               ContainsString(
+                                                   filter.StringValues,
+                                                   username,
+                                                   StringComparison.OrdinalIgnoreCase),
             TelegramFilterKind.MessageThreadId => facts.MessageThreadId is { } messageThreadId &&
-                                                  filter.LongValues.Contains(messageThreadId),
+                                                  ContainsLong(filter.LongValues, messageThreadId),
             TelegramFilterKind.HasMessageThread => facts.MessageThreadId is not null,
             TelegramFilterKind.HasCallbackData => context is CallbackQueryContext callbackContext &&
                                                   !string.IsNullOrWhiteSpace(callbackContext.TelegramCallbackQuery.Data),
             TelegramFilterKind.CallbackDataPrefix => context is CallbackQueryContext callbackContext &&
                                                      callbackContext.TelegramCallbackQuery.Data is { } data &&
-                                                     filter.StringValues.Any(prefix => data.StartsWith(prefix, StringComparison.Ordinal)),
+                                                     StartsWithAnyPrefix(data, filter.StringValues),
             _ => context is MessageContext messageContext &&
                  MatchesMessageBuiltInFilter(messageContext.TelegramMessage, filter)
         };
@@ -78,7 +98,7 @@ internal static class TelegramFilterEvaluator
     {
         return filter.Kind switch
         {
-            TelegramFilterKind.FromUser => message.From is not null && filter.LongValues.Contains(message.From.Id),
+            TelegramFilterKind.FromUser => message.From is not null && ContainsLong(filter.LongValues, message.From.Id),
             TelegramFilterKind.HasText => !string.IsNullOrWhiteSpace(message.Text),
             TelegramFilterKind.HasPhoto => message.Photo is { Count: > 0 },
             TelegramFilterKind.HasDocument => message.Document is not null,
@@ -220,6 +240,52 @@ internal static class TelegramFilterEvaluator
         return filter.StringValues.Count > 0
             ? filter.StringValues[0]
             : null;
+    }
+
+    private static bool ContainsString(
+        IReadOnlyList<string> values,
+        string value,
+        StringComparison comparison)
+    {
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (string.Equals(values[index], value, comparison))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsLong(
+        IReadOnlyList<long> values,
+        long value)
+    {
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (values[index] == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithAnyPrefix(
+        string value,
+        IReadOnlyList<string> prefixes)
+    {
+        for (var index = 0; index < prefixes.Count; index++)
+        {
+            if (value.StartsWith(prefixes[index], StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static ValueTask<TelegramMemberStatusSet?> ResolveUncachedStatusAsync(

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -55,8 +55,177 @@ internal sealed class TelegramHandlerSelector
         string? currentState,
         CancellationToken cancellationToken)
     {
-        foreach (var handler in PrioritizeCallbackHandlers(_table.CallbackHandlers, currentState))
+        if (HasCurrentState(currentState))
         {
+            var statefulPayloadSelection = await SelectCallbackHandlerPassAsync(
+                context,
+                _table.CallbackHandlers,
+                currentState,
+                requireCurrentState: true,
+                requireCallbackPayload: true,
+                cancellationToken).ConfigureAwait(false);
+
+            if (statefulPayloadSelection is not null)
+            {
+                return statefulPayloadSelection;
+            }
+
+            var statefulRawSelection = await SelectCallbackHandlerPassAsync(
+                context,
+                _table.CallbackHandlers,
+                currentState,
+                requireCurrentState: true,
+                requireCallbackPayload: false,
+                cancellationToken).ConfigureAwait(false);
+
+            if (statefulRawSelection is not null)
+            {
+                return statefulRawSelection;
+            }
+        }
+
+        var statelessPayloadSelection = await SelectCallbackHandlerPassAsync(
+            context,
+            _table.CallbackHandlers,
+            currentState: null,
+            requireCurrentState: false,
+            requireCallbackPayload: true,
+            cancellationToken).ConfigureAwait(false);
+
+        if (statelessPayloadSelection is not null)
+        {
+            return statelessPayloadSelection;
+        }
+
+        return await SelectCallbackHandlerPassAsync(
+            context,
+            _table.CallbackHandlers,
+            currentState: null,
+            requireCurrentState: false,
+            requireCallbackPayload: false,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerAsync(
+        ChatMemberUpdatedContext context,
+        TelegramRouteKind updateRouteKind,
+        string? currentState,
+        CancellationToken cancellationToken)
+    {
+        if (HasCurrentState(currentState))
+        {
+            var statefulSelection = await SelectChatMemberHandlerPassAsync(
+                context,
+                _table.ChatMemberHandlers,
+                updateRouteKind,
+                currentState,
+                requireCurrentState: true,
+                cancellationToken).ConfigureAwait(false);
+
+            if (statefulSelection is not null)
+            {
+                return statefulSelection;
+            }
+        }
+
+        return await SelectChatMemberHandlerPassAsync(
+            context,
+            _table.ChatMemberHandlers,
+            updateRouteKind,
+            currentState: null,
+            requireCurrentState: false,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
+        MessageContext context,
+        IReadOnlyList<TelegramHandlerDescriptor> handlers,
+        string? currentState,
+        CancellationToken cancellationToken)
+    {
+        if (HasCurrentState(currentState))
+        {
+            var statefulSelection = await SelectMessageHandlerPassAsync(
+                context,
+                handlers,
+                currentState,
+                requireCurrentState: true,
+                cancellationToken).ConfigureAwait(false);
+
+            if (statefulSelection is not null)
+            {
+                return statefulSelection;
+            }
+        }
+
+        return await SelectMessageHandlerPassAsync(
+            context,
+            handlers,
+            currentState: null,
+            requireCurrentState: false,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerPassAsync(
+        MessageContext context,
+        IReadOnlyList<TelegramHandlerDescriptor> handlers,
+        string? currentState,
+        bool requireCurrentState,
+        CancellationToken cancellationToken)
+    {
+        for (var index = 0; index < handlers.Count; index++)
+        {
+            var handler = handlers[index];
+
+            if (!MatchesStatePass(handler, currentState, requireCurrentState))
+            {
+                continue;
+            }
+
+            var route = handler.Route;
+
+            if (!TryMatchRoute(context.TelegramMessage, route, out var routeValues))
+            {
+                continue;
+            }
+
+            if (!await TelegramFilterEvaluator.MatchesAsync(
+                    context,
+                    route.Filters,
+                    route.RoleRequirements,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            return new TelegramRouteSelection(handler, route, routeValues, callbackPayload: null);
+        }
+
+        return null;
+    }
+
+    private static async ValueTask<TelegramRouteSelection?> SelectCallbackHandlerPassAsync(
+        CallbackQueryContext context,
+        IReadOnlyList<TelegramHandlerDescriptor> handlers,
+        string? currentState,
+        bool requireCurrentState,
+        bool requireCallbackPayload,
+        CancellationToken cancellationToken)
+    {
+        for (var index = 0; index < handlers.Count; index++)
+        {
+            var handler = handlers[index];
+
+            if ((handler.CallbackPayloadType is not null) != requireCallbackPayload)
+            {
+                continue;
+            }
+
+            if (!MatchesStatePass(handler, currentState, requireCurrentState))
+            {
+                continue;
+            }
+
             var route = handler.Route;
 
             if (route.CallbackPayloadType is null)
@@ -78,35 +247,46 @@ internal sealed class TelegramHandlerSelector
                 continue;
             }
 
-            if (TryDeserializeCallbackPayload(
+            if (!TryDeserializeCallbackPayload(
                     context,
                     route.CallbackPayloadType,
                     out var callbackPayload))
             {
-                if (!await TelegramFilterEvaluator.MatchesAsync(
-                        context,
-                        route.Filters,
-                        route.RoleRequirements,
-                        cancellationToken).ConfigureAwait(false))
-                {
-                    continue;
-                }
-
-                return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload);
+                continue;
             }
+
+            if (!await TelegramFilterEvaluator.MatchesAsync(
+                    context,
+                    route.Filters,
+                    route.RoleRequirements,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload);
         }
 
         return null;
     }
 
-    public async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerAsync(
+    private static async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerPassAsync(
         ChatMemberUpdatedContext context,
+        IReadOnlyList<TelegramHandlerDescriptor> handlers,
         TelegramRouteKind updateRouteKind,
         string? currentState,
+        bool requireCurrentState,
         CancellationToken cancellationToken)
     {
-        foreach (var handler in PrioritizeHandlersByState(_table.ChatMemberHandlers, currentState))
+        for (var index = 0; index < handlers.Count; index++)
         {
+            var handler = handlers[index];
+
+            if (!MatchesStatePass(handler, currentState, requireCurrentState))
+            {
+                continue;
+            }
+
             var route = handler.Route;
 
             if (route.RouteKind != updateRouteKind)
@@ -129,36 +309,6 @@ internal sealed class TelegramHandlerSelector
             }
 
             return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload: null);
-        }
-
-        return null;
-    }
-
-    private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
-        MessageContext context,
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
-        string? currentState,
-        CancellationToken cancellationToken)
-    {
-        foreach (var handler in PrioritizeHandlersByState(handlers, currentState))
-        {
-            var route = handler.Route;
-
-            if (!TryMatchRoute(context.TelegramMessage, route, out var routeValues))
-            {
-                continue;
-            }
-
-            if (!await TelegramFilterEvaluator.MatchesAsync(
-                    context,
-                    route.Filters,
-                    route.RoleRequirements,
-                    cancellationToken).ConfigureAwait(false))
-            {
-                continue;
-            }
-
-            return new TelegramRouteSelection(handler, route, routeValues, callbackPayload: null);
         }
 
         return null;
@@ -187,73 +337,37 @@ internal sealed class TelegramHandlerSelector
         };
     }
 
-    private static IEnumerable<TelegramHandlerDescriptor> PrioritizeHandlersByState(
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
-        string? currentState)
+    private static bool HasCurrentState(string? currentState)
     {
-        if (!string.IsNullOrWhiteSpace(currentState))
-        {
-            foreach (var handler in handlers)
-            {
-                if (MatchesState(handler, currentState))
-                {
-                    yield return handler;
-                }
-            }
-        }
-
-        foreach (var handler in handlers)
-        {
-            if (handler.States.Count == 0)
-            {
-                yield return handler;
-            }
-        }
+        return !string.IsNullOrWhiteSpace(currentState);
     }
 
-    private static IEnumerable<TelegramHandlerDescriptor> PrioritizeCallbackHandlers(
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
-        string? currentState)
+    private static bool MatchesStatePass(
+        TelegramHandlerDescriptor handler,
+        string? currentState,
+        bool requireCurrentState)
     {
-        if (!string.IsNullOrWhiteSpace(currentState))
+        if (!requireCurrentState)
         {
-            foreach (var handler in handlers)
-            {
-                if (handler.CallbackPayloadType is not null && MatchesState(handler, currentState))
-                {
-                    yield return handler;
-                }
-            }
-
-            foreach (var handler in handlers)
-            {
-                if (handler.CallbackPayloadType is null && MatchesState(handler, currentState))
-                {
-                    yield return handler;
-                }
-            }
+            return handler.States.Count == 0;
         }
 
-        foreach (var handler in handlers)
-        {
-            if (handler.CallbackPayloadType is not null && handler.States.Count == 0)
-            {
-                yield return handler;
-            }
-        }
-
-        foreach (var handler in handlers)
-        {
-            if (handler.CallbackPayloadType is null && handler.States.Count == 0)
-            {
-                yield return handler;
-            }
-        }
+        return currentState is not null && MatchesState(handler, currentState);
     }
 
     private static bool MatchesState(TelegramHandlerDescriptor handler, string currentState)
     {
-        return handler.States.Any(state => string.Equals(state, currentState, StringComparison.Ordinal));
+        var states = handler.States;
+
+        for (var index = 0; index < states.Count; index++)
+        {
+            if (string.Equals(states[index], currentState, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool TryDeserializeCallbackPayload(
@@ -501,8 +615,17 @@ internal sealed class TelegramHandlerSelector
 
     private static bool MatchesTextFilters(Message message, TelegramRouteDescriptor route)
     {
-        return route.TextFilters.Count == 0 ||
-               route.TextFilters.All(filter => filter.Matches(message.Text));
+        var textFilters = route.TextFilters;
+
+        for (var index = 0; index < textFilters.Count; index++)
+        {
+            if (!textFilters[index].Matches(message.Text))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool MatchesChatMemberTransition(
@@ -516,10 +639,20 @@ internal sealed class TelegramHandlerSelector
 
         var oldStatus = TelegramChatMemberClassifier.GetStatus(context.OldChatMember);
         var newStatus = TelegramChatMemberClassifier.GetStatus(context.NewChatMember);
+        var transitions = route.ChatMemberTransitions;
 
-        return route.ChatMemberTransitions.Any(transition =>
-            (transition.OldStatus & oldStatus) != 0 &&
-            (transition.NewStatus & newStatus) != 0);
+        for (var index = 0; index < transitions.Count; index++)
+        {
+            var transition = transitions[index];
+
+            if ((transition.OldStatus & oldStatus) != 0 &&
+                (transition.NewStatus & newStatus) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private delegate object? CallbackPayloadDeserializer(ICallbackDataSerializer serializer, string data);

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -1455,6 +1455,23 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task BuiltInFilterNoMatch_DoesNotResolveCustomFilter()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<BuiltInFilterBeforeCustomFilterHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("custom"));
+
+        Assert.Equal(["message:custom"], probe.Events);
+    }
+
+    [Fact]
     public async Task TypedCallbackPayloadMismatch_DoesNotRunCustomFilter()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -3885,6 +3902,18 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(CallbackQueryContext context, HandlerProbe probe)
         {
             probe.Events.Add($"custom-callback:{context.TelegramCallbackQuery.Data}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class BuiltInFilterBeforeCustomFilterHandler
+    {
+        [Message]
+        [ChatId(999)]
+        [UseFilter<ThrowingMessageFilter>]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"built-in-before-custom:{context.TelegramMessage.Text}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary

- Removes iterator and LINQ allocations from Telegram handler selection hot paths.
- Keeps current command/message/chat-member state fallback behavior unchanged.
- Keeps callback priority unchanged: stateful typed, stateful raw, stateless typed, stateless raw.
- Removes LINQ-based built-in/custom filter splitting from per-update filter evaluation.
- Adds regression coverage that built-in filter no-match does not resolve or run custom filters.

## Touched hot paths

- `TelegramHandlerSelector`: handler candidate passes now use direct indexed loops instead of iterator methods.
- `TelegramFilterEvaluator`: built-in filters, custom filters, and small value checks now use direct loops.
- Route matching, callback payload serialization, role resolution, and public APIs are intentionally unchanged.

## Verification

- `dotnet test TeleFlow.sln --no-restore`
- `dotnet build TeleFlow.sln -c Release --no-restore`
- `dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*TeleFlowDispatchBenchmarks*" --job Dry`
- `git diff --check`

Closes #55
