### PR TITLE
fix(core): resolve update middleware from update scope

### DIFF
--- a/docs/en/advanced/middleware-and-rate-limiting.md
+++ b/docs/en/advanced/middleware-and-rate-limiting.md
@@ -29,13 +29,15 @@ Update middleware runs before Telegram routing, built-in filters, custom filters
 This example records an incoming Telegram user, increments update statistics, and stops the pipeline when the user is blocked:
 
 ```csharp
-using Microsoft.Extensions.DependencyInjection;
 using TeleFlow.Core.Middleware;
 using TeleFlow.Core.Updates;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Types;
 
-public sealed class UserGateMiddleware : IUpdateMiddleware
+public sealed class UserGateMiddleware(
+    IUserRepository users,
+    IAntiSpamService antiSpam,
+    IUpdateStatistics stats) : IUpdateMiddleware
 {
     public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
     {
@@ -51,10 +53,6 @@ public sealed class UserGateMiddleware : IUpdateMiddleware
             await next(context);
             return;
         }
-
-        var users = context.Services.GetRequiredService<IUserRepository>();
-        var antiSpam = context.Services.GetRequiredService<IAntiSpamService>();
-        var stats = context.Services.GetRequiredService<IUpdateStatistics>();
 
         await users.EnsureExistsAsync(actor.UserId, context.CancellationToken);
         await stats.RecordIncomingUpdateAsync(
@@ -113,7 +111,19 @@ builder.Services.AddScoped<IUpdateStatistics, UpdateStatistics>();
 builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 ```
 
-`AddUpdateMiddleware<T>()` registers middleware as a singleton. Resolve scoped application services from `context.Services`, which is the service provider for the current update scope.
+`AddUpdateMiddleware<T>()` registers middleware in the update pipeline and creates the middleware from the current update scope. This means middleware can use scoped constructor dependencies such as repositories, unit-of-work services, database contexts, and request/update-scoped application services.
+
+Use `context.Services` only when a middleware intentionally needs dynamic service resolution. Constructor injection is the recommended path for normal application dependencies.
+
+If a middleware is stateless and must be reused as one process-wide instance, register it explicitly:
+
+```csharp
+builder.Services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
+```
+
+Singleton middleware must not depend on scoped services in its constructor.
+
+Do not register middleware directly as `IUpdateMiddleware` in `IServiceCollection`. TeleFlow builds the middleware pipeline from middleware registrations, not from arbitrary `IUpdateMiddleware` services, and application startup fails clearly when direct registrations are found.
 
 If a middleware does not call `next(context)`, TeleFlow stops processing that update. Routing and handlers will not run. Use this for global gates such as ban lists, tenant shutdown, or hard rate limits.
 

--- a/docs/en/fundamentals/dependency-injection.md
+++ b/docs/en/fundamentals/dependency-injection.md
@@ -90,7 +90,7 @@ Use these intentionally. A replacement point is not a reason to customize everyt
 
 - Use singleton for stateless services and thread-safe repositories.
 - Use singleton for in-memory demo repositories only when process-local data is acceptable.
-- Use scoped services only when the surrounding host provides scopes in the way your application expects.
+- Use scoped services for update-scoped application work. TeleFlow creates one DI scope per update when the update goes through the framework pipeline, and scoped middleware plus handlers share that scope.
 - Avoid mutable singleton state for production workflows unless it is explicitly synchronized and process-local by design.
 
 TeleFlow itself does not turn DI into an application architecture. Keep your own boundaries clear.

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -87,6 +87,7 @@ Core:
 services.AddUpdateDispatcher<MyDispatcher>();
 services.AddUpdateSource<MySource>();
 services.AddUpdateMiddleware<MyMiddleware>();
+services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 services.AddDefaultUpdateRateLimiting();
 services.AddUpdateRateLimiter<MyLimiter>();
 ```

--- a/docs/ru/advanced/middleware-and-rate-limiting.md
+++ b/docs/ru/advanced/middleware-and-rate-limiting.md
@@ -29,13 +29,15 @@ Update middleware выполняется до Telegram routing, built-in filters
 Этот пример регистрирует входящего Telegram user, пишет статистику update-а и останавливает pipeline, если user заблокирован:
 
 ```csharp
-using Microsoft.Extensions.DependencyInjection;
 using TeleFlow.Core.Middleware;
 using TeleFlow.Core.Updates;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Types;
 
