### PR TITLE
chore(framework): deprecate reflection assembly registration

### DIFF
--- a/docs/en/advanced/generated-registration.md
+++ b/docs/en/advanced/generated-registration.md
@@ -1,10 +1,11 @@
 # Generated Registration
 
-TeleFlow has three handler registration paths:
+TeleFlow has two supported handler registration paths for new code:
 
 1. generated assembly registration;
-2. explicit direct registration;
-3. explicit reflection assembly registration.
+2. explicit direct registration.
+
+A deprecated reflection assembly API still exists as a temporary migration path before `1.0`.
 
 The recommended default for application code is generated assembly registration.
 
@@ -16,7 +17,7 @@ That gives three practical benefits:
 
 - missing metadata is caught during startup;
 - generated metadata can be checked by analyzers;
-- reflection is an explicit opt-in path, not a silent fallback.
+- reflection is not a silent fallback for assembly registration.
 
 ## Setup
 
@@ -72,15 +73,15 @@ Use it for:
 - manually composed modules;
 - situations where the handler list should be obvious at the registration site.
 
-## Reflection Registration
+## Deprecated Reflection Registration
 
-Reflection registration exists as an explicit API:
+Reflection assembly registration is deprecated and will be removed before `1.0`:
 
 ```csharp
 builder.Services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
 ```
 
-Use it only when the application intentionally chooses reflection-based discovery.
+Do not use it for new projects. Use generated assembly registration for normal applications, or direct registration when the handler list should be explicit at the registration site.
 
 ## What Gets Generated
 
@@ -142,4 +143,4 @@ For production apps:
 - use generated assembly registration by default;
 - keep `IWF.TeleFlow.Generators` private with `PrivateAssets="all"`;
 - use direct registration in tests where it improves clarity;
-- avoid reflection registration unless there is a documented reason.
+- treat reflection assembly registration as a deprecated migration path only.

--- a/docs/en/enterprise/index.md
+++ b/docs/en/enterprise/index.md
@@ -32,7 +32,7 @@ Or:
 builder.Services.AddWebhook(options => options.Path = "/telegram/webhook");
 ```
 
-Use generated registration as the default. Use reflection registration only when it is written down as an intentional decision.
+Use generated registration as the default. Use explicit handler/module registration for narrow manual composition. Deprecated reflection assembly registration should not be used in new production code.
 
 ## Boundaries
 

--- a/docs/en/enterprise/production-checklist.md
+++ b/docs/en/enterprise/production-checklist.md
@@ -19,7 +19,7 @@ Related pages:
 - Use generated assembly registration by default.
 - Keep at least one startup test that exercises generated registration.
 - Use direct registration for narrow tests.
-- Avoid reflection registration unless documented.
+- Avoid deprecated reflection assembly registration in new production code.
 
 ## Transport
 

--- a/docs/en/getting-started/packages.md
+++ b/docs/en/getting-started/packages.md
@@ -110,13 +110,13 @@ services.AddTelegramHandler<StartHandler>();
 services.AddTelegramModule<AdminModule>();
 ```
 
-Reflection assembly registration exists as a separate opt-in API:
+Reflection assembly registration is deprecated and will be removed before `1.0`:
 
 ```csharp
 services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
 ```
 
-Use it only when the application intentionally accepts reflection-based discovery.
+Do not use it for new projects. Use generated assembly registration, or register handlers/modules explicitly when the handler list should be manual.
 
 ## Client-Only Applications
 

