### PR TITLE
perf(framework): avoid callback payload miss exceptions

### DIFF
--- a/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
@@ -232,6 +232,39 @@ internal sealed class CallbackDataMetadata
             $"Callback data payload type '{PayloadType.FullName}' has unsupported field type '{fieldType.FullName}'.");
     }
 
+    public bool MatchesSerializedPayload(string serializedPayload)
+    {
+        ArgumentNullException.ThrowIfNull(serializedPayload);
+
+        if (!serializedPayload.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (Fields.Count == 0)
+        {
+            return serializedPayload.Length == Prefix.Length;
+        }
+
+        if (serializedPayload.Length <= Prefix.Length ||
+            serializedPayload[Prefix.Length] != ':')
+        {
+            return false;
+        }
+
+        var separatorCount = 0;
+
+        for (var index = Prefix.Length; index < serializedPayload.Length; index++)
+        {
+            if (serializedPayload[index] == ':')
+            {
+                separatorCount++;
+            }
+        }
+
+        return separatorCount == Fields.Count;
+    }
+
     private static string Escape(string value)
     {
         return value

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -375,11 +375,26 @@ internal sealed class TelegramHandlerSelector
         Type payloadType,
         out object? payload)
     {
+        var data = context.TelegramCallbackQuery.Data!;
+
+        if (context.CallbackData is ICallbackDataRouteDeserializer routeDeserializer)
+        {
+            try
+            {
+                return routeDeserializer.TryDeserializeForRoute(payloadType, data, out payload);
+            }
+            catch (Exception exception) when (IsCallbackPayloadNoMatchException(exception))
+            {
+                payload = null;
+                return false;
+            }
+        }
+
         var deserializer = CallbackPayloadDeserializers.GetOrAdd(payloadType, CreateCallbackPayloadDeserializer);
 
         try
         {
-            payload = deserializer(context.CallbackData, context.TelegramCallbackQuery.Data!);
+            payload = deserializer(context.CallbackData, data);
             return true;
         }
         catch (Exception exception) when (IsCallbackPayloadNoMatchException(exception))

--- a/src/TeleFlow.Telegram.Framework/Internal/ICallbackDataRouteDeserializer.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/ICallbackDataRouteDeserializer.cs
@@ -1,0 +1,8 @@
+using TeleFlow.Core.Callbacks;
+
+namespace TeleFlow.Telegram.Internal;
+
+internal interface ICallbackDataRouteDeserializer : ICallbackDataSerializer
+{
+    bool TryDeserializeForRoute(Type payloadType, string serializedPayload, out object? payload);
+}

--- a/src/TeleFlow.Telegram.Framework/JsonCallbackDataSerializer.cs
+++ b/src/TeleFlow.Telegram.Framework/JsonCallbackDataSerializer.cs
@@ -5,7 +5,7 @@ using TeleFlow.Telegram.Internal;
 
 namespace TeleFlow.Telegram;
 
-public sealed class JsonCallbackDataSerializer : ICallbackDataSerializer
+public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
 {
     private const int MaxTelegramCallbackDataBytes = 64;
 
@@ -49,12 +49,42 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataSerializer
             ?? throw new JsonException("Telegram callback data deserialized to null.");
     }
 
+    bool ICallbackDataRouteDeserializer.TryDeserializeForRoute(
+        Type payloadType,
+        string serializedPayload,
+        out object? payload)
+    {
+        ArgumentNullException.ThrowIfNull(payloadType);
+        ArgumentNullException.ThrowIfNull(serializedPayload);
+
+        if (CallbackDataMetadata.TryCreate(payloadType, out var metadata))
+        {
+            if (!metadata.MatchesSerializedPayload(serializedPayload))
+            {
+                payload = null;
+                return false;
+            }
+
+            payload = DeserializeCompact(serializedPayload, metadata);
+            return true;
+        }
+
+        payload = DeserializeJson(payloadType, serializedPayload);
+        return true;
+    }
+
     private static string SerializeCompact<TPayload>(TPayload payload, CallbackDataMetadata metadata)
     {
         var values = metadata.Fields
             .Select(field => metadata.FormatField(field.Property.GetValue(payload), field.Property.PropertyType));
 
         return string.Join(':', values.Prepend(metadata.Prefix));
+    }
+
+    private object DeserializeJson(Type payloadType, string serializedPayload)
+    {
+        return JsonSerializer.Deserialize(serializedPayload, payloadType, _jsonSerializerOptions)
+            ?? throw new JsonException("Telegram callback data deserialized to null.");
     }
 
     private static object DeserializeCompact(string serializedPayload, CallbackDataMetadata metadata)

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2065,6 +2065,80 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task TypedCallbackRouteDeserializer_RejectedPayload_DoesNotBindPayload()
+    {
+        var serializer = new RouteDeserializingCallbackDataSerializer(canDeserialize: false);
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddSingleton<ICallbackDataSerializer>(serializer);
+                services.AddTelegramHandler<CompactCallbackHandler>();
+                services.AddTelegramHandler<RawCallbackHandler>();
+            });
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateCallbackUpdate("other:value"));
+
+        Assert.Equal(["callback:other:value"], probe.Events);
+        Assert.Equal(1, serializer.RouteDeserializeCalls);
+        Assert.Equal(0, serializer.PayloadBindingCalls);
+        Assert.Equal(0, serializer.PublicDeserializeCalls);
+    }
+
+    [Fact]
+    public async Task TypedCallbackRouteDeserializer_AcceptedPayload_BindsPayload()
+    {
+        var serializer = new RouteDeserializingCallbackDataSerializer(canDeserialize: true);
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddSingleton<ICallbackDataSerializer>(serializer);
+                services.AddTelegramHandler<CompactCallbackHandler>();
+                services.AddTelegramHandler<RawCallbackHandler>();
+            });
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateCallbackUpdate("del:item:9"));
+
+        Assert.Equal(["compact-callback:item:9"], probe.Events);
+        Assert.Equal(1, serializer.RouteDeserializeCalls);
+        Assert.Equal(1, serializer.PayloadBindingCalls);
+        Assert.Equal(0, serializer.PublicDeserializeCalls);
+    }
+
+    [Fact]
+    public void DefaultCallbackRouteDeserializer_RejectsCompactPayloadByPrefixAndShape()
+    {
+        using var serviceProvider = CreateServiceProvider(static _ => { });
+        var serializer = serviceProvider.GetRequiredService<ICallbackDataSerializer>();
+        var routeDeserializer = Assert.IsAssignableFrom<ICallbackDataRouteDeserializer>(serializer);
+
+        Assert.False(routeDeserializer.TryDeserializeForRoute(typeof(CompactDeleteCallback), "other:value", out _));
+        Assert.False(routeDeserializer.TryDeserializeForRoute(typeof(CompactDeleteCallback), "delete:x:7", out _));
+        Assert.False(routeDeserializer.TryDeserializeForRoute(typeof(CompactDeleteCallback), "del:x", out _));
+        Assert.False(routeDeserializer.TryDeserializeForRoute(typeof(CompactDeleteCallback), "del:x:7:extra", out _));
+
+        Assert.True(routeDeserializer.TryDeserializeForRoute(typeof(CompactDeleteCallback), "del:x:7", out var payload));
+        var callbackPayload = Assert.IsType<CompactDeleteCallback>(payload);
+
+        Assert.Equal("x", callbackPayload.Name);
+        Assert.Equal(7, callbackPayload.Id);
+    }
+
+    [Fact]
+    public void DefaultCallbackRouteDeserializer_PreservesJsonPayloadFallback()
+    {
+        using var serviceProvider = CreateServiceProvider(static _ => { });
+        var serializer = serviceProvider.GetRequiredService<ICallbackDataSerializer>();
+        var routeDeserializer = Assert.IsAssignableFrom<ICallbackDataRouteDeserializer>(serializer);
+
+        Assert.True(routeDeserializer.TryDeserializeForRoute(typeof(DeleteCallbackPayload), """{"id":42}""", out var payload));
+        var callbackPayload = Assert.IsType<DeleteCallbackPayload>(payload);
+
+        Assert.Equal(42, callbackPayload.Id);
+    }
+
+    [Fact]
     public void DuplicateCompactCallbackPrefixes_FailDuringDispatcherBuild()
     {
         var services = CreateBaseServices();
@@ -4879,6 +4953,43 @@ public sealed class TelegramHandlerDispatcherTests
             }
 
             throw new InvalidOperationException("Unexpected callback data.");