-public sealed class UserGateMiddleware : IUpdateMiddleware
+public sealed class UserGateMiddleware(
+    IUserRepository users,
+    IAntiSpamService antiSpam,
+    IUpdateStatistics stats) : IUpdateMiddleware
 {
     public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
     {
@@ -51,10 +53,6 @@ public sealed class UserGateMiddleware : IUpdateMiddleware
             await next(context);
             return;
         }
-
-        var users = context.Services.GetRequiredService<IUserRepository>();
-        var antiSpam = context.Services.GetRequiredService<IAntiSpamService>();
-        var stats = context.Services.GetRequiredService<IUpdateStatistics>();
 
         await users.EnsureExistsAsync(actor.UserId, context.CancellationToken);
         await stats.RecordIncomingUpdateAsync(
@@ -113,7 +111,19 @@ builder.Services.AddScoped<IUpdateStatistics, UpdateStatistics>();
 builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 ```
 
-`AddUpdateMiddleware<T>()` регистрирует middleware как singleton. Scoped application services резолви из `context.Services`: это service provider текущего update scope.
+`AddUpdateMiddleware<T>()` добавляет middleware в update pipeline и создаёт его из текущего update scope. Поэтому middleware может принимать scoped-зависимости в конструкторе: repositories, unit-of-work services, database contexts и другие update-scoped application services.
+
+`context.Services` используй только когда middleware намеренно нужен dynamic service resolution. Для обычных application dependencies рекомендуемый путь - constructor injection.
+
+Если middleware stateless и должен переиспользоваться как один process-wide instance, регистрируй это явно:
+
+```csharp
+builder.Services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
+```
+
+Singleton middleware не должен принимать scoped services в конструкторе.
+
+Не регистрируй middleware напрямую как `IUpdateMiddleware` в `IServiceCollection`. TeleFlow строит middleware pipeline из middleware-регистраций, а не из произвольных `IUpdateMiddleware` services, и startup приложения намеренно падает с понятной ошибкой, если находит прямые регистрации.
 
 Если middleware не вызывает `next(context)`, TeleFlow прекращает обработку этого update. Routing и handlers не выполнятся. Используй это для глобальных gates: ban list, tenant shutdown или жёсткие rate limits.
 

--- a/docs/ru/fundamentals/dependency-injection.md
+++ b/docs/ru/fundamentals/dependency-injection.md
@@ -90,7 +90,7 @@ builder.Services.AddUpdateRateLimiter<TenantUpdateRateLimiter>();
 
 - Singleton подходит для stateless services и thread-safe repositories.
 - Singleton подходит для in-memory demo repositories только когда process-local data acceptable.
-- Scoped services используй только когда surrounding host создаёт scopes так, как ожидает приложение.
+- Scoped services используй для update-scoped application work. TeleFlow создаёт один DI scope на update, когда update проходит через framework pipeline, и scoped middleware вместе с handlers разделяют этот scope.
 - Избегай mutable singleton state в production workflows, если он явно не синхронизирован и не process-local by design.
 
 TeleFlow сам по себе не превращает DI в application architecture. Границы своего приложения нужно держать отдельно.

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -87,6 +87,7 @@ Core:
 services.AddUpdateDispatcher<MyDispatcher>();
 services.AddUpdateSource<MySource>();
 services.AddUpdateMiddleware<MyMiddleware>();
+services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 services.AddDefaultUpdateRateLimiting();
 services.AddUpdateRateLimiter<MyLimiter>();
 ```

--- a/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
@@ -17,6 +17,8 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
 
     public ITeleFlowApplication Build()
     {
+        ValidateMiddlewareRegistrations();
+
         var serviceProvider = Services.BuildServiceProvider(new ServiceProviderOptions
         {
             ValidateOnBuild = true,
@@ -26,7 +28,7 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
         var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
         var updateSource = ResolveSingleRequiredService<IUpdateSource>(serviceProvider);
         var dispatcher = ResolveSingleRequiredService<IUpdateDispatcher>(serviceProvider);
-        var middleware = serviceProvider.GetServices<IUpdateMiddleware>().ToArray();
+        var middleware = serviceProvider.GetServices<UpdateMiddlewareRegistration>().ToArray();
         var processor = new DefaultUpdateProcessor(scopeFactory, dispatcher, middleware);
 
         return new TeleFlowApplication(serviceProvider, updateSource, processor);
@@ -45,5 +47,19 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
                 $"Only one {typeof(TService).Name} registration is supported when building the TeleFlow application."),
             _ => services[0]
         };
+    }
+
+    private void ValidateMiddlewareRegistrations()
+    {
+        if (!Services.Any(static descriptor => descriptor.ServiceType == typeof(IUpdateMiddleware)))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Direct IUpdateMiddleware service registrations are not used by the TeleFlow update pipeline. " +
+            $"Register middleware with {nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware)}<TMiddleware>() " +
+            $"or {nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware)}<TMiddleware>() so TeleFlow can " +
+            "resolve it from the correct update scope.");
     }
 }