--- a/docs/en/getting-started/recommended-paths.md
+++ b/docs/en/getting-started/recommended-paths.md
@@ -34,7 +34,7 @@ public sealed class StartHandler
 }
 ```
 
-Do not start with custom middleware, custom storage, webhook deployment, or reflection registration. Those are useful later, but they slow down the first bot.
+Do not start with custom middleware, custom storage, webhook deployment, or deprecated reflection assembly registration. Middleware, storage, and webhooks are useful later; reflection assembly registration is a migration path only.
 
 ## If You Are Building A Real Product
 
@@ -72,7 +72,7 @@ Prefer explicit boundaries and observable failure:
 
 - use generated registration for assembly discovery;
 - use direct registration in tests and narrow modules;
-- avoid reflection registration unless the application intentionally accepts it;
+- avoid deprecated reflection assembly registration in new code;
 - treat state storage as infrastructure, not as an in-memory convenience;
 - keep transport choice documented;
 - verify package graph in CI;

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -147,5 +147,5 @@ The current repository includes:
 - state, state data, wizard navigation, and memory storage;
 - long polling and ASP.NET Core webhook adapters;
 - raw long polling and raw webhook packages;
-- generated handler registration, explicit direct registration, and explicit reflection registration;
+- generated handler registration and explicit direct registration;
 - middleware, update processor, update source, dispatcher, storage, callback serializer, and client replacement points.

--- a/docs/en/reference/troubleshooting.md
+++ b/docs/en/reference/troubleshooting.md
@@ -30,11 +30,13 @@ If you intentionally do not want generated registration, use:
 builder.Services.AddTelegramHandler<StartHandler>();
 ```
 
-Or:
+Or register a module explicitly:
 
 ```csharp
-builder.Services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
+builder.Services.AddTelegramModule<AdminHandlers>();
 ```
+
+Do not switch to deprecated reflection assembly registration to fix missing generated metadata.
 
 ## Can I Read The Token From `appsettings.json`?
 

--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -28,7 +28,7 @@ Target state:
 - Allow policies such as per-user, per-chat, per-user-per-chat, per-command, and custom keys.
 - Support memory storage for simple bots and a replaceable distributed storage contract for production deployments.
 - Provide explicit rejection behavior: skip silently, answer the user, throw a typed exception, or call a configured rejection delegate.
-- Preserve generated/reflection registration parity.
+- Keep generated assembly registration as the primary path and keep explicit registration predictable.
 - Keep policy application visible in handler metadata so debugging does not depend on hidden runtime conventions.
 
 Possible public shape:
@@ -117,13 +117,13 @@ Target state:
 - Review and freeze public API names, package graph, handler metadata, diagnostics, and registration behavior.
 - Remove or mark transitional APIs before stable packages are published.
 - Keep `TeleFlow.Core` transport-agnostic, generated schema DTOs framework-free, and framework runtime behavior inside Telegram framework packages.
-- Keep generated assembly registration as the recommended production path, with explicit reflection registration remaining opt-in.
+- Keep generated assembly registration as the recommended production path, with deprecated reflection assembly registration on a removal path before `1.0`.
 - Make quickstart, package guide, enterprise docs, samples, and release notes match the actual packages and APIs.
 
 Expected outcome:
 
 - CI, release verification, package graph tests, analyzer tests, and representative sample builds are green.
-- Generated registration and explicit reflection registration have parity for supported framework semantics.
+- Generated registration is the production assembly path, and explicit handler/module registration has documented semantics.
 - Documentation describes current behavior only; planned features remain in this roadmap.
 - Release notes state alpha/stable status, breaking-change rules, supported .NET versions, and Telegram Bot API schema version.
 
@@ -218,7 +218,7 @@ Rules:
 - Typed state data must be explicit; TeleFlow must not silently track mutable objects and auto-save them after handler execution.
 - State data is a runtime cursor for conversational progress. Durable domain history belongs in application repositories or databases.
 - Complex question-level machines belong in application/domain code, stored as typed state data, not as a heavy nested FSM DSL in TeleFlow core.
-- Generated and reflection registration must support the same state enter and typed state data behavior.
+- Generated registration and explicit handler/module registration must support documented state enter and typed state data behavior.
 
 Expected outcome:
 
@@ -340,7 +340,7 @@ Expected outcome:
 - Runtime permission changes affect later updates without redeploy.
 - Module-level and handler-level requirements combine deterministically.
 - Access checks are testable without Telegram network access.
-- Generated and explicit reflection registration produce equivalent ACL metadata.
+- Generated registration and explicit handler/module registration produce documented ACL metadata.
 
 ## Distributed Runtime
 
@@ -383,7 +383,7 @@ Current state:
 
 - Client-only AOT smoke verification exists as an engineering target.
 - Full client request serialization AOT support depends on generated JSON metadata and avoiding runtime reflection in request serialization and multipart metadata.
