### PR TITLE
perf(framework): cache inline keyboard callback serializers

### DIFF
--- a/src/TeleFlow.Telegram.Framework/InlineKeyboard.cs
+++ b/src/TeleFlow.Telegram.Framework/InlineKeyboard.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using System.Text;
 using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram.Schema.Types;
@@ -7,6 +9,8 @@ namespace TeleFlow.Telegram;
 public sealed class InlineKeyboard
 {
     private const int MaxTelegramCallbackDataBytes = 64;
+
+    private static readonly ConcurrentDictionary<Type, CallbackPayloadSerializer> CallbackPayloadSerializers = new();
 
     private readonly List<List<InlineKeyboardButtonIntent>> _rows = [[]];
 
@@ -24,7 +28,17 @@ public sealed class InlineKeyboard
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
         ArgumentNullException.ThrowIfNull(payload);
 
-        CurrentRow.Add(new InlineKeyboardButtonIntent(text, Payload: payload, CallbackData: null, Url: null));
+        var payloadObject = (object)payload;
+        var payloadSerializer = CallbackPayloadSerializers.GetOrAdd(
+            payloadObject.GetType(),
+            CreateCallbackPayloadSerializer);
+
+        CurrentRow.Add(new InlineKeyboardButtonIntent(
+            Text: text,
+            Payload: payloadObject,
+            PayloadSerializer: payloadSerializer,
+            CallbackData: null,
+            Url: null));
         return this;
     }
 
@@ -34,7 +48,12 @@ public sealed class InlineKeyboard
         ArgumentException.ThrowIfNullOrWhiteSpace(callbackData);
         ValidateCallbackDataLength(callbackData);
 
-        CurrentRow.Add(new InlineKeyboardButtonIntent(text, Payload: null, callbackData, Url: null));
+        CurrentRow.Add(new InlineKeyboardButtonIntent(
+            Text: text,
+            Payload: null,
+            PayloadSerializer: null,
+            CallbackData: callbackData,
+            Url: null));
         return this;
     }
 
@@ -66,7 +85,12 @@ public sealed class InlineKeyboard
 
     private InlineKeyboard UrlCore(string text, string url)
     {
-        CurrentRow.Add(new InlineKeyboardButtonIntent(text, Payload: null, CallbackData: null, url));
+        CurrentRow.Add(new InlineKeyboardButtonIntent(
+            Text: text,
+            Payload: null,
+            PayloadSerializer: null,
+            CallbackData: null,
+            Url: url));
         return this;
     }
 
@@ -113,20 +137,34 @@ public sealed class InlineKeyboard
         }
     }
 