--- a/src/TeleFlow.Core/Middleware/ServiceCollectionMiddlewareExtensions.cs
+++ b/src/TeleFlow.Core/Middleware/ServiceCollectionMiddlewareExtensions.cs
@@ -11,7 +11,18 @@ public static class ServiceCollectionMiddlewareExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<IUpdateMiddleware, TMiddleware>();
+        services.AddScoped<TMiddleware>();
+        services.AddUpdateMiddlewareRegistration<TMiddleware>();
+        return services;
+    }
+
+    public static IServiceCollection AddSingletonUpdateMiddleware<TMiddleware>(this IServiceCollection services)
+        where TMiddleware : class, IUpdateMiddleware
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<TMiddleware>();
+        services.AddUpdateMiddlewareRegistration<TMiddleware>();
         return services;
     }
 
@@ -19,8 +30,24 @@ public static class ServiceCollectionMiddlewareExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IUpdateMiddleware, UpdateRateLimitMiddleware>());
+        services.AddUpdateMiddleware<UpdateRateLimitMiddleware>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IUpdateRateLimiter, NoOpUpdateRateLimiter>());
         return services;
+    }
+
+    private static void AddUpdateMiddlewareRegistration<TMiddleware>(this IServiceCollection services)
+        where TMiddleware : class, IUpdateMiddleware
+    {
+        var middlewareType = typeof(TMiddleware);
+
+        if (services.Any(descriptor =>
+                descriptor.ServiceType == typeof(UpdateMiddlewareRegistration) &&
+                descriptor.ImplementationInstance is UpdateMiddlewareRegistration registration &&
+                registration.MiddlewareType == middlewareType))
+        {
+            return;
+        }
+
+        services.AddSingleton(new UpdateMiddlewareRegistration(middlewareType));
     }
 }

--- a/src/TeleFlow.Core/Middleware/UpdateMiddlewareRegistration.cs
+++ b/src/TeleFlow.Core/Middleware/UpdateMiddlewareRegistration.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeleFlow.Core.Middleware;
+
+internal sealed class UpdateMiddlewareRegistration
+{
+    public UpdateMiddlewareRegistration(Type middlewareType)
+    {
+        ArgumentNullException.ThrowIfNull(middlewareType);
+
+        if (!typeof(IUpdateMiddleware).IsAssignableFrom(middlewareType))
+        {
+            throw new ArgumentException(
+                $"Middleware type must implement {nameof(IUpdateMiddleware)}.",
+                nameof(middlewareType));
+        }
+
+        MiddlewareType = middlewareType;
+    }
+
+    public Type MiddlewareType { get; }
+
+    public IUpdateMiddleware Resolve(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        return (IUpdateMiddleware)services.GetRequiredService(MiddlewareType);
+    }
+}

--- a/src/TeleFlow.Core/Updates/DefaultUpdateProcessor.cs
+++ b/src/TeleFlow.Core/Updates/DefaultUpdateProcessor.cs
@@ -7,39 +7,42 @@ namespace TeleFlow.Core.Updates;
 internal sealed class DefaultUpdateProcessor : IUpdateProcessor
 {
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly UpdateDelegate _pipeline;
+    private readonly IUpdateDispatcher _dispatcher;
+    private readonly IReadOnlyList<UpdateMiddlewareRegistration> _middleware;
 
     public DefaultUpdateProcessor(
         IServiceScopeFactory scopeFactory,
         IUpdateDispatcher dispatcher,
-        IEnumerable<IUpdateMiddleware> middleware)
+        IEnumerable<UpdateMiddlewareRegistration> middleware)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
-        ArgumentNullException.ThrowIfNull(dispatcher);
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         ArgumentNullException.ThrowIfNull(middleware);
 
