### PR TITLE
ci: improve Telegram summary formatting

### DIFF
--- a/eng/send-telegram-announcement.ps1
+++ b/eng/send-telegram-announcement.ps1
@@ -370,14 +370,26 @@ function New-AnnouncementText {
     }
 
     if (-not [string]::IsNullOrWhiteSpace($summary)) {
-        $header += "`n`n<b>Summary</b>`n$(ConvertTo-HtmlText $summary)"
+        $header += "`n`n<b>Summary</b>"
+
+        $normalizedBody = if ([string]::IsNullOrWhiteSpace($normalizedBody)) {
+            $summary
+        }
+        else {
+            $summary + "`n`n" + $normalizedBody
+        }
     }
 
     if ([string]::IsNullOrWhiteSpace($normalizedBody)) {
         return @($header)
     }
 
-    $quotePrefix = "`n`n<blockquote expandable>"
+    $quotePrefix = if (-not [string]::IsNullOrWhiteSpace($summary)) {
+        "`n<blockquote expandable>"
+    }
+    else {
+        "`n`n<blockquote expandable>"
+    }
     $quoteSuffix = "</blockquote>"
     $availableBodyLength = $MaximumMessageLength - $header.Length - $quotePrefix.Length - $quoteSuffix.Length
 

--- a/eng/send-telegram-announcement.ps1
+++ b/eng/send-telegram-announcement.ps1
@@ -122,6 +122,22 @@ function Select-MarkdownSection {
     return $match.Groups[1].Value.Trim()
 }
 
+function Remove-MarkdownSection {
+    param(
+        [AllowEmptyString()][string] $Text,
+        [string] $Heading
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text) -or [string]::IsNullOrWhiteSpace($Heading)) {
+        return $Text
+    }
+
+    $escapedHeading = [System.Text.RegularExpressions.Regex]::Escape($Heading)
+    $pattern = "(?ms)^\s*#{1,6}\s+$escapedHeading\s*$\s*.*?(?=^\s*#{1,6}\s+\S|\z)"
+
+    return [System.Text.RegularExpressions.Regex]::Replace($Text, $pattern, "").Trim()
+}
+
 function ConvertTo-Announcement {
     param([object] $Payload)
 
@@ -317,17 +333,44 @@ function New-AnnouncementText {
     $header = New-AnnouncementHeaderText $Announcement
     $previewLength = Get-BodyPreviewLength $Announcement.Kind
     $normalizedBody = ([string] $Announcement.Body).Trim()
+    $summary = ""
 
-    if ($Announcement.Kind -eq "pull_request") {
-        $normalizedBody = Select-MarkdownSection `
+    if ($Announcement.Kind -eq "issue" -or $Announcement.Kind -eq "pull_request") {
+        $summary = Select-MarkdownSection `
             -Text $normalizedBody `
             -Heading "Summary"
+
+        $hasSummary = -not [string]::IsNullOrWhiteSpace($summary)
+        $summaryIsBody = [string]::Equals($summary, $normalizedBody, [StringComparison]::Ordinal)
+
+        if ($hasSummary -and -not $summaryIsBody) {
+            $normalizedBody = Remove-MarkdownSection `
+                -Text $normalizedBody `
+                -Heading "Summary"
+
+            if ($Announcement.Kind -eq "pull_request") {
+                $normalizedBody = ""
+            }
+        }
+        else {
+            $summary = ""
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($summary)) {
+        $summary = ConvertTo-PlainTextPreview `
+            -Text $summary `
+            -MaximumLength $previewLength
     }
 
     if ($previewLength -ge 0) {
         $normalizedBody = ConvertTo-PlainTextPreview `
             -Text $normalizedBody `
             -MaximumLength $previewLength
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($summary)) {
+        $header += "`n`n<b>Summary</b>`n$(ConvertTo-HtmlText $summary)"
     }
 
     if ([string]::IsNullOrWhiteSpace($normalizedBody)) {


### PR DESCRIPTION
## Summary
- render `## Summary` outside the expandable quote for issue and pull request announcements
- keep issue details after `Summary` inside an expandable quote
- keep pull request announcements concise by omitting validation/details sections when a summary exists

## Validation
- `pwsh -NoProfile -File .\eng\send-telegram-announcement.ps1 -Kind issue -Title "Epic: Test architecture refactor before 1.0" -Number "69" -State "opened" -Url "https://github.com/IWFTech/TeleFlow/issues/69" -Body "## Summary`nRefactor tests.`n`n## Current State`n- Mixed files." -Repository "IWFTech/TeleFlow" -DryRun`
- `pwsh -NoProfile -File .\eng\send-telegram-announcement.ps1 -Kind pull_request -Title "perf: cache compact callback metadata" -Number "68" -State "merged" -Url "https://github.com/IWFTech/TeleFlow/pull/68" -Body "## Summary`n- add cache`n`n## Validation`n- dotnet test" -Repository "IWFTech/TeleFlow" -DryRun`
- `pwsh -NoProfile -File .\eng\send-telegram-announcement.ps1 -Kind release -Title "TeleFlow 1.0.0-alpha.4" -Tag "v1.0.0-alpha.4" -Url "https://github.com/IWFTech/TeleFlow/releases/tag/v1.0.0-alpha.4" -Body "- Fix one`n- Fix two" -Repository "IWFTech/TeleFlow" -DryRun`
- `git diff --check`