+        }
+    }
+
+    private sealed class RouteDeserializingCallbackDataSerializer(bool canDeserialize) : ICallbackDataRouteDeserializer
+    {
+        public int RouteDeserializeCalls { get; private set; }
+
+        public int PayloadBindingCalls { get; private set; }
+
+        public int PublicDeserializeCalls { get; private set; }
+
+        public bool TryDeserializeForRoute(Type payloadType, string serializedPayload, out object? payload)
+        {
+            RouteDeserializeCalls++;
+
+            if (!canDeserialize ||
+                payloadType != typeof(CompactDeleteCallback) ||
+                !string.Equals(serializedPayload, "del:item:9", StringComparison.Ordinal))
+            {
+                payload = null;
+                return false;
+            }
+
+            PayloadBindingCalls++;
+            payload = new CompactDeleteCallback("item", 9);
+            return true;
+        }
+
+        public string Serialize<TPayload>(TPayload payload)
+        {
+            throw new InvalidOperationException("Route deserializer test double is dispatch-only.");
+        }
+
+        public TPayload Deserialize<TPayload>(string serializedPayload)
+        {
+            PublicDeserializeCalls++;
+            throw new InvalidOperationException("Route deserializer should be used during handler selection.");
         }
     }
 


### PR DESCRIPTION
## Summary
- add an internal callback route deserializer for typed callback selection
- reject compact callback payloads by prefix and shape before binding the payload
- keep the public callback serializer API unchanged while preserving JSON fallback behavior

## Validation
- dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj --filter "CallbackRouteDeserializer"
- dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj
- dotnet build TeleFlow.sln
- git diff --check

Closes #48