-        _pipeline = BuildPipeline(dispatcher, middleware.ToArray());
+        _middleware = middleware.ToArray();
     }
 
     public async Task ProcessAsync(IUpdatePayload payload, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(payload);
 
-        using var scope = _scopeFactory.CreateScope();
+        await using var scope = _scopeFactory.CreateAsyncScope();
         var context = new UpdateContext(scope.ServiceProvider, payload, cancellationToken);
+        var pipeline = BuildPipeline(scope.ServiceProvider, _dispatcher, _middleware);
 
-        await _pipeline(context).ConfigureAwait(false);
+        await pipeline(context).ConfigureAwait(false);
     }
 
     private static UpdateDelegate BuildPipeline(
+        IServiceProvider services,
         IUpdateDispatcher dispatcher,
-        IUpdateMiddleware[] middleware)
+        IReadOnlyList<UpdateMiddlewareRegistration> middleware)
     {
         UpdateDelegate pipeline = context => dispatcher.DispatchAsync(context, context.CancellationToken);
 
-        for (var index = middleware.Length - 1; index >= 0; index--)
+        for (var index = middleware.Count - 1; index >= 0; index--)
         {
-            var current = middleware[index];
+            var current = middleware[index].Resolve(services);
             var next = pipeline;
             pipeline = context => current.InvokeAsync(context, next);
         }

--- a/src/TeleFlow.Storage.Memory/MemoryStateServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Storage.Memory/MemoryStateServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ public static class MemoryStateServiceCollectionExtensions
         services.TryAddSingleton<IStateDataStore, MemoryStateDataStore>();
         services.TryAddSingleton<IStateDataSerializer, JsonStateDataSerializer>();
         services.TryAddSingleton<IStateHistoryStore, MemoryStateHistoryStore>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IUpdateMiddleware, UpdateStateMiddleware>());
+        services.AddUpdateMiddleware<UpdateStateMiddleware>();
 
         return services;
     }

--- a/tests/TeleFlow.ArchitectureTests/RuntimeExecutionTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/RuntimeExecutionTests.cs
@@ -64,10 +64,11 @@ public sealed class RuntimeExecutionTests
         var application = CreateApplication(
             services =>
             {
+                services.AddSingleton(trace);
                 services.AddSingleton<IUpdateSource>(source);
                 services.AddSingleton<IUpdateDispatcher>(dispatcher);
-                services.AddSingleton<IUpdateMiddleware>(new ProbeMiddleware("mw-1", trace));
-                services.AddSingleton<IUpdateMiddleware>(new ProbeMiddleware("mw-2", trace));
+                services.AddUpdateMiddleware<FirstProbeMiddleware>();
+                services.AddUpdateMiddleware<SecondProbeMiddleware>();
             });
 
         await application.RunAsync();
@@ -92,9 +93,10 @@ public sealed class RuntimeExecutionTests
         var application = CreateApplication(
             services =>
             {
+                services.AddSingleton(trace);
                 services.AddSingleton<IUpdateSource>(source);
                 services.AddSingleton<IUpdateDispatcher>(dispatcher);
-                services.AddSingleton<IUpdateMiddleware>(new ProbeMiddleware("stop", trace, shortCircuit: true));
+                services.AddUpdateMiddleware<ShortCircuitMiddleware>();
             });
 
         await application.RunAsync();
@@ -104,28 +106,62 @@ public sealed class RuntimeExecutionTests
     }
 
     [Fact]
