### PR TITLE
fix(generator): report routeless handler constraints

### DIFF
--- a/docs/en/features/state-and-wizard.md
+++ b/docs/en/features/state-and-wizard.md
@@ -38,6 +38,7 @@ public sealed class RegistrationHandlers
         await ctx.Message.AnswerAsync("What is your name?", ct);
     }
 
+    [Message]
     [State(RegistrationStates.Name)]
     [HasText]
     public async Task Name(MessageContext ctx, CancellationToken ct)
@@ -47,6 +48,7 @@ public sealed class RegistrationHandlers
         await ctx.Message.AnswerAsync("How old are you?", ct);
     }
 
+    [Message]
     [State(RegistrationStates.Age)]
     [HasText]
     public async Task Age(MessageContext ctx, CancellationToken ct)
@@ -107,6 +109,7 @@ public sealed class TicketWizard
         await ctx.Message.AnswerAsync("Choose category.", ct);
     }
 
+    [Message]
     [State("ticket:category")]
     [HasText]
     public async Task Category(MessageContext ctx, CancellationToken ct)
@@ -116,6 +119,7 @@ public sealed class TicketWizard
         await ctx.Message.AnswerAsync("Describe the issue.", ct);
     }
 
+    [Message]
     [State("ticket:description")]
     [Text("back")]
     public async Task Back(MessageContext ctx, CancellationToken ct)
@@ -155,6 +159,7 @@ public sealed class TicketScene
         await ctx.Message.AnswerAsync("Choose category.", ct);
     }
 
+    [Message]
     [SceneStep(nameof(Category))]
     [HasText]
     public Task CategoryStep(MessageContext ctx, CancellationToken ct)

--- a/docs/en/fundamentals/filters.md
+++ b/docs/en/fundamentals/filters.md
@@ -27,6 +27,8 @@ Filter attributes add conditions that must be true before that handler can run:
 [UseFilter<AdminOnlyFilter>]
 ```
 
+Filters are not routes. A handler that uses filters or state constraints still needs an explicit route attribute such as `[Message]`, `[Command]`, `[Callback]`, or `[ChatMemberUpdated]`.
+
 For example:
 
 ```csharp

--- a/docs/en/reference/troubleshooting.md
+++ b/docs/en/reference/troubleshooting.md
@@ -38,6 +38,35 @@ builder.Services.AddTelegramModule<AdminHandlers>();
 
 Do not switch to deprecated reflection assembly registration to fix missing generated metadata.
 
+## `TLF027`: handler is missing a route attribute
+
+State and filter attributes constrain a handler, but they do not route updates by themselves.
+
+Wrong:
+
+```csharp
+[State("registration:name")]
+[HasText]
+public Task Name(MessageContext ctx, CancellationToken ct)
+{
+    return Task.CompletedTask;
+}
+```
+
+Correct:
+
+```csharp
+[Message]
+[State("registration:name")]
+[HasText]
+public Task Name(MessageContext ctx, CancellationToken ct)
+{
+    return Task.CompletedTask;
+}
+```
+
+Use `[Message]`, `[Command]`, `[Callback]`, `[ChatMemberUpdated]`, or another explicit route attribute before adding state and filter constraints.
+
 ## Can I Read The Token From `appsettings.json`?
 
 Yes. TeleFlow does not care where the token comes from. Read it through normal .NET configuration and pass the resolved value explicitly:

