### PR TITLE
docs(schema): use generated keyboard style constants

### DIFF
--- a/docs/en/features/callbacks-and-keyboards.md
+++ b/docs/en/features/callbacks-and-keyboards.md
@@ -40,6 +40,9 @@ Typed payloads are better when callback data carries structured information:
 public sealed record TicketAction(long Id, string Action);
 ```
 
+Button style examples below use generated Bot API constants from
+`TeleFlow.Telegram.Schema.Constants`.
+
 Create buttons:
 
 ```csharp
@@ -50,11 +53,11 @@ public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
         .Button(
             "Take",
             new TicketAction(id, "take"),
-            new InlineKeyboardButtonOptions { Style = "primary" })
+            new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
         .Button(
             "Resolve",
             new TicketAction(id, "resolve"),
-            new InlineKeyboardButtonOptions { Style = "success" })
+            new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
         .Build();
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
@@ -156,7 +159,7 @@ var keyboard = new InlineKeyboardMarkup
             {
                 Text = "Delete",
                 CallbackData = "ticket:delete:42",
-                Style = "danger"
+                Style = ButtonStyles.Danger
             }
         ]
     ]
@@ -167,6 +170,8 @@ await ctx.Message.AnswerAsync("Choose:", keyboard, ct);
 
 Use the builder for common cases. Use native markup when you need full Bot API
 control or a newly added Telegram field that the builder does not wrap yet.
+If Telegram exposes a string value before the schema package has generated a
+constant for it, pass that raw string directly.
 
 ## Remove Keyboard
 

--- a/docs/en/tutorials/support-desk.md
+++ b/docs/en/tutorials/support-desk.md
@@ -35,6 +35,7 @@ using TeleFlow.Core.Application;
 using TeleFlow.Storage.Memory;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Constants;
 
 var token = Environment.GetEnvironmentVariable("TELEFLOW_BOT_TOKEN")
     ?? throw new InvalidOperationException("TELEFLOW_BOT_TOKEN is not set.");
@@ -342,11 +343,11 @@ public sealed class AdminTicketHandlers
             .Button(
                 "Take",
                 new TicketAction(ticket.Id, "take"),
-                new InlineKeyboardButtonOptions { Style = "primary" })
+                new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
             .Button(
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
-                new InlineKeyboardButtonOptions { Style = "success" })
+                new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
             .Build();
 
         await ctx.Message.AnswerAsync(

--- a/docs/ru/features/callbacks-and-keyboards.md
+++ b/docs/ru/features/callbacks-and-keyboards.md
@@ -40,6 +40,9 @@ Typed payloads лучше, когда callback data несёт structured inform
 public sealed record TicketAction(long Id, string Action);
 ```
 
+Примеры button style ниже используют generated Bot API constants из
+`TeleFlow.Telegram.Schema.Constants`.
+
 Создание buttons:
 
 ```csharp
@@ -50,11 +53,11 @@ public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
         .Button(
             "Take",
             new TicketAction(id, "take"),
-            new InlineKeyboardButtonOptions { Style = "primary" })
+            new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
         .Button(
             "Resolve",
             new TicketAction(id, "resolve"),
-            new InlineKeyboardButtonOptions { Style = "success" })
+            new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
         .Build();
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
@@ -156,7 +159,7 @@ var keyboard = new InlineKeyboardMarkup
             {
                 Text = "Delete",
                 CallbackData = "ticket:delete:42",
-                Style = "danger"
+                Style = ButtonStyles.Danger
             }
         ]
     ]
@@ -167,7 +170,9 @@ await ctx.Message.AnswerAsync("Choose:", keyboard, ct);
 
 Builder стоит использовать для обычных сценариев. Нативная markup нужна, когда
 требуется полный контроль Bot API или новое Telegram-поле, для которого builder
-ещё не успел получить удобный wrapper.
+ещё не успел получить удобный wrapper. Если Telegram добавил string value до
+того, как schema package сгенерировал для него constant, передай эту строку
+напрямую.
 
 ## Remove keyboard
 

--- a/docs/ru/tutorials/support-desk.md
+++ b/docs/ru/tutorials/support-desk.md
@@ -35,6 +35,7 @@ using TeleFlow.Core.Application;
 using TeleFlow.Storage.Memory;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Constants;
 
 var token = Environment.GetEnvironmentVariable("TELEFLOW_BOT_TOKEN")
     ?? throw new InvalidOperationException("TELEFLOW_BOT_TOKEN is not set.");
@@ -342,11 +343,11 @@ public sealed class AdminTicketHandlers
             .Button(
                 "Take",
                 new TicketAction(ticket.Id, "take"),
-                new InlineKeyboardButtonOptions { Style = "primary" })
+                new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
             .Button(
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
-                new InlineKeyboardButtonOptions { Style = "success" })
+                new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
             .Build();
 
         await ctx.Message.AnswerAsync(

--- a/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
@@ -1,5 +1,6 @@
 using TeleFlow.Annotations;
 using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.ArchitectureTests;
@@ -15,22 +16,22 @@ public sealed class KeyboardBuilderTests
                 new InlineKeyboardDeleteCallback(42),
                 new InlineKeyboardButtonOptions
                 {
-                    Style = "danger",
+                    Style = ButtonStyles.Danger,
                     IconCustomEmojiId = "emoji-delete"
                 })
-            .Button("Raw", "raw:42", new InlineKeyboardButtonOptions { Style = "primary" })
+            .Button("Raw", "raw:42", new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
             .Row()
-            .Url("Open", "https://example.com", new InlineKeyboardButtonOptions { Style = "success" })
+            .Url("Open", "https://example.com", new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
             .Build();
 
         Assert.Equal(2, markup.InlineKeyboard.Count);
         Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
-        Assert.Equal("danger", markup.InlineKeyboard[0][0].Style);
+        Assert.Equal(ButtonStyles.Danger, markup.InlineKeyboard[0][0].Style);
         Assert.Equal("emoji-delete", markup.InlineKeyboard[0][0].IconCustomEmojiId);
         Assert.Equal("raw:42", markup.InlineKeyboard[0][1].CallbackData);
-        Assert.Equal("primary", markup.InlineKeyboard[0][1].Style);
+        Assert.Equal(ButtonStyles.Primary, markup.InlineKeyboard[0][1].Style);
         Assert.Equal("https://example.com", markup.InlineKeyboard[1][0].Url);
-        Assert.Equal("success", markup.InlineKeyboard[1][0].Style);
+        Assert.Equal(ButtonStyles.Success, markup.InlineKeyboard[1][0].Style);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace raw keyboard style literals in docs and architecture tests with generated Bot API constants
- keep `InlineKeyboardButtonOptions.Style` string-based for forward compatibility with new Telegram values
- document the raw string escape hatch for values not generated yet

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~KeyboardBuilderTests|FullyQualifiedName~TelegramSchemaTests"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj`
- `dotnet build TeleFlow.sln`
- `git diff --check`

Closes #74