+    public void Build_FailsClearlyForDirectMiddlewareServiceRegistration()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<IUpdateSource>(new RecordingUpdateSource([]));
+        builder.Services.AddSingleton<IUpdateDispatcher>(new RecordingDispatcher());
+        builder.Services.AddSingleton<IUpdateMiddleware, DirectMiddleware>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.Contains(nameof(IUpdateMiddleware), exception.Message);
+        Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware), exception.Message);
+        Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware), exception.Message);
+    }
+
+    [Fact]
     public async Task Dispatcher_ReceivesSameContextSeenByMiddleware()
     {
         var source = new RecordingUpdateSource([new TestUpdatePayload("only")]);
         var dispatcher = new RecordingDispatcher();
-        UpdateContext? middlewareContext = null;
+        var recorder = new ContextRecorder();
 
         var application = CreateApplication(
             services =>
             {
+                services.AddSingleton(recorder);
                 services.AddSingleton<IUpdateSource>(source);
                 services.AddSingleton<IUpdateDispatcher>(dispatcher);
-                services.AddSingleton<IUpdateMiddleware>(
-                    new DelegateMiddleware((context, next) =>
-                    {
-                        middlewareContext = context;
-                        return next(context);
-                    }));
+                services.AddUpdateMiddleware<ContextRecordingMiddleware>();
             });
 
         await application.RunAsync();
 
-        Assert.Same(middlewareContext, dispatcher.Contexts.Single());
+        Assert.Same(recorder.Context, dispatcher.Contexts.Single());
+    }
+
+    [Fact]
+    public async Task AddUpdateMiddleware_AllowsScopedConstructorDependencies()
+    {
+        var source = new RecordingUpdateSource([new TestUpdatePayload("only")]);
+        var dispatcher = new ScopedProbeDispatcher();
+        var recorder = new ScopedProbeRecorder();
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(recorder);
+                services.AddScoped<ScopedProbe>();
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddUpdateMiddleware<ScopedConstructorMiddleware>();
+            });
+
+        await application.RunAsync();
+
+        Assert.Equal(dispatcher.ProbeIds.Single(), recorder.MiddlewareProbeIds.Single());
     }
 
     [Fact]
@@ -136,35 +172,52 @@ public sealed class RuntimeExecutionTests
             new TestUpdatePayload("first"),
             new TestUpdatePayload("second")
         ]);
-        var dispatcher = new RecordingDispatcher();
+        var dispatcher = new ScopedProbeDispatcher();
+        var recorder = new ScopedProbeRecorder();
 
         var application = CreateApplication(
             services =>
             {
+                services.AddSingleton(recorder);
                 services.AddScoped<ScopedProbe>();
                 services.AddSingleton<IUpdateSource>(source);
                 services.AddSingleton<IUpdateDispatcher>(dispatcher);
-                services.AddSingleton<IUpdateMiddleware>(
-                    new DelegateMiddleware((context, next) =>
-                    {
-                        var probeFromFirstResolution = context.Services.GetRequiredService<ScopedProbe>();
-                        var probeFromSecondResolution = context.Services.GetRequiredService<ScopedProbe>();
-
-                        context.Items["scoped-first"] = probeFromFirstResolution.Id;
-                        context.Items["scoped-second"] = probeFromSecondResolution.Id;
-
-                        return next(context);
-                    }));
+                services.AddUpdateMiddleware<ScopedConstructorMiddleware>();
             });
 
         await application.RunAsync();
 
-        var firstContext = dispatcher.Contexts[0];
-        var secondContext = dispatcher.Contexts[1];
+        Assert.Collection(
+            recorder.MiddlewareProbeIds.Zip(dispatcher.ProbeIds),
+            pair => Assert.Equal(pair.First, pair.Second),
+            pair => Assert.Equal(pair.First, pair.Second));
+        Assert.NotEqual(recorder.MiddlewareProbeIds[0], recorder.MiddlewareProbeIds[1]);
+    }
 
-        Assert.Equal(firstContext.Items["scoped-first"], firstContext.Items["scoped-second"]);
-        Assert.Equal(secondContext.Items["scoped-first"], secondContext.Items["scoped-second"]);
-        Assert.NotEqual(firstContext.Items["scoped-first"], secondContext.Items["scoped-first"]);
+    [Fact]
+    public async Task AddSingletonUpdateMiddleware_ReusesMiddlewareAcrossUpdates()
+    {
+        var source = new RecordingUpdateSource(
+        [
+            new TestUpdatePayload("first"),
+            new TestUpdatePayload("second")
+        ]);
+        var dispatcher = new RecordingDispatcher();
+        var recorder = new SingletonMiddlewareRecorder();
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(recorder);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddSingletonUpdateMiddleware<SingletonRecordingMiddleware>();
+            });
+
+        await application.RunAsync();
+
+        Assert.Equal(2, recorder.MiddlewareInstanceIds.Count);
+        Assert.Equal(recorder.MiddlewareInstanceIds[0], recorder.MiddlewareInstanceIds[1]);
     }
 
     [Fact]
