### PR TITLE
perf: cache compact callback metadata

### DIFF
--- a/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using TeleFlow.Annotations;
@@ -6,6 +7,8 @@ namespace TeleFlow.Telegram.Internal;
 
 internal sealed class CallbackDataMetadata
 {
+    private static readonly ConcurrentDictionary<Type, Lazy<MetadataLookup>> MetadataCache = new();
+
     private CallbackDataMetadata(
         Type payloadType,
         string prefix,
@@ -30,15 +33,43 @@ internal sealed class CallbackDataMetadata
     {
         ArgumentNullException.ThrowIfNull(payloadType);
 
-        var attribute = payloadType.GetCustomAttribute<CallbackDataAttribute>(inherit: false);
-        if (attribute is null)
+        var lookup = MetadataCache.GetOrAdd(
+            payloadType,
+            static type => new Lazy<MetadataLookup>(
+                () => CreateLookup(type),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+
+        if (lookup.ErrorMessage is not null)
+        {
+            throw new InvalidOperationException(lookup.ErrorMessage);
+        }
+
+        if (lookup.Metadata is null)
         {
             metadata = null!;
             return false;
         }
 
-        metadata = Create(payloadType, attribute.Prefix);
+        metadata = lookup.Metadata;
         return true;
+    }
+
+    private static MetadataLookup CreateLookup(Type payloadType)
+    {
+        var attribute = payloadType.GetCustomAttribute<CallbackDataAttribute>(inherit: false);
+        if (attribute is null)
+        {
+            return MetadataLookup.Missing;
+        }
+
+        try
+        {
+            return MetadataLookup.Valid(Create(payloadType, attribute.Prefix));
+        }
+        catch (InvalidOperationException exception)
+        {
+            return MetadataLookup.Invalid(exception.Message);
+        }
     }
 
     private static CallbackDataMetadata Create(Type payloadType, string prefix)
@@ -213,6 +244,33 @@ internal sealed class CallbackDataMetadata
         return value
             .Replace("%3A", ":", StringComparison.Ordinal)
             .Replace("%25", "%", StringComparison.Ordinal);
+    }
+
+    private sealed class MetadataLookup
+    {
+        public static readonly MetadataLookup Missing = new(metadata: null, errorMessage: null);
+
+        private MetadataLookup(
+            CallbackDataMetadata? metadata,
+            string? errorMessage)
+        {
+            Metadata = metadata;
+            ErrorMessage = errorMessage;
+        }
+
+        public CallbackDataMetadata? Metadata { get; }
+
+        public string? ErrorMessage { get; }
+
+        public static MetadataLookup Valid(CallbackDataMetadata metadata)
+        {
+            return new MetadataLookup(metadata, errorMessage: null);
+        }
+
+        public static MetadataLookup Invalid(string errorMessage)
+        {
+            return new MetadataLookup(metadata: null, errorMessage);
+        }
     }
 }
 

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -11,6 +11,7 @@ using TeleFlow.Core.States;
 using TeleFlow.Core.Updates;
 using TeleFlow.Storage.Memory;
 using TeleFlow.Telegram;
+using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Methods;
 using TeleFlow.Telegram.Schema.Types;
 
@@ -2471,6 +2472,43 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public void CallbackDataMetadata_TryCreate_CachesCompactPayloadMetadata()
+    {
+        Assert.True(CallbackDataMetadata.TryCreate(typeof(CompactDeleteCallback), out var first));
+        Assert.True(CallbackDataMetadata.TryCreate(typeof(CompactDeleteCallback), out var second));
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void CallbackDataMetadata_TryCreate_PreservesJsonFallbackForNonCompactPayloads()
+    {
+        using var serviceProvider = CreateServiceProvider(static _ => { });
+        var serializer = serviceProvider.GetRequiredService<ICallbackDataSerializer>();
+
+        Assert.False(CallbackDataMetadata.TryCreate(typeof(DeleteCallbackPayload), out _));
+        Assert.False(CallbackDataMetadata.TryCreate(typeof(DeleteCallbackPayload), out _));
+
+        var serialized = serializer.Serialize(new DeleteCallbackPayload(42));
+        var deserialized = serializer.Deserialize<DeleteCallbackPayload>(serialized);
+
+        Assert.Equal("""{"id":42}""", serialized);
+        Assert.Equal(42, deserialized.Id);
+    }
+
+    [Fact]
+    public void CallbackDataMetadata_TryCreate_PreservesInvalidPayloadDiagnostics()
+    {
+        var first = Assert.Throws<InvalidOperationException>(
+            () => CallbackDataMetadata.TryCreate(typeof(InvalidCompactCallback), out _));
+        var second = Assert.Throws<InvalidOperationException>(
+            () => CallbackDataMetadata.TryCreate(typeof(InvalidCompactCallback), out _));
+
+        Assert.Equal(first.Message, second.Message);
+        Assert.Contains("field 'Id' must not be nullable", first.Message);
+    }
+
+    [Fact]
     public async Task CustomCallbackSerializer_CanReplaceDefaultSerializer()
     {
         var customSerializer = new CustomCallbackDataSerializer();
@@ -4800,6 +4838,9 @@ public sealed class TelegramHandlerDispatcherTests
 
     [CallbackData("del")]
     public sealed record DuplicateCompactDeleteCallback(long Id);
+
+    [CallbackData("bad")]
+    public sealed record InvalidCompactCallback(int? Id);
 
     public sealed record LargeCallbackPayload(string Value);
 


### PR DESCRIPTION
## Summary
- cache compact callback metadata per payload type
- cache non-compact callback metadata misses so JSON fallback types avoid repeated reflection
- preserve deterministic invalid compact payload diagnostics

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "CallbackDataMetadata_TryCreate" --no-restore`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~TelegramHandlerDispatcherTests&FullyQualifiedName~Callback" --no-restore`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-restore`
- `dotnet format whitespace TeleFlow.sln --verify-no-changes --no-restore --verbosity minimal`
- `dotnet build src\TeleFlow.Telegram.Framework\TeleFlow.Telegram.Framework.csproj --no-restore`

Closes #49