### PR TITLE
perf(core): lazy-create state wrappers

### DIFF
--- a/src/TeleFlow.Core/States/UpdateState.cs
+++ b/src/TeleFlow.Core/States/UpdateState.cs
@@ -3,8 +3,11 @@ namespace TeleFlow.Core.States;
 public sealed class UpdateState
 {
     private readonly IStateStore _stateStore;
-    private readonly UpdateStateData? _data;
-    private readonly UpdateWizard? _wizard;
+    private readonly IStateDataStore? _dataStore;
+    private readonly IStateDataSerializer? _dataSerializer;
+    private readonly IStateHistoryStore? _historyStore;
+    private UpdateStateData? _data;
+    private UpdateWizard? _wizard;
     private string? _currentState;
     private bool _isHydrated;
 
@@ -18,17 +21,10 @@ public sealed class UpdateState
         ArgumentNullException.ThrowIfNull(stateStore);
 
         _stateStore = stateStore;
+        _dataStore = dataStore;
+        _dataSerializer = dataSerializer;
+        _historyStore = historyStore;
         Key = key;
-
-        if (dataStore is not null && dataSerializer is not null)
-        {
-            _data = new UpdateStateData(dataStore, dataSerializer, key);
-        }
-
-        if (historyStore is not null)
-        {
-            _wizard = new UpdateWizard(this, historyStore);
-        }
     }
 
     public StateKey Key { get; }
@@ -47,13 +43,45 @@ public sealed class UpdateState
         }
     }
 
-    public UpdateStateData Data => _data ??
-        throw new InvalidOperationException(
-            "State data is not available for the current update. Register state data storage and serializer before using ctx.State.Data.");
+    public UpdateStateData Data
+    {
+        get
+        {
+            if (_data is not null)
+            {
+                return _data;
+            }
 
-    public UpdateWizard Wizard => _wizard ??
-        throw new InvalidOperationException(
-            "Wizard is not available for the current update. Register state history storage before using ctx.State.Wizard.");
+            if (_dataStore is null || _dataSerializer is null)
+            {
+                throw new InvalidOperationException(
+                    "State data is not available for the current update. Register state data storage and serializer before using ctx.State.Data.");
+            }
+
+            _data = new UpdateStateData(_dataStore, _dataSerializer, Key);
+            return _data;
+        }
+    }
+
+    public UpdateWizard Wizard
+    {
+        get
+        {
+            if (_wizard is not null)
+            {
+                return _wizard;
+            }
+
+            if (_historyStore is null)
+            {
+                throw new InvalidOperationException(
+                    "Wizard is not available for the current update. Register state history storage before using ctx.State.Wizard.");
+            }
+
+            _wizard = new UpdateWizard(this, _historyStore);
+            return _wizard;
+        }
+    }
 
     public async ValueTask<string?> GetAsync(CancellationToken cancellationToken = default)
     {

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TeleFlow.Annotations;
@@ -62,6 +63,30 @@ public sealed class StageSixStateAndMiddlewareTests
 
         Assert.Null(await state.GetAsync());
         Assert.Null(await state.Data.GetAsync<string>("name"));
+    }
+
+    [Fact]
+    public void UpdateState_Data_IsCreatedLazilyOnFirstAccess()
+    {
+        var state = CreateUpdateStateWithData();
+
+        Assert.Null(GetUpdateStateField<UpdateStateData>(state, "_data"));
+
+        var data = state.Data;
+
+        Assert.Same(data, GetUpdateStateField<UpdateStateData>(state, "_data"));
+    }
+
+    [Fact]
+    public void UpdateState_Wizard_IsCreatedLazilyOnFirstAccess()
+    {
+        var state = CreateUpdateStateWithWizard();
+
+        Assert.Null(GetUpdateStateField<UpdateWizard>(state, "_wizard"));
+
+        var wizard = state.Wizard;
+
+        Assert.Same(wizard, GetUpdateStateField<UpdateWizard>(state, "_wizard"));
     }
 
     [Fact]
@@ -921,6 +946,23 @@ public sealed class StageSixStateAndMiddlewareTests
             new MemoryStateDataStore(),
             new JsonStateDataSerializer(),
             new MemoryStateHistoryStore());
+    }
+
+    private static T? GetUpdateStateField<T>(
+        UpdateState state,
+        string fieldName)
+        where T : class
+    {
+        var field = typeof(UpdateState).GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (field is null)
+        {
+            throw new InvalidOperationException($"UpdateState field '{fieldName}' was not found.");
+        }
+
+        return (T?)field.GetValue(state);
     }
 
     private static StateKey CreateStateKey(


### PR DESCRIPTION
## Summary

- Lazily creates `UpdateStateData` only when `UpdateState.Data` is accessed.
- Lazily creates `UpdateWizard` only when `UpdateState.Wizard` is accessed.
- Preserves existing missing-storage failure messages and public API shape.
- Adds focused regression coverage for lazy wrapper creation.

## Touched hot paths

- `UpdateState`: avoids allocating state data and wizard wrapper objects for updates that do not use them.
- `UpdateStateMiddleware` behavior is unchanged; optional stores are still resolved once per state-capable update.

## Verification

- `dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~StageSixStateAndMiddlewareTests" --no-restore`
- `dotnet test TeleFlow.sln --no-restore`
- `dotnet build TeleFlow.sln -c Release --no-restore`
- `dotnet run -c Release --project benchmarks/TeleFlow.Benchmarks/TeleFlow.Benchmarks.csproj -- --filter "*TeleFlowDispatchBenchmarks*" --job Dry`
- `git diff --check`

Closes #53