@@ -199,7 +252,8 @@ public sealed class RuntimeExecutionTests
             {
                 services.AddSingleton<IUpdateSource>(source);
                 services.AddSingleton<IUpdateDispatcher>(dispatcher);
-                services.AddSingleton<IUpdateMiddleware>(new ThrowingMiddleware(exception));
+                services.AddSingleton(exception);
+                services.AddUpdateMiddleware<ThrowingMiddleware>();
             });
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => application.RunAsync());
@@ -233,9 +287,10 @@ public sealed class RuntimeExecutionTests
         var dispatcher = new RecordingDispatcher(trace);
         var services = new ServiceCollection();
 
+        services.AddSingleton(trace);
         services.AddSingleton<IUpdateDispatcher>(dispatcher);
-        services.AddSingleton<IUpdateMiddleware>(new ProbeMiddleware("mw-1", trace));
-        services.AddSingleton<IUpdateMiddleware>(new ProbeMiddleware("mw-2", trace));
+        services.AddUpdateMiddleware<FirstProbeMiddleware>();
+        services.AddUpdateMiddleware<SecondProbeMiddleware>();
         services.AddSingleton<IUpdateProcessor, DefaultUpdateProcessor>();
 
         using var provider = services.BuildServiceProvider(new ServiceProviderOptions
@@ -265,14 +320,11 @@ public sealed class RuntimeExecutionTests
         var dispatcher = new RecordingDispatcher();
         var services = new ServiceCollection();
 
+        var recorder = new ScopedProbeRecorder();
+        services.AddSingleton(recorder);
         services.AddScoped<ScopedProbe>();
         services.AddSingleton<IUpdateDispatcher>(dispatcher);
-        services.AddSingleton<IUpdateMiddleware>(
-            new DelegateMiddleware((context, next) =>
-            {
-                context.Items["scope"] = context.Services.GetRequiredService<ScopedProbe>().Id;
-                return next(context);
-            }));
+        services.AddUpdateMiddleware<ScopedConstructorMiddleware>();
         services.AddSingleton<IUpdateProcessor, DefaultUpdateProcessor>();
 
         using var provider = services.BuildServiceProvider(new ServiceProviderOptions
@@ -286,7 +338,7 @@ public sealed class RuntimeExecutionTests
         await processor.ProcessAsync(new TestUpdatePayload("first"));
         await processor.ProcessAsync(new TestUpdatePayload("second"));
 
-        Assert.NotEqual(dispatcher.Contexts[0].Items["scope"], dispatcher.Contexts[1].Items["scope"]);
+        Assert.NotEqual(recorder.MiddlewareProbeIds[0], recorder.MiddlewareProbeIds[1]);
     }
 
     private static ITeleFlowApplication CreateApplication(Action<IServiceCollection> configureServices)
@@ -347,13 +399,24 @@ public sealed class RuntimeExecutionTests
         }
     }
 
-    private sealed class ProbeMiddleware : IUpdateMiddleware
+    private sealed class ScopedProbeDispatcher : IUpdateDispatcher
+    {
+        public List<Guid> ProbeIds { get; } = [];
+
+        public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        {
+            ProbeIds.Add(context.Services.GetRequiredService<ScopedProbe>().Id);
+            return Task.CompletedTask;
+        }
+    }
+
+    private abstract class ProbeMiddleware : IUpdateMiddleware
     {
         private readonly string _name;
         private readonly List<string> _trace;
         private readonly bool _shortCircuit;
 
-        public ProbeMiddleware(string name, List<string> trace, bool shortCircuit = false)
+        protected ProbeMiddleware(string name, List<string> trace, bool shortCircuit = false)
         {
             _name = name;
             _trace = trace;
@@ -375,27 +438,72 @@ public sealed class RuntimeExecutionTests
         }
     }
 
-    private sealed class DelegateMiddleware : IUpdateMiddleware
+    private sealed class FirstProbeMiddleware(List<string> trace) : ProbeMiddleware("mw-1", trace);
+
+    private sealed class SecondProbeMiddleware(List<string> trace) : ProbeMiddleware("mw-2", trace);
+
+    private sealed class ShortCircuitMiddleware(List<string> trace) : ProbeMiddleware("stop", trace, shortCircuit: true);
+
+    private sealed class ContextRecordingMiddleware(ContextRecorder recorder) : IUpdateMiddleware
     {
-        private readonly Func<UpdateContext, UpdateDelegate, Task> _handler;
-
-        public DelegateMiddleware(Func<UpdateContext, UpdateDelegate, Task> handler)
-        {
-            _handler = handler;
-        }
-
         public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
         {
-            return _handler(context, next);
+            recorder.Context = context;
+            return next(context);
         }
     }
 