-- Full framework NativeAOT support is a separate track because handler reflection registration and DI invocation have different constraints.
+- Full framework NativeAOT support is a separate track because handler registration and DI invocation have different constraints.
 
 Target state:
 

--- a/docs/ru/advanced/generated-registration.md
+++ b/docs/ru/advanced/generated-registration.md
@@ -1,10 +1,11 @@
 # Generated registration
 
-В TeleFlow есть три пути регистрации handlers:
+В TeleFlow есть два поддерживаемых пути регистрации handlers для нового кода:
 
 1. generated assembly registration;
-2. explicit direct registration;
-3. explicit reflection assembly registration.
+2. explicit direct registration.
+
+Deprecated reflection assembly API остаётся только как временный migration path до `1.0`.
 
 Рекомендуемый default для application code - generated assembly registration.
 
@@ -16,7 +17,7 @@ Assembly scanning удобен, но runtime reflection как скрытый de
 
 - missing metadata ловится на startup;
 - generated metadata можно проверять analyzers;
-- reflection становится explicit opt-in path, а не silent fallback.
+- reflection не является silent fallback для assembly registration.
 
 ## Настройка
 
@@ -72,15 +73,15 @@ builder.Services.AddTelegramModule<AdminHandlers>();
 - manually composed modules;
 - случаев, когда handler list должен быть очевиден на registration site.
 
-## Reflection registration
+## Deprecated reflection registration
 
-Reflection registration существует как explicit API:
+Reflection assembly registration объявлен deprecated и будет удалён до `1.0`:
 
 ```csharp
 builder.Services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
 ```
 
-Используй его только когда приложение осознанно выбирает reflection-based discovery.
+Не используй его в новых проектах. Для обычных приложений используй generated assembly registration, а для ручного контроля - direct registration с явным списком handlers/modules.
 
 ## Что генерируется
 
@@ -142,4 +143,4 @@ Generated metadata описывает:
 - используй generated assembly registration by default;
 - держи `IWF.TeleFlow.Generators` private через `PrivateAssets="all"`;
 - используй direct registration в tests, где это улучшает clarity;
-- избегай reflection registration, если нет documented reason.
+- используй reflection assembly registration только как deprecated migration path во время миграции.

--- a/docs/ru/enterprise/production-checklist.md
+++ b/docs/ru/enterprise/production-checklist.md
@@ -19,7 +19,7 @@
 - Use generated assembly registration by default.
 - Держи хотя бы один startup test, который проверяет generated registration.
 - Direct registration используй для узких tests.
-- Избегай reflection registration, если он не documented.
+- Избегай deprecated reflection assembly registration в новом production code.
 
 ## Транспорт
 

--- a/docs/ru/getting-started/packages.md
+++ b/docs/ru/getting-started/packages.md
@@ -110,13 +110,13 @@ services.AddTelegramHandler<StartHandler>();
 services.AddTelegramModule<AdminModule>();
 ```
 
-Reflection assembly registration существует как отдельный opt-in API:
+Reflection assembly registration объявлен deprecated и будет удалён до `1.0`:
 
 ```csharp
 services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
 ```
 
-Используй его только если приложение осознанно принимает reflection-based discovery.
+Не используй его в новых проектах. Используй generated assembly registration, либо регистрируй handlers/modules явно, если список должен быть ручным.
 
 ## Client-only приложения
 

--- a/docs/ru/getting-started/recommended-paths.md
+++ b/docs/ru/getting-started/recommended-paths.md
@@ -34,7 +34,7 @@ public sealed class StartHandler
 }
 ```
 
-Не начинай с custom middleware, custom storage, webhook deployment или reflection registration. Это полезно позже, но замедляет первый бот.
+Не начинай с custom middleware, custom storage, webhook deployment или deprecated reflection assembly registration. Middleware, storage и webhooks пригодятся позже; reflection assembly registration остаётся только migration path.
 
 ## Если ты делаешь реальный продукт
 
@@ -72,7 +72,7 @@ Infrastructure/
 
 - используй generated registration для assembly discovery;
 - используй direct registration в tests и узких modules;