--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -173,6 +173,7 @@ Target state:
 Possible public shape:
 
 ```csharp
+[Message]
 [State("quiz:question")]
 [HasText]
 public async Task Answer(

--- a/docs/en/tutorials/support-desk.md
+++ b/docs/en/tutorials/support-desk.md
@@ -266,6 +266,7 @@ public sealed class TicketCreationHandlers
         await ctx.Message.AnswerAsync("Choose ticket category.", keyboard, ct);
     }
 
+    [Message]
     [State(TicketStates.Category)]
     [HasText]
     public async Task Category(MessageContext ctx, CancellationToken ct)
@@ -278,6 +279,7 @@ public sealed class TicketCreationHandlers
             ct);
     }
 
+    [Message]
     [State(TicketStates.Description)]
     [HasText]
     public async Task Description(MessageContext ctx, CancellationToken ct)

--- a/docs/ru/features/state-and-wizard.md
+++ b/docs/ru/features/state-and-wizard.md
@@ -38,6 +38,7 @@ public sealed class RegistrationHandlers
         await ctx.Message.AnswerAsync("What is your name?", ct);
     }
 
+    [Message]
     [State(RegistrationStates.Name)]
     [HasText]
     public async Task Name(MessageContext ctx, CancellationToken ct)
@@ -47,6 +48,7 @@ public sealed class RegistrationHandlers
         await ctx.Message.AnswerAsync("How old are you?", ct);
     }
 
+    [Message]
     [State(RegistrationStates.Age)]
     [HasText]
     public async Task Age(MessageContext ctx, CancellationToken ct)
@@ -107,6 +109,7 @@ public sealed class TicketWizard
         await ctx.Message.AnswerAsync("Choose category.", ct);
     }
 
+    [Message]
     [State("ticket:category")]
     [HasText]
     public async Task Category(MessageContext ctx, CancellationToken ct)
@@ -116,6 +119,7 @@ public sealed class TicketWizard
         await ctx.Message.AnswerAsync("Describe the issue.", ct);
     }
 
+    [Message]
     [State("ticket:description")]
     [Text("back")]
     public async Task Back(MessageContext ctx, CancellationToken ct)
@@ -155,6 +159,7 @@ public sealed class TicketScene
         await ctx.Message.AnswerAsync("Choose category.", ct);
     }
 
+    [Message]
     [SceneStep(nameof(Category))]
     [HasText]
     public Task CategoryStep(MessageContext ctx, CancellationToken ct)

--- a/docs/ru/fundamentals/filters.md
+++ b/docs/ru/fundamentals/filters.md
@@ -27,6 +27,8 @@ Filter attributes добавляют условия, которые должны
 [UseFilter<AdminOnlyFilter>]
 ```
 
+Filters не являются routes. Handler с filters или state constraints всё равно должен иметь явный route attribute: `[Message]`, `[Command]`, `[Callback]` или `[ChatMemberUpdated]`.
+
 Например:
 
 ```csharp

--- a/docs/ru/reference/troubleshooting.md
+++ b/docs/ru/reference/troubleshooting.md
@@ -38,6 +38,35 @@ builder.Services.AddTelegramModule<AdminHandlers>();
 
 Не переходи на deprecated reflection assembly registration как способ починить missing generated metadata.
 
+## `TLF027`: у handler нет route attribute
+
+State и filter attributes ограничивают handler, но сами не route-ят updates.
+
+Неправильно:
+
+```csharp
+[State("registration:name")]
+[HasText]
+public Task Name(MessageContext ctx, CancellationToken ct)
+{
+    return Task.CompletedTask;
+}
+```
+
+Правильно:
+
+```csharp
+[Message]
+[State("registration:name")]
+[HasText]
+public Task Name(MessageContext ctx, CancellationToken ct)
+{
+    return Task.CompletedTask;
+}
+```
+
+Используй `[Message]`, `[Command]`, `[Callback]`, `[ChatMemberUpdated]` или другой явный route attribute перед state и filter constraints.
+
 ## Можно ли читать token из `appsettings.json`?
 
 Да. TeleFlow не важно, откуда пришёл token. Прочитай его через обычную .NET configuration и явно передай resolved value:

--- a/docs/ru/roadmap.md
+++ b/docs/ru/roadmap.md
@@ -173,6 +173,7 @@ Non-goals для первой реализации:
 Возможная форма public API:
 
 ```csharp