+    private static CallbackPayloadSerializer CreateCallbackPayloadSerializer(Type payloadType)
+    {
+        var serializeMethod = typeof(InlineKeyboard)
+            .GetMethod(nameof(SerializeCallbackPayload), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(payloadType);
+
+        return serializeMethod.CreateDelegate<CallbackPayloadSerializer>();
+    }
+
+    private static string SerializeCallbackPayload<TPayload>(
+        ICallbackDataSerializer callbackDataSerializer,
+        object payload)
+    {
+        return callbackDataSerializer.Serialize((TPayload)payload);
+    }
+
     private sealed record InlineKeyboardButtonIntent(
         string Text,
         object? Payload,
+        CallbackPayloadSerializer? PayloadSerializer,
         string? CallbackData,
         string? Url)
     {
         public InlineKeyboardButton ToButton(ICallbackDataSerializer callbackDataSerializer)
         {
-            if (Payload is not null)
+            if (Payload is not null && PayloadSerializer is not null)
             {
-                var serializeMethod = typeof(ICallbackDataSerializer)
-                    .GetMethod(nameof(ICallbackDataSerializer.Serialize))!
-                    .MakeGenericMethod(Payload.GetType());
-                var callbackData = (string)serializeMethod.Invoke(callbackDataSerializer, [Payload])!;
+                var callbackData = PayloadSerializer(callbackDataSerializer, Payload);
 
                 return new InlineKeyboardButton
                 {
@@ -156,4 +194,6 @@ public sealed class InlineKeyboard
             throw new InvalidOperationException("Inline keyboard button intent does not contain an action.");
         }
     }
+
+    private delegate string CallbackPayloadSerializer(ICallbackDataSerializer serializer, object payload);
 }

--- a/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
@@ -1,3 +1,5 @@
+using TeleFlow.Annotations;
+using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Types;
 
@@ -5,6 +7,52 @@ namespace TeleFlow.ArchitectureTests;
 
 public sealed class KeyboardBuilderTests
 {
+    [Fact]
+    public void InlineKeyboard_CreatesMarkupWithTypedStringAndUrlButtons()
+    {
+        var serializer = new TypeRecordingCallbackDataSerializer();
+        IInlineKeyboardCallback callback = new InlineKeyboardDeleteCallback(42);
+
+        var markup = InlineKeyboard.Create()
+            .Button("Delete", callback)
+            .Button("Raw", "raw:42")
+            .Row()
+            .Url("Open", "https://example.com")
+            .ToMarkup(serializer);
+
+        Assert.Equal(2, markup.InlineKeyboard.Count);
+        Assert.Equal("InlineKeyboardDeleteCallback:42", markup.InlineKeyboard[0][0].CallbackData);
+        Assert.Equal("raw:42", markup.InlineKeyboard[0][1].CallbackData);
+        Assert.Equal("https://example.com", markup.InlineKeyboard[1][0].Url);
+        Assert.Equal([typeof(InlineKeyboardDeleteCallback)], serializer.SerializedPayloadTypes);
+    }
+
+    [Fact]
+    public void InlineKeyboard_TypedCallbackButton_UsesRuntimePayloadType()
+    {
+        var serializer = new TypeRecordingCallbackDataSerializer();
+        object callback = new InlineKeyboardDeleteCallback(7);
+
+        var markup = InlineKeyboard.Create()
+            .Button("Delete", callback)
+            .ToMarkup(serializer);
+
+        Assert.Equal("InlineKeyboardDeleteCallback:7", markup.InlineKeyboard[0][0].CallbackData);
+        Assert.Equal([typeof(InlineKeyboardDeleteCallback)], serializer.SerializedPayloadTypes);
+    }
+
+    [Fact]
+    public void InlineKeyboard_TypedCallbackData_PreservesTelegramByteLimitValidation()
+    {
+        var serializer = new JsonCallbackDataSerializer(TelegramJsonOptions.CreateDefault());
+        var keyboard = InlineKeyboard.Create()
+            .Button("Large", new LargeInlineKeyboardCallback(new string('x', 80)));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.ToMarkup(serializer));
+
+        Assert.Contains("64 UTF-8 bytes", exception.Message);
+    }
+
     [Fact]
     public void ReplyKeyboard_CreatesMarkupWithRowsAndOptions()
     {
@@ -97,5 +145,34 @@ public sealed class KeyboardBuilderTests
 
         Assert.Contains("64", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("placeholder", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private interface IInlineKeyboardCallback
+    {
+        int Id { get; }
+    }
+
+    private sealed record InlineKeyboardDeleteCallback(int Id) : IInlineKeyboardCallback;
+
+    [CallbackData("large")]
+    private sealed record LargeInlineKeyboardCallback(string Value);
+
+    private sealed class TypeRecordingCallbackDataSerializer : ICallbackDataSerializer
+    {
+        public List<Type> SerializedPayloadTypes { get; } = [];
+
+        public string Serialize<TPayload>(TPayload payload)
+        {
+            SerializedPayloadTypes.Add(typeof(TPayload));
+
+            return payload is IInlineKeyboardCallback callback
+                ? $"{typeof(TPayload).Name}:{callback.Id}"
+                : typeof(TPayload).Name;
+        }
+
+        public TPayload Deserialize<TPayload>(string serializedPayload)
+        {
+            throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- cache typed inline keyboard callback serializers by runtime payload type
- render typed callback buttons through cached delegates instead of per-button reflection invocation
- preserve mixed typed/string/url button behavior and Telegram callback data byte-limit validation

## Validation
- dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~KeyboardBuilderTests"
- dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj
- dotnet build TeleFlow.sln
- git diff --check

Closes #50
