### PR TITLE
docs(release): add alpha4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 No unreleased changes.
 
+## 1.0.0-alpha.4 - 2026-06-30
+
+This alpha focuses on runtime hot-path reductions, scoped middleware lifetimes, explicit keyboard markup ownership, generated Bot API constants, and release workflow hardening.
+
+### Added
+
+- Telegram announcement workflow for release, pull request, and issue notifications.
+- Generated Bot API discriminator constants adoption for documented keyboard button styles.
+
+### Changed
+
+- Update middleware is resolved from the per-update scope, so middleware can depend on scoped application services such as repositories.
+- Inline keyboard creation now uses an explicit `InlineKeyboardBuilder.Build()` step that returns native `InlineKeyboardMarkup`.
+- Handler timing details are collected only when debug logging is enabled.
+- State hydration snapshot semantics were clarified after review, including how failed storage reads interact with cached update state.
+- State data and wizard wrappers are created lazily per update.
+- Telegram error handlers are pre-indexed for exception-path dispatch.
+- Handler selection, filter evaluation, typed callback route misses, compact callback metadata lookup, and JSON-only request content building now avoid several avoidable runtime allocations or scans.
+- Generated Telegram schema output was refreshed with grouped discriminator constants.
+- Telegram announcement summaries were reformatted for clearer public issue, pull request, and release messages.
+- GitHub Actions dependencies and NuGet symbol package publishing were hardened.
+
+### Fixed
+
+- Scoped repositories and services can now be consumed from update middleware without singleton lifetime validation failures.
+- Callback route candidate checks no longer use exception-driven no-match flow for typed callback payloads.
+- JSON-only Telegram requests no longer recursively scan payload values when the request type cannot contain upload streams.
+- Duplicate NuGet symbol package push behavior was removed from the publish workflow.
+
+### Breaking Changes
+
+- Inline keyboard builders must be converted to native markup explicitly with `.Build()` before being passed to Telegram methods or message helpers.
+
+### Notes
+
+- Final typed keyboard callback serialization ownership is intentionally not finalized in this alpha. The design work continues in `1.0.0-alpha.5`.
+
 ## 1.0.0-alpha.3 - 2026-06-28
 
 This alpha focuses on framework trust, state consistency, package readability, and documentation polish.


### PR DESCRIPTION
## Summary
- add the `1.0.0-alpha.4` changelog section
- document scoped middleware, keyboard API, runtime performance, schema refresh, and CI/release workflow changes
- call out the explicit `InlineKeyboardBuilder.Build()` breaking change and alpha.5 keyboard callback serialization follow-up

## Validation
- `git diff --check`