+[Message]
 [State("quiz:question")]
 [HasText]
 public async Task Answer(

--- a/docs/ru/tutorials/support-desk.md
+++ b/docs/ru/tutorials/support-desk.md
@@ -266,6 +266,7 @@ public sealed class TicketCreationHandlers
         await ctx.Message.AnswerAsync("Choose ticket category.", keyboard, ct);
     }
 
+    [Message]
     [State(TicketStates.Category)]
     [HasText]
     public async Task Category(MessageContext ctx, CancellationToken ct)
@@ -278,6 +279,7 @@ public sealed class TicketCreationHandlers
             ct);
     }
 
+    [Message]
     [State(TicketStates.Description)]
     [HasText]
     public async Task Description(MessageContext ctx, CancellationToken ct)

--- a/src/TeleFlow.Generators/TelegramHandlerAnalyzer.Diagnostics.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerAnalyzer.Diagnostics.cs
@@ -31,6 +31,7 @@ public sealed partial class TelegramHandlerAnalyzer
     public const string InvalidAutoAnswerCallbackId = "TLF024";
     public const string InvalidClassBasedHandlerId = "TLF025";
     public const string InvalidErrorHandlerId = "TLF026";
+    public const string MissingRouteAttributeId = "TLF027";
 
     private static readonly DiagnosticDescriptor MultipleRouteAttributes = CreateDescriptor(
         MultipleRouteAttributesId,
@@ -188,6 +189,12 @@ public sealed partial class TelegramHandlerAnalyzer
         "{0}",
         "Usage");
 
+    private static readonly DiagnosticDescriptor MissingRouteAttribute = CreateDescriptor(
+        MissingRouteAttributeId,
+        "Telegram handler is missing a route attribute",
+        "Telegram handler method '{0}' uses state or filter attributes but has no route attribute. Add [Message], [Command], [Callback], [ChatMemberUpdated], or another explicit Telegram route attribute.",
+        "Usage");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(
             MultipleRouteAttributes,
@@ -215,7 +222,8 @@ public sealed partial class TelegramHandlerAnalyzer
             InvalidSceneStep,
             InvalidAutoAnswerCallback,
             InvalidClassBasedHandler,
-            InvalidErrorHandler);
+            InvalidErrorHandler,
+            MissingRouteAttribute);
 
     private static DiagnosticDescriptor CreateDescriptor(
         string id,

--- a/src/TeleFlow.Generators/TelegramHandlerAnalyzer.RouteLessHandlers.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerAnalyzer.RouteLessHandlers.cs
@@ -1,0 +1,106 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TeleFlow.Generators;
+
+public sealed partial class TelegramHandlerAnalyzer
+{
+    private static readonly string[] RouteLessHandlerAttributeMetadataNames =
+    {
+        TelegramHandlerSymbols.StateAttribute,
+        TelegramHandlerSymbols.RequireTelegramRoleAttribute,
+        TelegramHandlerSymbols.ChatMemberTransitionAttribute,
+        TelegramHandlerSymbols.ChatMemberChangedAttribute
+    };
+
+    private static readonly string[] RouteLessHandlerGenericAttributeMetadataNames =
+    {
+        TelegramHandlerSymbols.GenericStateAttribute,
+        TelegramHandlerSymbols.GenericUseFilterAttribute
+    };
+
+    private static void AnalyzeMissingRouteAttribute(
+        SymbolAnalysisContext context,
+        IMethodSymbol method)
+    {
+        if (TelegramHandlerSymbols.HasAnyErrorAttribute(method) ||
+            TelegramHandlerSymbols.HasAttribute(method, TelegramHandlerSymbols.SceneStepAttribute, inherit: true) ||
+            !TryGetRouteLessHandlerAttribute(method, out AttributeData attribute))
+        {
+            return;
+        }
+
+        string displayName = method.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        Location? location = attribute.ApplicationSyntaxReference
+            ?.GetSyntax(context.CancellationToken)
+            .GetLocation();
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            MissingRouteAttribute,
+            location ?? method.Locations.FirstOrDefault(static candidate => candidate.IsInSource),
+            displayName));
+    }
+
+    private static bool TryGetRouteLessHandlerAttribute(
+        IMethodSymbol method,
+        out AttributeData attribute)
+    {
+        if (TryGetFirstKnownAttribute(method, RouteLessHandlerAttributeMetadataNames, out attribute) ||
+            TryGetFirstKnownGenericAttribute(method, RouteLessHandlerGenericAttributeMetadataNames, out attribute) ||
+            TryGetFirst(TelegramBuiltInFilterFacts.GetAttributes(method), out attribute))
+        {
+            return true;
+        }
+
+        attribute = null!;
+        return false;
+    }
+
+    private static bool TryGetFirstKnownAttribute(
+        IMethodSymbol method,
+        IReadOnlyList<string> metadataNames,
+        out AttributeData attribute)
+    {
+        foreach (string metadataName in metadataNames)
+        {
+            if (TryGetFirst(TelegramHandlerSymbols.GetAttributes(method, metadataName, inherit: true), out attribute))
+            {
+                return true;
+            }
+        }
+
+        attribute = null!;
+        return false;
+    }
+
+    private static bool TryGetFirstKnownGenericAttribute(
+        IMethodSymbol method,
+        IReadOnlyList<string> metadataNames,
+        out AttributeData attribute)
+    {
+        foreach (string metadataName in metadataNames)
+        {
+            if (TryGetFirst(TelegramHandlerSymbols.GetGenericAttributes(method, metadataName, inherit: true), out attribute))
+            {
+                return true;
+            }
+        }
+
+        attribute = null!;
+        return false;
+    }
+
+    private static bool TryGetFirst(
+        IEnumerable<AttributeData> attributes,
+        out AttributeData attribute)
+    {
+        foreach (AttributeData candidate in attributes)
+        {
+            attribute = candidate;
+            return true;
+        }
+
+        attribute = null!;
+        return false;
+    }
+}

