### PR TITLE
perf(telegram-client): skip upload scans for JSON-only requests

### DIFF
--- a/src/TeleFlow.Telegram.Client/Internal/TelegramMultipartContentBuilder.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramMultipartContentBuilder.cs
@@ -1,0 +1,160 @@
+using System.Collections;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Converts a Telegram request payload that contains uploads into multipart fields and files.
+/// Nested files are exposed to Telegram JSON fields through attach:// references.
+/// This path is used when a user sends local streams/files through generated Bot API methods.
+/// </summary>
+internal sealed class TelegramMultipartContentBuilder
+{
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly List<TelegramMultipartField> _fields = [];
+    private readonly List<TelegramMultipartFile> _files = [];
+    private int _fileIndex;
+
+    public TelegramMultipartContentBuilder(JsonSerializerOptions serializerOptions)
+    {
+        ArgumentNullException.ThrowIfNull(serializerOptions);
+        _serializerOptions = serializerOptions;
+    }
+
+    public TelegramMultipartTransportContent Build(object payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        foreach (var property in TelegramRequestTypeMetadataCache.Get(payload.GetType()).TelegramProperties)
+        {
+            var value = property.GetValue(payload);
+            if (value is null)
+            {
+                continue;
+            }
+
+            var fieldName = property.TelegramName;
+            if (TelegramRequestUploadDetector.TryGetDirectInputFile(value, out var inputFile))
+            {
+                AddFile(fieldName, inputFile);
+                continue;
+            }
+
+            var node = ToJsonNode(value);
+            if (node is not null)
+            {
+                AddField(fieldName, node);
+            }
+        }
+
+        return new TelegramMultipartTransportContent(_fields.ToArray(), _files.ToArray());
+    }
+
+    private JsonNode? ToJsonNode(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        // Nested files are represented in JSON fields by attach:// names.
+        // The binary stream is added to the same multipart body under that generated name.
+        if (value is InputFile inputFile)
+        {
+            var fileName = "file" + _fileIndex.ToString(CultureInfo.InvariantCulture);
+            _fileIndex++;
+            AddFile(fileName, inputFile);
+            return JsonValue.Create("attach://" + fileName);
+        }
+
+        if (value is string stringValue)
+        {
+            return JsonValue.Create(stringValue);
+        }
+
+        if (value is bool boolValue)
+        {
+            return JsonValue.Create(boolValue);
+        }
+
+        if (value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
+        {
+            return JsonSerializer.SerializeToNode(value, value.GetType(), _serializerOptions);
+        }
+
+        if (value is IEnumerable enumerable and not string)
+        {
+            var array = new JsonArray();
+            foreach (var item in enumerable)
+            {
+                array.Add(ToJsonNode(item));
+            }
+
+            return array;
+        }
+
+        var unionCase = TelegramRequestUploadDetector.GetActiveUnionCase(value);
+        if (unionCase is not null)
+        {
+            // Telegram unions serialize as their selected value, not as the wrapper object.
+            return ToJsonNode(unionCase.Value);
+        }
+
+        var metadata = TelegramRequestTypeMetadataCache.Get(value.GetType());
+        if (metadata.TelegramProperties.Length == 0)
+        {
+            return JsonSerializer.SerializeToNode(value, value.GetType(), _serializerOptions);
+        }
+
+        var jsonObject = new JsonObject();
+        foreach (var property in metadata.TelegramProperties)
+        {
+            var propertyValue = property.GetValue(value);
+            if (propertyValue is null)
+            {
+                continue;
+            }
+
+            var node = ToJsonNode(propertyValue);
+            if (node is not null)
+            {
+                jsonObject[property.TelegramName] = node;
+            }
+        }
+
+        return jsonObject;
+    }
+
+    private void AddField(string name, JsonNode node)
+    {
+        var value = node switch
+        {
+            JsonValue jsonValue when jsonValue.TryGetValue<string>(out var stringValue) => stringValue,
+            JsonValue jsonValue when jsonValue.TryGetValue<bool>(out var boolValue) => boolValue ? "true" : "false",
+            _ => node.ToJsonString(_serializerOptions)
+        };
+
+        _fields.Add(new TelegramMultipartField(name, value));
+    }
+
+    private void AddFile(string name, InputFile inputFile)
+    {
+        if (!inputFile.Content.CanRead)
+        {
+            throw new InvalidOperationException(
+                $"InputFile '{inputFile.FileName}' cannot be uploaded because its stream is not readable.");
+        }
+
+        if (!inputFile.Content.CanSeek)
+        {
+            throw new InvalidOperationException(
+                $"InputFile '{inputFile.FileName}' cannot be uploaded by the default Telegram executor because its stream is not seekable. Use a seekable stream so retry behavior can resend the same content.");
+        }
+
+        inputFile.Content.Position = 0;
+        _files.Add(new TelegramMultipartFile(name, inputFile.FileName, inputFile.Content));
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestContentBuilder.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestContentBuilder.cs
@@ -1,18 +1,14 @@
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Globalization;
-using System.Reflection;
 using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
-using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal;
 
+/// <summary>
+/// Builds the transport-level request body for Telegram API method payloads.
+/// It keeps the normal JSON path cheap and delegates multipart-specific work only when upload data is present.
+/// This is reached by the Telegram request executor for every outgoing Bot API call, including ctx.Bot.*Async helpers.
+/// </summary>
 internal sealed class TelegramRequestContentBuilder
 {
-    private static readonly ConcurrentDictionary<Type, TypeMetadata> TypeMetadataCache = new();
-
     private readonly JsonSerializerOptions _serializerOptions;
 
     public TelegramRequestContentBuilder(JsonSerializerOptions serializerOptions)
@@ -24,300 +20,18 @@ internal sealed class TelegramRequestContentBuilder
     public TelegramTransportContent Build(object payload)
     {
         ArgumentNullException.ThrowIfNull(payload);
+        var payloadType = payload.GetType();
 
-        if (!ContainsInputFile(payload, new HashSet<object>(ReferenceEqualityComparer.Instance)))
+        // Telegram requests are JSON unless a concrete value contains an InputFile stream.
+        // The type check is the cheap hot-path proof; the value scan only runs for upload-capable shapes.
+        if (!TelegramRequestUploadDetector.MayContainInputFile(payloadType) ||
+            !TelegramRequestUploadDetector.ContainsInputFile(payload))
         {
-            var json = JsonSerializer.Serialize(payload, payload.GetType(), _serializerOptions);
+            var json = JsonSerializer.Serialize(payload, payloadType, _serializerOptions);
             return new TelegramJsonTransportContent(json);
         }
 
-        return BuildMultipart(payload);
-    }
-
-    private TelegramMultipartTransportContent BuildMultipart(object payload)
-    {
-        var context = new MultipartBuildContext(_serializerOptions);
-
-        foreach (var property in GetTypeMetadata(payload.GetType()).TelegramProperties)
-        {
-            var value = property.GetValue(payload);
-            if (value is null)
-            {
-                continue;
-            }
-
-            var fieldName = property.TelegramName;
-            if (TryGetDirectInputFile(value, out var inputFile))
-            {
-                context.AddFile(fieldName, inputFile);
-                continue;
-            }
-
-            var node = context.ToJsonNode(value);
-            if (node is null)
-            {
-                continue;
-            }
-
-            context.AddField(fieldName, node);
-        }
-
-        return context.Build();
-    }
-
-    private static bool ContainsInputFile(object? value, HashSet<object> visited)
-    {
-        if (value is null)
-        {
-            return false;
-        }
-
-        if (value is InputFile)
-        {
-            return true;
-        }
-
-        var type = value.GetType();
-        var metadata = GetTypeMetadata(type);
-
-        if (metadata.IsScalar || value is Stream)
-        {
-            return false;
-        }
-
-        if (!type.IsValueType && !visited.Add(value))
-        {
-            return false;
-        }
-
-        if (value is IEnumerable enumerable and not string)
-        {
-            foreach (var item in enumerable)
-            {
-                if (ContainsInputFile(item, visited))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        foreach (var property in metadata.ReadableProperties)
-        {
-            if (ContainsInputFile(property.GetValue(value), visited))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool TryGetDirectInputFile(object value, out InputFile inputFile)
-    {
-        if (value is InputFile direct)
-        {
-            inputFile = direct;
-            return true;
-        }
-
-        var unionCase = GetActiveUnionCase(value);
-        if (unionCase?.Value is InputFile nested)
-        {
-            inputFile = nested;
-            return true;
-        }
-
-        inputFile = null!;
-        return false;
-    }
-
-    private static ActiveUnionCase? GetActiveUnionCase(object value)
-    {
-        var metadata = GetTypeMetadata(value.GetType());
-        if (metadata.TelegramProperties.Length > 0)
-        {
-            return null;
-        }
-
-        var activeCases = metadata.ReadableProperties
-            .Select(property => new ActiveUnionCase(property.Name, property.GetValue(value)))
-            .Where(static item => item.Value is not null)
-            .ToArray();
-
-        return activeCases.Length == 1 ? activeCases[0] : null;
-    }
-
-    private static TypeMetadata GetTypeMetadata(Type type)
-    {
-        return TypeMetadataCache.GetOrAdd(type, CreateTypeMetadata);
-    }
-
-    private static TypeMetadata CreateTypeMetadata(Type type)
-    {
-        var readableProperties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-            .Where(static property => property.CanRead && property.GetIndexParameters().Length == 0)
-            .Select(static property => new PropertyMetadata(
-                property,
-                property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name))
-            .ToArray();
-
-        var telegramProperties = readableProperties
-            .Where(static property => property.JsonPropertyName is not null)
-            .ToArray();
-
-        var scalarType = Nullable.GetUnderlyingType(type) ?? type;
-        var isScalar = scalarType.IsPrimitive ||
-                       scalarType.IsEnum ||
-                       scalarType == typeof(string) ||
-                       scalarType == typeof(decimal) ||
-                       scalarType == typeof(DateTime) ||
-                       scalarType == typeof(DateTimeOffset) ||
-                       scalarType == typeof(Guid);
-
-        return new TypeMetadata(isScalar, readableProperties, telegramProperties);
-    }
-
-    private sealed class MultipartBuildContext
-    {
-        private readonly JsonSerializerOptions _serializerOptions;
-        private readonly List<TelegramMultipartField> _fields = [];
-        private readonly List<TelegramMultipartFile> _files = [];
-        private int _fileIndex;
-
-        public MultipartBuildContext(JsonSerializerOptions serializerOptions)
-        {
-            _serializerOptions = serializerOptions;
-        }
-
-        public TelegramMultipartTransportContent Build()
-        {
-            return new TelegramMultipartTransportContent(_fields.ToArray(), _files.ToArray());
-        }
-
-        public JsonNode? ToJsonNode(object? value)
-        {
-            if (value is null)
-            {
-                return null;
-            }
-
-            if (value is InputFile inputFile)
-            {
-                var fileName = "file" + _fileIndex.ToString(CultureInfo.InvariantCulture);
-                _fileIndex++;
-                AddFile(fileName, inputFile);
-                return JsonValue.Create("attach://" + fileName);
-            }
-
-            if (value is string stringValue)
-            {
-                return JsonValue.Create(stringValue);
-            }
-
-            if (value is bool boolValue)
-            {
-                return JsonValue.Create(boolValue);
-            }
-
-            if (value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
-            {
-                return JsonSerializer.SerializeToNode(value, value.GetType(), _serializerOptions);
-            }
-
-            if (value is IEnumerable enumerable and not string)
-            {
-                var array = new JsonArray();
-                foreach (var item in enumerable)
-                {
-                    array.Add(ToJsonNode(item));
-                }
-
-                return array;
-            }
-
-            var unionCase = GetActiveUnionCase(value);
-            if (unionCase is not null)
-            {
-                return ToJsonNode(unionCase.Value);
-            }
-
-            var metadata = GetTypeMetadata(value.GetType());
-            if (metadata.TelegramProperties.Length == 0)
-            {
-                return JsonSerializer.SerializeToNode(value, value.GetType(), _serializerOptions);
-            }
-
-            var jsonObject = new JsonObject();
-            foreach (var property in metadata.TelegramProperties)
-            {
-                var propertyValue = property.GetValue(value);
-                if (propertyValue is null)
-                {
-                    continue;
-                }
-
-                var node = ToJsonNode(propertyValue);
-                if (node is not null)
-                {
-                    jsonObject[property.TelegramName] = node;
-                }
-            }
-
-            return jsonObject;
-        }
-
-        public void AddField(string name, JsonNode node)
-        {
-            var value = node switch
-            {
-                JsonValue jsonValue when jsonValue.TryGetValue<string>(out var stringValue) => stringValue,
-                JsonValue jsonValue when jsonValue.TryGetValue<bool>(out var boolValue) => boolValue ? "true" : "false",
-                _ => node.ToJsonString(_serializerOptions)
-            };
-
-            _fields.Add(new TelegramMultipartField(name, value));
-        }
-
-        public void AddFile(string name, InputFile inputFile)
-        {
-            if (!inputFile.Content.CanRead)
-            {
-                throw new InvalidOperationException(
-                    $"InputFile '{inputFile.FileName}' cannot be uploaded because its stream is not readable.");
-            }
-
-            if (!inputFile.Content.CanSeek)
-            {
-                throw new InvalidOperationException(
-                    $"InputFile '{inputFile.FileName}' cannot be uploaded by the default Telegram executor because its stream is not seekable. Use a seekable stream so retry behavior can resend the same content.");
-            }
-
-            inputFile.Content.Position = 0;
-            _files.Add(new TelegramMultipartFile(name, inputFile.FileName, inputFile.Content));
-        }
-    }
-
-    private sealed record ActiveUnionCase(string Name, object? Value);
-
-    private sealed record TypeMetadata(
-        bool IsScalar,
-        PropertyMetadata[] ReadableProperties,
-        PropertyMetadata[] TelegramProperties);
-
-    private sealed record PropertyMetadata(PropertyInfo Property, string? JsonPropertyName)
-    {
-        public string Name => Property.Name;
-
-        public string TelegramName =>
-            JsonPropertyName ??
-            throw new InvalidOperationException(
-                $"Telegram payload property '{Property.DeclaringType?.FullName}.{Property.Name}' is missing JsonPropertyName metadata.");
-
-        public object? GetValue(object value)
-        {
-            return Property.GetValue(value);
-        }
+        var builder = new TelegramMultipartContentBuilder(_serializerOptions);
+        return builder.Build(payload);
     }
 }

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestTypeMetadata.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestTypeMetadata.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json.Serialization;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Caches reflection metadata used by Telegram request content building.
+/// The cache keeps JSON property discovery, ignored-property handling, and scalar detection in one place.
+/// It is shared by JSON/multipart routing and multipart rendering so both paths interpret generated schema types consistently.
+/// </summary>
+internal static class TelegramRequestTypeMetadataCache
+{
+    private static readonly ConcurrentDictionary<Type, TelegramRequestTypeMetadata> MetadataCache = new();
+
+    public static TelegramRequestTypeMetadata Get(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return MetadataCache.GetOrAdd(type, Create);
+    }
+
+    public static bool IsScalarType(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        var scalarType = Nullable.GetUnderlyingType(type) ?? type;
+
+        return scalarType.IsPrimitive ||
+               scalarType.IsEnum ||
+               scalarType == typeof(string) ||
+               scalarType == typeof(decimal) ||
+               scalarType == typeof(DateTime) ||
+               scalarType == typeof(DateTimeOffset) ||
+               scalarType == typeof(Guid);
+    }
+
+    private static TelegramRequestTypeMetadata Create(Type type)
+    {
+        var readableProperties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(static property => property.CanRead && property.GetIndexParameters().Length == 0)
+            // Keep reflection metadata aligned with System.Text.Json and avoid evaluating ignored getters
+            // while deciding whether a request needs multipart.
+            .Where(static property => !IsAlwaysJsonIgnored(property))
+            .Select(static property => new TelegramRequestPropertyMetadata(
+                property,
+                property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name))
+            .ToArray();
+
+        var telegramProperties = readableProperties
+            .Where(static property => property.JsonPropertyName is not null)
+            .ToArray();
+
+        return new TelegramRequestTypeMetadata(IsScalarType(type), readableProperties, telegramProperties);
+    }
+
+    private static bool IsAlwaysJsonIgnored(PropertyInfo property)
+    {
+        var ignore = property.GetCustomAttribute<JsonIgnoreAttribute>();
+        return ignore?.Condition == JsonIgnoreCondition.Always;
+    }
+}
+
+/// <summary>
+/// Reflection snapshot for one request-related CLR type.
+/// It separates all readable properties from Telegram JSON fields discovered through JsonPropertyName metadata.
+/// </summary>
+internal sealed record TelegramRequestTypeMetadata(
+    bool IsScalar,
+    TelegramRequestPropertyMetadata[] ReadableProperties,
+    TelegramRequestPropertyMetadata[] TelegramProperties);
+
+/// <summary>
+/// Reflection wrapper around a readable CLR property and its optional Telegram JSON field name.
+/// Multipart rendering uses it to read CLR values and write Telegram field names without repeating reflection rules.
+/// </summary>
+internal sealed record TelegramRequestPropertyMetadata(PropertyInfo Property, string? JsonPropertyName)
+{
+    public Type PropertyType => Property.PropertyType;
+
+    public string Name => Property.Name;
+
+    public string TelegramName =>
+        JsonPropertyName ??
+        throw new InvalidOperationException(
+            $"Telegram payload property '{Property.DeclaringType?.FullName}.{Property.Name}' is missing JsonPropertyName metadata.");
+
+    public object? GetValue(object value)
+    {
+        return Property.GetValue(value);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestUploadDetector.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestUploadDetector.cs
@@ -1,0 +1,216 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Detects whether a Telegram request payload can contain files that must be sent as multipart content.
+/// This protects the common JSON-only path from unnecessary recursive object scans.
+/// It is used before sending outgoing Bot API requests such as sendMessage, sendPhoto, and media groups.
+/// </summary>
+internal static class TelegramRequestUploadDetector
+{
+    private static readonly ConcurrentDictionary<Type, bool> CapabilityCache = new();
+
+    // Type-level proof used before touching object values.
+    // false means "cannot contain InputFile"; true means "maybe, inspect the actual value".
+    public static bool MayContainInputFile(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        return CapabilityCache.GetOrAdd(
+            type,
+            static candidate => MayContainInputFile(candidate, []));
+    }
+
+    public static bool ContainsInputFile(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return ContainsInputFile(value, new HashSet<object>(ReferenceEqualityComparer.Instance));
+    }
+
+    // Top-level method properties can be InputFile directly, or a generated union wrapper whose
+    // selected case is InputFile. Both are sent as normal multipart file fields.
+    public static bool TryGetDirectInputFile(object value, out InputFile inputFile)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (value is InputFile direct)
+        {
+            inputFile = direct;
+            return true;
+        }
+
+        var unionCase = GetActiveUnionCase(value);
+        if (unionCase?.Value is InputFile nested)
+        {
+            inputFile = nested;
+            return true;
+        }
+
+        inputFile = null!;
+        return false;
+    }
+
+    // Generated Telegram union wrappers have no [JsonPropertyName] fields of their own.
+    // Exactly one non-null public property is treated as the active union case.
+    public static TelegramActiveUnionCase? GetActiveUnionCase(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        var metadata = TelegramRequestTypeMetadataCache.Get(value.GetType());
+        if (metadata.TelegramProperties.Length > 0)
+        {
+            return null;
+        }
+
+        var activeCases = metadata.ReadableProperties
+            .Select(property => new TelegramActiveUnionCase(property.Name, property.GetValue(value)))
+            .Where(static item => item.Value is not null)
+            .ToArray();
+
+        return activeCases.Length == 1 ? activeCases[0] : null;
+    }
+
+    private static bool ContainsInputFile(object? value, HashSet<object> visited)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (value is InputFile)
+        {
+            return true;
+        }
+
+        var type = value.GetType();
+        if (!MayContainInputFile(type))
+        {
+            return false;
+        }
+
+        var metadata = TelegramRequestTypeMetadataCache.Get(type);
+        if (metadata.IsScalar || value is Stream)
+        {
+            return false;
+        }
+
+        if (!type.IsValueType && !visited.Add(value))
+        {
+            return false;
+        }
+
+        if (value is IEnumerable enumerable and not string)
+        {
+            foreach (var item in enumerable)
+            {
+                if (ContainsInputFile(item, visited))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        foreach (var property in metadata.ReadableProperties)
+        {
+            if (ContainsInputFile(property.GetValue(value), visited))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MayContainInputFile(Type type, HashSet<Type> visiting)
+    {
+        var candidate = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (candidate == typeof(InputFile))
+        {
+            return true;
+        }
+
+        if (TelegramRequestTypeMetadataCache.IsScalarType(candidate) ||
+            typeof(Stream).IsAssignableFrom(candidate))
+        {
+            return false;
+        }
+
+        if (candidate == typeof(object) || candidate.IsGenericParameter)
+        {
+            return true;
+        }
+
+        if (TryGetEnumerableElementType(candidate, out var elementType))
+        {
+            return elementType is null || MayContainInputFile(elementType, visiting);
+        }
+
+        // Interfaces, abstract classes, and replaceable classes are conservative by design:
+        // the declared type may be safe, but a runtime implementation/subclass may contain InputFile.
+        if (candidate.IsInterface || candidate.IsAbstract || !candidate.IsSealed)
+        {
+            return true;
+        }
+
+        // This guard is for recursive type graphs. Runtime object cycles are handled by
+        // ContainsInputFile with reference equality tracking.
+        if (!visiting.Add(candidate))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var property in TelegramRequestTypeMetadataCache.Get(candidate).ReadableProperties)
+            {
+                if (MayContainInputFile(property.PropertyType, visiting))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            visiting.Remove(candidate);
+        }
+    }
+
+    private static bool TryGetEnumerableElementType(Type type, out Type? elementType)
+    {
+        if (type == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            elementType = null;
+            return false;
+        }
+
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType();
+            return true;
+        }
+
+        var enumerableType = type
+            .GetInterfaces()
+            .Append(type)
+            .FirstOrDefault(static candidate =>
+                candidate.IsGenericType &&
+                candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        elementType = enumerableType?.GetGenericArguments()[0];
+        return true;
+    }
+}
+
+/// <summary>
+/// Represents the selected case of a generated Telegram union wrapper.
+/// Request content builders use it to serialize unions as the active value expected by Telegram.
+/// </summary>
+internal sealed record TelegramActiveUnionCase(string Name, object? Value);

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -928,6 +929,47 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.StartsWith("multipart/form-data", request.ContentType, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("name=photo", request.Body);
         Assert.Contains("filename=photo.png", request.Body);
+    }
+
+    [Fact]
+    public async Task Executor_UsesJsonForUploadCapableMethodWithExistingFileId()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":true,"result":{"message_id":10,"date":0,"chat":{"id":123,"type":"private"}}}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(handler);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        await client.SendAsync(
+            new SendPhoto
+            {
+                ChatId = IntegerString.From(123),
+                Photo = InputFileString.From("photo-file-id")
+            });
+
+        var request = handler.Requests.Single();
+        Assert.StartsWith("application/json", request.ContentType, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"photo\":\"photo-file-id\"", request.Body);
+    }
+
+    [Fact]
+    public async Task Executor_UsesJsonFastPathForPayloadTypesThatCannotContainInputFiles()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse("""{"ok":true,"result":true}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(handler);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var result = await client.SendAsync(new JsonOnlyProbeMethod { Value = "ok" });
+
+        var request = handler.Requests.Single();
+        Assert.True(result);
+        Assert.EndsWith("/jsonOnlyProbe", request.RequestUri, StringComparison.Ordinal);
+        Assert.StartsWith("application/json", request.ContentType, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"value\":\"ok\"", request.Body);
+        Assert.DoesNotContain("poison", request.Body, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -3282,6 +3324,18 @@ public sealed class TelegramRuntimeIntegrationTests
 
             return _responses.Dequeue();
         }
+    }
+
+    private sealed partial record class JsonOnlyProbeMethod : ITelegramApiMethod<bool>
+    {
+        public static string MethodName => "jsonOnlyProbe";
+
+        [JsonPropertyName("value")]
+        public required string Value { get; init; }
+
+        [JsonIgnore]
+        public object Poison =>
+            throw new InvalidOperationException("JSON-only request content should not scan ignored properties.");
     }
 
     private sealed class RecordingTelegramTransport : ITelegramTransport


### PR DESCRIPTION
## Summary
- add a JSON-only fast path for Telegram request payloads whose CLR type cannot contain `InputFile`
- preserve multipart behavior for direct and nested uploads, including generated union wrappers
- split request content building into focused internal components with type-level summaries for easier review
- cover existing file-id uploads and JSON-only payloads with regression tests

## Touched hot paths
- `TelegramRequestContentBuilder` now avoids recursive value scans when type metadata proves that a request cannot contain upload streams.
- `TelegramRequestUploadDetector` owns upload capability checks and value scans.
- `TelegramMultipartContentBuilder` keeps multipart rendering isolated from JSON-only request routing.
- `TelegramRequestTypeMetadataCache` shares reflection metadata between routing and multipart rendering.

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "Executor_UsesJsonFastPathForPayloadTypesThatCannotContainInputFiles|Executor_UsesJsonForUploadCapableMethodWithExistingFileId|Executor_UsesMultipartForInputFileString|Executor_UsesAttachReferencesForNestedMediaFiles" --no-restore`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "TelegramRuntimeIntegrationTests" --no-restore`
- `dotnet build TeleFlow.sln --no-restore`
- `dotnet test TeleFlow.sln --no-build`
- `git diff --check`
- `git diff --cached --check`

Closes #52