-- не используй reflection registration, если приложение не принимает это осознанно;
+- не используй deprecated reflection assembly registration в новом коде;
 - считай state storage инфраструктурой, а не удобной in-memory деталью;
 - документируй transport choice;
 - проверяй package graph в CI;

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -147,5 +147,5 @@ TeleFlow создан для момента, когда простой Telegram-
 - state, state data, wizard navigation и memory storage;
 - long polling и ASP.NET Core webhook adapters;
 - raw long polling и raw webhook packages;
-- generated handler registration, explicit direct registration и explicit reflection registration;
+- generated handler registration и explicit direct registration;
 - replacement points для middleware, update processor, update source, dispatcher, storage, callback serializer и client.

--- a/docs/ru/reference/troubleshooting.md
+++ b/docs/ru/reference/troubleshooting.md
@@ -30,11 +30,13 @@ builder.Services.AddLongPolling();
 builder.Services.AddTelegramHandler<StartHandler>();
 ```
 
-Или:
+Или зарегистрируй module явно:
 
 ```csharp
-builder.Services.AddTelegramHandlersFromAssemblyReflection(typeof(Program).Assembly);
+builder.Services.AddTelegramModule<AdminHandlers>();
 ```
+
+Не переходи на deprecated reflection assembly registration как способ починить missing generated metadata.
 
 ## Можно ли читать token из `appsettings.json`?
 

--- a/docs/ru/roadmap.md
+++ b/docs/ru/roadmap.md
@@ -28,7 +28,7 @@
 - Поддержать policies: per-user, per-chat, per-user-per-chat, per-command и custom keys.
 - Дать memory storage для простых ботов и заменяемый distributed storage contract для production deployments.
 - Сделать явное поведение при превышении лимита: пропустить молча, ответить пользователю, бросить typed exception или вызвать настроенный rejection delegate.
-- Сохранить parity между generated и reflection registration.
+- Оставить generated assembly registration основным путем и сделать explicit registration предсказуемым.
 - Держать policy application видимой в handler metadata, чтобы debugging не зависел от скрытых runtime conventions.
 
 Возможная форма public API:
@@ -117,13 +117,13 @@ Non-goals для первой реализации:
 - Проверить и заморозить public API names, package graph, handler metadata, diagnostics и registration behavior.
 - Удалить или явно пометить transitional APIs до публикации stable packages.
 - Держать `TeleFlow.Core` transport-agnostic, generated schema DTOs свободными от framework behavior, а framework runtime behavior внутри Telegram framework packages.
-- Оставить generated assembly registration рекомендуемым production path, а explicit reflection registration - opt-in путем.
+- Оставить generated assembly registration рекомендуемым production path, а deprecated reflection assembly registration поставить на путь удаления до `1.0`.
 - Синхронизировать quickstart, package guide, enterprise docs, samples и release notes с реальными packages и APIs.
 
 Нужный результат:
 
 - CI, release verification, package graph tests, analyzer tests и representative sample builds зелёные.
-- Generated registration и explicit reflection registration имеют parity для поддерживаемых framework semantics.
+- Generated registration является production assembly path, а explicit handler/module registration имеет documented semantics.
 - Документация описывает текущее поведение; planned features остаются только в roadmap.
 - Release notes фиксируют alpha/stable status, breaking-change rules, supported .NET versions и Telegram Bot API schema version.
 
@@ -218,7 +218,7 @@ public async Task EnterQuestion(
 - Typed state data должен быть явным; TeleFlow не должен скрыто отслеживать mutable objects и auto-save после handler execution.
 - State data - это runtime cursor для conversational progress. Durable domain history должна жить в application repositories или databases.
 - Complex question-level machines должны жить в application/domain code и храниться как typed state data, а не превращаться в тяжёлый nested FSM DSL внутри TeleFlow core.
-- Generated и reflection registration должны поддерживать одинаковое state enter и typed state data behavior.
+- Generated registration и explicit handler/module registration должны поддерживать documented state enter и typed state data behavior.
 
 Нужный результат:
 
@@ -340,7 +340,7 @@ public async Task EnterQuestion(
 - Runtime permission changes влияют на следующие updates без redeploy.
 - Module-level и handler-level requirements combine deterministically.
 - Access checks тестируются без Telegram network access.
-- Generated и explicit reflection registration дают equivalent ACL metadata.
+- Generated registration и explicit handler/module registration дают documented ACL metadata.
 
 ## Distributed runtime
 
@@ -383,7 +383,7 @@ public async Task EnterQuestion(
 
 - Client-only AOT smoke verification существует как engineering target.
 - Full client request serialization AOT support зависит от generated JSON metadata и отказа от runtime reflection в request serialization и multipart metadata.
-- Full framework NativeAOT support - отдельный track, потому что handler reflection registration и DI invocation имеют другие constraints.
+- Full framework NativeAOT support - отдельный track, потому что handler registration и DI invocation имеют разные constraints.
 
 Целевое состояние:
 

--- a/src/TeleFlow.Telegram.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Telegram.Framework/TelegramServiceCollectionExtensions.cs
@@ -12,6 +12,12 @@ namespace TeleFlow.Telegram;
 
 public static class TelegramServiceCollectionExtensions
 {
+    private const string ReflectionAssemblyRegistrationObsoleteDiagnosticId = "TLF900";
+
+    private const string ReflectionAssemblyRegistrationObsoleteMessage =
+        "Reflection-based assembly handler registration is deprecated and will be removed before 1.0. " +
+        "Use AddTelegramHandlersFromAssembly with IWF.TeleFlow.Generators, or register handlers explicitly with AddTelegramHandler<THandler> / AddTelegramModule<TModule>.";
+
     public static IServiceCollection AddTelegramBot(
         this IServiceCollection services,
         Action<TelegramBotOptions> configure)
@@ -105,6 +111,9 @@ public static class TelegramServiceCollectionExtensions
             $"Use {nameof(AddTelegramHandler)}<THandler>() or {nameof(AddTelegramModule)}<TModule>() for explicit direct registration.");
     }
 
+    [Obsolete(
+        ReflectionAssemblyRegistrationObsoleteMessage,
+        DiagnosticId = ReflectionAssemblyRegistrationObsoleteDiagnosticId)]
     public static IServiceCollection AddTelegramHandlersFromAssemblyReflection(
         this IServiceCollection services,
         Assembly assembly)

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -339,6 +339,26 @@ public sealed class PublicSurfaceTests
     }
 
     [Fact]
+    public void TelegramFramework_ReflectionAssemblyRegistration_IsObsolete()
+    {
+        var method = typeof(TeleFlow.Telegram.TelegramServiceCollectionExtensions).GetMethod(
+            nameof(TeleFlow.Telegram.TelegramServiceCollectionExtensions.AddTelegramHandlersFromAssemblyReflection),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var obsolete = method.GetCustomAttribute<ObsoleteAttribute>();
+
+        Assert.NotNull(obsolete);
+        Assert.False(obsolete.IsError);
+        Assert.Equal("TLF900", obsolete.DiagnosticId);
+        Assert.Contains("Reflection-based assembly handler registration is deprecated", obsolete.Message);
+        Assert.Contains("IWF.TeleFlow.Generators", obsolete.Message);
+        Assert.Contains("AddTelegramHandler<THandler>", obsolete.Message);
+        Assert.Contains("AddTelegramModule<TModule>", obsolete.Message);
+    }
+
+    [Fact]
     public void Telegram_PublicSurface_DoesNotDeclareDuplicateFrameworkRuntimeTypes()
     {
         var exportedTypeNames = LoadProjectAssembly("TeleFlow.Telegram")

--- a/tests/TeleFlow.ArchitectureTests/TelegramReflectionAssemblyRegistrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramReflectionAssemblyRegistrationTests.cs
@@ -13,6 +13,8 @@ using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.ArchitectureTests;
 
+#pragma warning disable TLF900 // These tests intentionally cover deprecated reflection assembly registration until removal.
+
 public sealed class TelegramReflectionAssemblyRegistrationTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- mark reflection-based assembly handler registration as deprecated with `TLF900`
- keep generated assembly registration and explicit handler/module registration behavior unchanged
- update EN/RU docs to present reflection assembly registration as a deprecated migration path before 1.0

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~TelegramReflectionAssemblyRegistrationTests|FullyQualifiedName~TelegramFramework_ReflectionAssemblyRegistration_IsObsolete"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj`
- `git diff --check`

Closes #90