-    private sealed class ThrowingMiddleware(Exception exception) : IUpdateMiddleware
+    private sealed class DirectMiddleware : IUpdateMiddleware
+    {
+        public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+        {
+            return next(context);
+        }
+    }
+
+    private sealed class ScopedConstructorMiddleware(
+        ScopedProbe probe,
+        ScopedProbeRecorder recorder) : IUpdateMiddleware
+    {
+        public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+        {
+            recorder.MiddlewareProbeIds.Add(probe.Id);
+            return next(context);
+        }
+    }
+
+    private sealed class SingletonRecordingMiddleware(SingletonMiddlewareRecorder recorder) : IUpdateMiddleware
+    {
+        private readonly Guid _instanceId = Guid.NewGuid();
+
+        public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+        {
+            recorder.MiddlewareInstanceIds.Add(_instanceId);
+            return next(context);
+        }
+    }
+
+    private sealed class ThrowingMiddleware(InvalidOperationException exception) : IUpdateMiddleware
     {
         public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
         {
             return Task.FromException(exception);
         }
+    }
+
+    private sealed class ContextRecorder
+    {
+        public UpdateContext? Context { get; set; }
+    }
+
+    private sealed class ScopedProbeRecorder
+    {
+        public List<Guid> MiddlewareProbeIds { get; } = [];
+    }
+
+    private sealed class SingletonMiddlewareRecorder
+    {
+        public List<Guid> MiddlewareInstanceIds { get; } = [];
     }
 
     private sealed class ScopedProbe

--- a/tests/TeleFlow.ArchitectureTests/StageSevenPolicyOverrideTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSevenPolicyOverrideTests.cs
@@ -164,13 +164,12 @@ public sealed class StageSevenPolicyOverrideTests
             limiter => Assert.IsType<FirstRecordingRateLimiter>(limiter),
             limiter => Assert.IsType<SecondRecordingRateLimiter>(limiter));
         Assert.Contains(
-            serviceProvider.GetServices<IUpdateMiddleware>(),
-            middleware => middleware is UpdateRateLimitMiddleware);
+            serviceProvider.GetServices<UpdateMiddlewareRegistration>(),
+            registration => registration.MiddlewareType == typeof(UpdateRateLimitMiddleware));
 
-        var context = new UpdateContext(serviceProvider, new TestUpdatePayload("rate-limit"));
-        var middleware = serviceProvider.GetServices<IUpdateMiddleware>()
-            .OfType<UpdateRateLimitMiddleware>()
-            .Single();
+        using var scope = serviceProvider.CreateScope();
+        var context = new UpdateContext(scope.ServiceProvider, new TestUpdatePayload("rate-limit"));
+        var middleware = scope.ServiceProvider.GetRequiredService<UpdateRateLimitMiddleware>();
 
         await middleware.InvokeAsync(
             context,

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -514,8 +514,8 @@ public sealed class StageSixStateAndMiddlewareTests
         Assert.Same(customSerializer, serviceProvider.GetRequiredService<IStateDataSerializer>());
         Assert.Same(customHistoryStore, serviceProvider.GetRequiredService<IStateHistoryStore>());
         Assert.Contains(
-            serviceProvider.GetServices<IUpdateMiddleware>(),
-            middleware => middleware is UpdateStateMiddleware);
+            serviceProvider.GetServices<UpdateMiddlewareRegistration>(),
+            registration => registration.MiddlewareType == typeof(UpdateStateMiddleware));
     }
 
     [Fact]
@@ -569,10 +569,7 @@ public sealed class StageSixStateAndMiddlewareTests
 
         Assert.Throws<InvalidOperationException>(() => context.GetMessageContext().State);
 
-        var stateMiddleware = serviceProvider
-            .GetServices<IUpdateMiddleware>()
-            .OfType<UpdateStateMiddleware>()
-            .Single();
+        var stateMiddleware = scope.ServiceProvider.GetRequiredService<UpdateStateMiddleware>();
 
         await stateMiddleware.InvokeAsync(context, static _ => Task.CompletedTask);
 
@@ -597,10 +594,7 @@ public sealed class StageSixStateAndMiddlewareTests
         var context = new UpdateContext(
             scope.ServiceProvider,
             new TelegramUpdatePayload(CreateMessageUpdate("hello", userId: 5, chatId: 100)));