--- a/src/TeleFlow.Generators/TelegramHandlerAnalyzer.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerAnalyzer.cs
@@ -117,6 +117,7 @@ public sealed partial class TelegramHandlerAnalyzer : DiagnosticAnalyzer
                     "SceneStepAttribute requires an explicit Telegram route attribute."));
             }
 
+            AnalyzeMissingRouteAttribute(context, method);
             AnalyzeAutoAnswerCallback(context, method, routeKind: null);
             return;
         }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
@@ -1315,6 +1315,187 @@ public sealed class TelegramHandlerGeneratorTests
         Assert.Contains(diagnostics, diagnostic => diagnostic.Id == diagnosticId);
     }
 
+    [Fact]
+    public async Task Analyzer_ReportsHandlerConstraintAttributesWithoutRoute()
+    {
+        var diagnostics = await GetAnalyzerDiagnosticsAsync(
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using TeleFlow.Annotations;
+            using TeleFlow.Core.States;
+            using TeleFlow.Telegram;
+
+            public sealed class RouteLessHandlers
+            {
+                [State("registration:name")]
+                [HasText]
+                public Task StateAndText(MessageContext context, CancellationToken cancellationToken)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [HasPhoto]
+                public Task Photo(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [CallbackDataPrefix("ticket:")]
+                public Task Callback(CallbackQueryContext context)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [UseFilter<AllowMessageFilter>]
+                public Task CustomFilter(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [RequireTelegramRole(TelegramMemberStatusSet.IsAdmin)]
+                public Task AdminOnly(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [ChatMemberTransition(TelegramMemberTransition.Join)]
+                public Task Joined(ChatMemberUpdatedContext context)
+                {
+                    return Task.CompletedTask;
+                }
+
+                [State<RegistrationStates>(nameof(RegistrationStates.Name))]
+                public Task TypedState(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+
+            [StateGroup("registration")]
+            public sealed partial class RegistrationStates
+            {
+                public static partial State Name { get; }
+            }
+
+            public sealed class AllowMessageFilter : ITelegramFilter<MessageContext>
+            {
+                public ValueTask<bool> MatchesAsync(
+                    MessageContext context,
+                    CancellationToken cancellationToken = default)
+                {
+                    return ValueTask.FromResult(true);
+                }
+            }
+            """);
+
+        Assert.True(
+            diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.MissingRouteAttributeId) >= 7,
+            "Expected route-less state, built-in filter, custom filter, role, and chat-member transition diagnostics.");
+    }
+
+    [Fact]
+    public async Task Analyzer_AllowsExplicitRouteWithStateAndFilters()
+    {
+        var diagnostics = await GetAnalyzerDiagnosticsAsync(
+            """
+            using System.Threading.Tasks;
+            using TeleFlow.Annotations;
+            using TeleFlow.Telegram;
+
+            public sealed class RegistrationHandlers
+            {
+                [Message]
+                [State("registration:name")]
+                [HasText]
+                public Task Name(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.MissingRouteAttributeId);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportRouteLessDiagnosticForErrorOnlyHandlers()
+    {
+        var diagnostics = await GetAnalyzerDiagnosticsAsync(
+            """
+            using System;
+            using TeleFlow.Annotations;
+            using TeleFlow.Telegram;
+
+            public sealed class ErrorHandlers
+            {
+                [Error]
+                public TelegramErrorHandlingResult Handle(Exception exception)
+                {
+                    return TelegramErrorHandlingResult.Handled;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.MissingRouteAttributeId);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportRouteLessDiagnosticForClassBasedHandlerWithClassRoute()
+    {
+        var diagnostics = await GetAnalyzerDiagnosticsAsync(
+            """
+            using System.Threading.Tasks;
+            using TeleFlow.Annotations;
+            using TeleFlow.Telegram;
+
+            [Message]
+            public sealed class NameHandler : MessageHandler
+            {
+                [State("registration:name")]
+                [HasText]
+                public Task HandleAsync(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.MissingRouteAttributeId);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Generator_DoesNotInferRoutesFromStateOrFilters()
+    {
+        var compilation = CreateCompilation(
+            """
+            using System.Threading.Tasks;
+            using TeleFlow.Annotations;
+            using TeleFlow.Telegram;
+
+            namespace Bot;
+
+            public sealed class RegistrationHandlers
+            {
+                [State("registration:name")]
+                [HasText]
+                public Task Name(MessageContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+            """);
+
+        var generatedCompilation = RunGenerator(compilation, out var diagnostics);
+        var generatedTree = generatedCompilation.SyntaxTrees
+            .FirstOrDefault(tree => tree.FilePath.EndsWith("TeleFlow.Telegram.GeneratedHandlers.g.cs", StringComparison.Ordinal));
+
+        Assert.Empty(diagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Null(generatedTree);
+    }
+
     [Theory]
     [InlineData("[Error] public Task Handle(Exception exception) => Task.CompletedTask;")]
     [InlineData("[Error] public TelegramErrorHandlingResult Handle(InvalidOperationException exception) => TelegramErrorHandlingResult.Handled;")]


### PR DESCRIPTION
## Summary
- add `TLF027` for methods that use state/filter constraints without an explicit Telegram route attribute
- keep generated registration explicit and avoid inferring routes from `[State]`, filters, roles, or transition constraints
- update EN/RU docs so state and wizard examples show explicit `[Message]` routes

## Touched hot paths
- This changes analyzer behavior only. Runtime dispatch and generated registration semantics are unchanged.
- The generator still ignores route-less methods instead of inferring a route.

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~Analyzer_ReportsHandlerConstraintAttributesWithoutRoute|FullyQualifiedName~Analyzer_AllowsExplicitRouteWithStateAndFilters|FullyQualifiedName~Analyzer_DoesNotReportRouteLessDiagnosticForErrorOnlyHandlers|FullyQualifiedName~Analyzer_DoesNotReportRouteLessDiagnosticForClassBasedHandlerWithClassRoute|FullyQualifiedName~Generator_DoesNotInferRoutesFromStateOrFilters"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj`
- `git diff --check`

Closes #92