-        var stateMiddleware = serviceProvider
-            .GetServices<IUpdateMiddleware>()
-            .OfType<UpdateStateMiddleware>()
-            .Single();
+        var stateMiddleware = scope.ServiceProvider.GetRequiredService<UpdateStateMiddleware>();
 
         await stateMiddleware.InvokeAsync(context, static _ => Task.CompletedTask);
 
@@ -623,10 +617,7 @@ public sealed class StageSixStateAndMiddlewareTests
         var context = new UpdateContext(
             scope.ServiceProvider,
             new TelegramUpdatePayload(CreateMessageUpdate("hello", userId: 5, chatId: 100)));
-        var stateMiddleware = serviceProvider
-            .GetServices<IUpdateMiddleware>()
-            .OfType<UpdateStateMiddleware>()
-            .Single();
+        var stateMiddleware = scope.ServiceProvider.GetRequiredService<UpdateStateMiddleware>();
 
         await stateMiddleware.InvokeAsync(context, static _ => Task.CompletedTask);
 
@@ -912,21 +903,12 @@ public sealed class StageSixStateAndMiddlewareTests
         ServiceProvider serviceProvider,
         IUpdatePayload payload)
     {
-        using var scope = serviceProvider.CreateScope();
-        var context = new UpdateContext(scope.ServiceProvider, payload);
-        var middleware = serviceProvider.GetServices<IUpdateMiddleware>().ToArray();
-        var dispatcher = scope.ServiceProvider.GetRequiredService<IUpdateDispatcher>();
+        var processor = new DefaultUpdateProcessor(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            serviceProvider.GetRequiredService<IUpdateDispatcher>(),
+            serviceProvider.GetServices<UpdateMiddlewareRegistration>());
 
-        UpdateDelegate pipeline = updateContext => dispatcher.DispatchAsync(updateContext);
-
-        for (var index = middleware.Length - 1; index >= 0; index--)
-        {
-            var current = middleware[index];
-            var next = pipeline;
-            pipeline = updateContext => current.InvokeAsync(updateContext, next);
-        }
-
-        await pipeline(context);
+        await processor.ProcessAsync(payload);
     }
 
     private static UpdateState CreateUpdateStateWithData()

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2816,22 +2816,12 @@ public sealed class TelegramHandlerDispatcherTests
         Update update,
         CancellationToken cancellationToken = default)
     {
-        using var scope = serviceProvider.CreateScope();
-        var context = new UpdateContext(
-            scope.ServiceProvider,
-            new TelegramUpdatePayload(update),
-            cancellationToken);
-        var dispatcher = scope.ServiceProvider.GetRequiredService<TeleFlow.Core.Dispatching.IUpdateDispatcher>();
-        var middlewares = scope.ServiceProvider.GetServices<IUpdateMiddleware>().Reverse().ToArray();
-        UpdateDelegate next = updateContext => dispatcher.DispatchAsync(updateContext, cancellationToken);
+        var processor = new DefaultUpdateProcessor(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            serviceProvider.GetRequiredService<TeleFlow.Core.Dispatching.IUpdateDispatcher>(),
+            serviceProvider.GetServices<UpdateMiddlewareRegistration>());
 
-        foreach (var middleware in middlewares)
-        {
-            var currentNext = next;
-            next = updateContext => middleware.InvokeAsync(updateContext, currentNext);
-        }
-
-        await next(context);
+        await processor.ProcessAsync(new TelegramUpdatePayload(update), cancellationToken);
     }
 
     private static IReadOnlyList<string?> GetRegisteredModuleNames(IServiceCollection services)


### PR DESCRIPTION
## Summary
- resolve update middleware from the per-update DI scope
- make `AddUpdateMiddleware<T>()` the scoped middleware registration path
- add explicit `AddSingletonUpdateMiddleware<T>()` for stateless process-wide middleware
- fail startup clearly when middleware is registered directly as `IUpdateMiddleware`
- sync EN/RU middleware and DI documentation

## Touched hot paths
- `DefaultUpdateProcessor` now creates an async update scope and resolves middleware from that scope before dispatch.
- Middleware ordering is still driven by registration order.
- Dispatcher invocation and handler execution stay on the same update context and cancellation path.
- State storage and default rate limiting now use the same middleware registration path.

## Validation
- `dotnet build TeleFlow.sln --no-restore`
- `dotnet test TeleFlow.sln --no-build`
- `git diff --check`

Closes #79