### PR TITLE
perf(framework): pre-index handler route candidates

### DIFF
--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramCallbackHandlerCandidateSet.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramCallbackHandlerCandidateSet.cs
@@ -1,0 +1,85 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Groups callback handler candidates by state and payload shape so callback dispatch can preserve
+/// typed-before-raw routing without scanning unrelated callback handlers on every callback query.
+/// </summary>
+internal sealed class TelegramCallbackHandlerCandidateSet
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> _statefulTypedByState;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> _statefulRawByState;
+
+    private TelegramCallbackHandlerCandidateSet(
+        IReadOnlyList<TelegramHandlerCandidate> statelessTyped,
+        IReadOnlyList<TelegramHandlerCandidate> statelessRaw,
+        IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> statefulTypedByState,
+        IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> statefulRawByState)
+    {
+        StatelessTyped = statelessTyped;
+        StatelessRaw = statelessRaw;
+        _statefulTypedByState = statefulTypedByState;
+        _statefulRawByState = statefulRawByState;
+    }
+
+    public IReadOnlyList<TelegramHandlerCandidate> StatelessTyped { get; }
+
+    public IReadOnlyList<TelegramHandlerCandidate> StatelessRaw { get; }
+
+    public bool HasStatefulCandidates => _statefulTypedByState.Count > 0 || _statefulRawByState.Count > 0;
+
+    public IReadOnlyList<TelegramHandlerCandidate> GetStatefulTypedCandidates(string currentState)
+    {
+        return _statefulTypedByState.TryGetValue(currentState, out var candidates)
+            ? candidates
+            : TelegramHandlerCandidateStateIndex.EmptyCandidates;
+    }
+
+    public IReadOnlyList<TelegramHandlerCandidate> GetStatefulRawCandidates(string currentState)
+    {
+        return _statefulRawByState.TryGetValue(currentState, out var candidates)
+            ? candidates
+            : TelegramHandlerCandidateStateIndex.EmptyCandidates;
+    }
+
+    public static TelegramCallbackHandlerCandidateSet Create(IReadOnlyList<TelegramHandlerDescriptor> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        var statelessTyped = new List<TelegramHandlerCandidate>();
+        var statelessRaw = new List<TelegramHandlerCandidate>();
+        var statefulTyped = new Dictionary<string, List<TelegramHandlerCandidate>>(StringComparer.Ordinal);
+        var statefulRaw = new Dictionary<string, List<TelegramHandlerCandidate>>(StringComparer.Ordinal);
+
+        for (var index = 0; index < handlers.Count; index++)
+        {
+            var handler = handlers[index];
+            var candidate = TelegramHandlerCandidate.Create(handler);
+            var isTyped = handler.CallbackPayloadType is not null;
+
+            if (handler.States.Count == 0)
+            {
+                if (isTyped)
+                {
+                    statelessTyped.Add(candidate);
+                }
+                else
+                {
+                    statelessRaw.Add(candidate);
+                }
+
+                continue;
+            }
+
+            TelegramHandlerCandidateStateIndex.Add(
+                isTyped ? statefulTyped : statefulRaw,
+                handler.States,
+                candidate);
+        }
+
+        return new TelegramCallbackHandlerCandidateSet(
+            statelessTyped.ToArray(),
+            statelessRaw.ToArray(),
+            TelegramHandlerCandidateStateIndex.Freeze(statefulTyped),
+            TelegramHandlerCandidateStateIndex.Freeze(statefulRaw));
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramFilterEvaluator.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramFilterEvaluator.cs
@@ -9,18 +9,16 @@ internal static class TelegramFilterEvaluator
 {
     public static async ValueTask<bool> MatchesAsync(
         TelegramUpdateContext context,
-        IReadOnlyList<TelegramFilterDescriptor> filters,
-        IReadOnlyList<TelegramRoleRequirementDescriptor> roleRequirements,
+        TelegramRouteFilterPlan filterPlan,
         CancellationToken cancellationToken)
     {
-        for (var index = 0; index < filters.Count; index++)
-        {
-            var filter = filters[index];
+        ArgumentNullException.ThrowIfNull(filterPlan);
 
-            if (filter.CustomFilterType is not null)
-            {
-                continue;
-            }
+        var builtInFilters = filterPlan.BuiltInFilters;
+
+        for (var index = 0; index < builtInFilters.Count; index++)
+        {
+            var filter = builtInFilters[index];
 
             if (!MatchesBuiltInFilter(context, filter))
             {
@@ -28,14 +26,11 @@ internal static class TelegramFilterEvaluator
             }
         }
 
-        for (var index = 0; index < filters.Count; index++)
-        {
-            var filterType = filters[index].CustomFilterType;
+        var customFilterTypes = filterPlan.CustomFilterTypes;
 
-            if (filterType is null)
-            {
-                continue;
-            }
+        for (var index = 0; index < customFilterTypes.Count; index++)
+        {
+            var filterType = customFilterTypes[index];
 
             if (!await MatchesCustomFilterAsync(context, filterType, cancellationToken).ConfigureAwait(false))
             {
@@ -43,20 +38,12 @@ internal static class TelegramFilterEvaluator
             }
         }
 
-        if (!await MatchesRoleRequirementsAsync(context, roleRequirements, cancellationToken).ConfigureAwait(false))
+        if (!await MatchesRoleRequirementsAsync(context, filterPlan.RoleRequirements, cancellationToken).ConfigureAwait(false))
         {
             return false;
         }
 
         return true;
-    }
-
-    public static ValueTask<bool> MatchesAsync(
-        TelegramUpdateContext context,
-        IReadOnlyList<TelegramFilterDescriptor> filters,
-        CancellationToken cancellationToken)
-    {
-        return MatchesAsync(context, filters, roleRequirements: [], cancellationToken);
     }
 
     private static bool MatchesBuiltInFilter(

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidate.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidate.cs
@@ -1,0 +1,21 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Represents a prepared handler route candidate selected from the handler table before per-update route
+/// matching, filter evaluation, and handler invocation.
+/// </summary>
+internal readonly record struct TelegramHandlerCandidate(
+    TelegramHandlerDescriptor Handler,
+    TelegramRouteDescriptor Route,
+    TelegramRouteFilterPlan Filters)
+{
+    public static TelegramHandlerCandidate Create(TelegramHandlerDescriptor handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        return new TelegramHandlerCandidate(
+            handler,
+            handler.Route,
+            TelegramRouteFilterPlan.Create(handler.Route));
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidateSet.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidateSet.cs
@@ -1,0 +1,55 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Groups command, message, or chat-member handler candidates by state at handler-table construction time so
+/// the selector can skip unrelated stateful handlers during incoming Telegram update dispatch.
+/// </summary>
+internal sealed class TelegramHandlerCandidateSet
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> _statefulByState;
+
+    private TelegramHandlerCandidateSet(
+        IReadOnlyList<TelegramHandlerCandidate> stateless,
+        IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> statefulByState)
+    {
+        Stateless = stateless;
+        _statefulByState = statefulByState;
+    }
+
+    public IReadOnlyList<TelegramHandlerCandidate> Stateless { get; }
+
+    public bool HasStatefulCandidates => _statefulByState.Count > 0;
+
+    public IReadOnlyList<TelegramHandlerCandidate> GetStatefulCandidates(string currentState)
+    {
+        return _statefulByState.TryGetValue(currentState, out var candidates)
+            ? candidates
+            : TelegramHandlerCandidateStateIndex.EmptyCandidates;
+    }
+
+    public static TelegramHandlerCandidateSet Create(IReadOnlyList<TelegramHandlerDescriptor> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        var stateless = new List<TelegramHandlerCandidate>();
+        var stateful = new Dictionary<string, List<TelegramHandlerCandidate>>(StringComparer.Ordinal);
+
+        for (var index = 0; index < handlers.Count; index++)
+        {
+            var handler = handlers[index];
+            var candidate = TelegramHandlerCandidate.Create(handler);
+
+            if (handler.States.Count == 0)
+            {
+                stateless.Add(candidate);
+                continue;
+            }
+
+            TelegramHandlerCandidateStateIndex.Add(stateful, handler.States, candidate);
+        }
+
+        return new TelegramHandlerCandidateSet(
+            stateless.ToArray(),
+            TelegramHandlerCandidateStateIndex.Freeze(stateful));
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidateStateIndex.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerCandidateStateIndex.cs
@@ -1,0 +1,44 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Builds immutable state-indexed handler candidate buckets used by message, command, chat-member, and
+/// callback route plans during Telegram update selection.
+/// </summary>
+internal static class TelegramHandlerCandidateStateIndex
+{
+    public static readonly IReadOnlyList<TelegramHandlerCandidate> EmptyCandidates = [];
+
+    public static void Add(
+        Dictionary<string, List<TelegramHandlerCandidate>> stateful,
+        IReadOnlyList<string> states,
+        TelegramHandlerCandidate candidate)
+    {
+        for (var index = 0; index < states.Count; index++)
+        {
+            var state = states[index];
+
+            if (!stateful.TryGetValue(state, out var candidates))
+            {
+                candidates = [];
+                stateful.Add(state, candidates);
+            }
+
+            candidates.Add(candidate);
+        }
+    }
+
+    public static IReadOnlyDictionary<string, IReadOnlyList<TelegramHandlerCandidate>> Freeze(
+        Dictionary<string, List<TelegramHandlerCandidate>> stateful)
+    {
+        var frozen = new Dictionary<string, IReadOnlyList<TelegramHandlerCandidate>>(
+            stateful.Count,
+            StringComparer.Ordinal);
+
+        foreach (var item in stateful)
+        {
+            frozen.Add(item.Key, item.Value.ToArray());
+        }
+
+        return frozen;
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -34,7 +34,7 @@ internal sealed class TelegramHandlerSelector
     {
         var selection = await SelectMessageHandlerAsync(
             context,
-            _table.CommandHandlers,
+            _table.CommandHandlerCandidates,
             currentState,
             cancellationToken).ConfigureAwait(false);
 
@@ -45,7 +45,7 @@ internal sealed class TelegramHandlerSelector
 
         return await SelectMessageHandlerAsync(
             context,
-            _table.MessageHandlers,
+            _table.MessageHandlerCandidates,
             currentState,
             cancellationToken).ConfigureAwait(false);
     }
@@ -57,12 +57,10 @@ internal sealed class TelegramHandlerSelector
     {
         if (HasCurrentState(currentState))
         {
+            var state = currentState!;
             var statefulPayloadSelection = await SelectCallbackHandlerPassAsync(
                 context,
-                _table.CallbackHandlers,
-                currentState,
-                requireCurrentState: true,
-                requireCallbackPayload: true,
+                _table.CallbackHandlerCandidates.GetStatefulTypedCandidates(state),
                 cancellationToken).ConfigureAwait(false);
 
             if (statefulPayloadSelection is not null)
@@ -72,10 +70,7 @@ internal sealed class TelegramHandlerSelector
 
             var statefulRawSelection = await SelectCallbackHandlerPassAsync(
                 context,
-                _table.CallbackHandlers,
-                currentState,
-                requireCurrentState: true,
-                requireCallbackPayload: false,
+                _table.CallbackHandlerCandidates.GetStatefulRawCandidates(state),
                 cancellationToken).ConfigureAwait(false);
 
             if (statefulRawSelection is not null)
@@ -86,10 +81,7 @@ internal sealed class TelegramHandlerSelector
 
         var statelessPayloadSelection = await SelectCallbackHandlerPassAsync(
             context,
-            _table.CallbackHandlers,
-            currentState: null,
-            requireCurrentState: false,
-            requireCallbackPayload: true,
+            _table.CallbackHandlerCandidates.StatelessTyped,
             cancellationToken).ConfigureAwait(false);
 
         if (statelessPayloadSelection is not null)
@@ -99,10 +91,7 @@ internal sealed class TelegramHandlerSelector
 
         return await SelectCallbackHandlerPassAsync(
             context,
-            _table.CallbackHandlers,
-            currentState: null,
-            requireCurrentState: false,
-            requireCallbackPayload: false,
+            _table.CallbackHandlerCandidates.StatelessRaw,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -114,12 +103,11 @@ internal sealed class TelegramHandlerSelector
     {
         if (HasCurrentState(currentState))
         {
+            var state = currentState!;
             var statefulSelection = await SelectChatMemberHandlerPassAsync(
                 context,
-                _table.ChatMemberHandlers,
+                _table.ChatMemberHandlerCandidates.GetStatefulCandidates(state),
                 updateRouteKind,
-                currentState,
-                requireCurrentState: true,
                 cancellationToken).ConfigureAwait(false);
 
             if (statefulSelection is not null)
@@ -130,26 +118,23 @@ internal sealed class TelegramHandlerSelector
 
         return await SelectChatMemberHandlerPassAsync(
             context,
-            _table.ChatMemberHandlers,
+            _table.ChatMemberHandlerCandidates.Stateless,
             updateRouteKind,
-            currentState: null,
-            requireCurrentState: false,
             cancellationToken).ConfigureAwait(false);
     }
 
     private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
         MessageContext context,
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
+        TelegramHandlerCandidateSet candidates,
         string? currentState,
         CancellationToken cancellationToken)
     {
         if (HasCurrentState(currentState))
         {
+            var state = currentState!;
             var statefulSelection = await SelectMessageHandlerPassAsync(
                 context,
-                handlers,
-                currentState,
-                requireCurrentState: true,
+                candidates.GetStatefulCandidates(state),
                 cancellationToken).ConfigureAwait(false);
 
             if (statefulSelection is not null)
@@ -160,29 +145,19 @@ internal sealed class TelegramHandlerSelector
 
         return await SelectMessageHandlerPassAsync(
             context,
-            handlers,
-            currentState: null,
-            requireCurrentState: false,
+            candidates.Stateless,
             cancellationToken).ConfigureAwait(false);
     }
 
     private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerPassAsync(
         MessageContext context,
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
-        string? currentState,
-        bool requireCurrentState,
+        IReadOnlyList<TelegramHandlerCandidate> candidates,
         CancellationToken cancellationToken)
     {
-        for (var index = 0; index < handlers.Count; index++)
+        for (var index = 0; index < candidates.Count; index++)
         {
-            var handler = handlers[index];
-
-            if (!MatchesStatePass(handler, currentState, requireCurrentState))
-            {
-                continue;
-            }
-
-            var route = handler.Route;
+            var candidate = candidates[index];
+            var route = candidate.Route;
 
             if (!TryMatchRoute(context.TelegramMessage, route, out var routeValues))
             {
@@ -191,14 +166,13 @@ internal sealed class TelegramHandlerSelector
 
             if (!await TelegramFilterEvaluator.MatchesAsync(
                     context,
-                    route.Filters,
-                    route.RoleRequirements,
+                    candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
                 continue;
             }
 
-            return new TelegramRouteSelection(handler, route, routeValues, callbackPayload: null);
+            return new TelegramRouteSelection(candidate.Handler, route, routeValues, callbackPayload: null);
         }
 
         return null;
@@ -206,40 +180,25 @@ internal sealed class TelegramHandlerSelector
 
     private static async ValueTask<TelegramRouteSelection?> SelectCallbackHandlerPassAsync(
         CallbackQueryContext context,
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
-        string? currentState,
-        bool requireCurrentState,
-        bool requireCallbackPayload,
+        IReadOnlyList<TelegramHandlerCandidate> candidates,
         CancellationToken cancellationToken)
     {
-        for (var index = 0; index < handlers.Count; index++)
+        for (var index = 0; index < candidates.Count; index++)
         {
-            var handler = handlers[index];
-
-            if ((handler.CallbackPayloadType is not null) != requireCallbackPayload)
-            {
-                continue;
-            }
-
-            if (!MatchesStatePass(handler, currentState, requireCurrentState))
-            {
-                continue;
-            }
-
-            var route = handler.Route;
+            var candidate = candidates[index];
+            var route = candidate.Route;
 
             if (route.CallbackPayloadType is null)
             {
                 if (!await TelegramFilterEvaluator.MatchesAsync(
                         context,
-                        route.Filters,
-                        route.RoleRequirements,
+                        candidate.Filters,
                         cancellationToken).ConfigureAwait(false))
                 {
                     continue;
                 }
 
-                return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload: null);
+                return new TelegramRouteSelection(candidate.Handler, route, EmptyRouteValues, callbackPayload: null);
             }
 
             if (string.IsNullOrWhiteSpace(context.TelegramCallbackQuery.Data))
@@ -257,14 +216,13 @@ internal sealed class TelegramHandlerSelector
 
             if (!await TelegramFilterEvaluator.MatchesAsync(
                     context,
-                    route.Filters,
-                    route.RoleRequirements,
+                    candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
                 continue;
             }
 
-            return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload);
+            return new TelegramRouteSelection(candidate.Handler, route, EmptyRouteValues, callbackPayload);
         }
 
         return null;
@@ -272,22 +230,14 @@ internal sealed class TelegramHandlerSelector
 
     private static async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerPassAsync(
         ChatMemberUpdatedContext context,
-        IReadOnlyList<TelegramHandlerDescriptor> handlers,
+        IReadOnlyList<TelegramHandlerCandidate> candidates,
         TelegramRouteKind updateRouteKind,
-        string? currentState,
-        bool requireCurrentState,
         CancellationToken cancellationToken)
     {
-        for (var index = 0; index < handlers.Count; index++)
+        for (var index = 0; index < candidates.Count; index++)
         {
-            var handler = handlers[index];
-
-            if (!MatchesStatePass(handler, currentState, requireCurrentState))
-            {
-                continue;
-            }
-
-            var route = handler.Route;
+            var candidate = candidates[index];
+            var route = candidate.Route;
 
             if (route.RouteKind != updateRouteKind)
             {
@@ -301,14 +251,13 @@ internal sealed class TelegramHandlerSelector
 
             if (!await TelegramFilterEvaluator.MatchesAsync(
                     context,
-                    route.Filters,
-                    route.RoleRequirements,
+                    candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
                 continue;
             }
 
-            return new TelegramRouteSelection(handler, route, EmptyRouteValues, callbackPayload: null);
+            return new TelegramRouteSelection(candidate.Handler, route, EmptyRouteValues, callbackPayload: null);
         }
 
         return null;
@@ -340,34 +289,6 @@ internal sealed class TelegramHandlerSelector
     private static bool HasCurrentState(string? currentState)
     {
         return !string.IsNullOrWhiteSpace(currentState);
-    }
-
-    private static bool MatchesStatePass(
-        TelegramHandlerDescriptor handler,
-        string? currentState,
-        bool requireCurrentState)
-    {
-        if (!requireCurrentState)
-        {
-            return handler.States.Count == 0;
-        }
-
-        return currentState is not null && MatchesState(handler, currentState);
-    }
-
-    private static bool MatchesState(TelegramHandlerDescriptor handler, string currentState)
-    {
-        var states = handler.States;
-
-        for (var index = 0; index < states.Count; index++)
-        {
-            if (string.Equals(states[index], currentState, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool TryDeserializeCallbackPayload(

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerTable.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramHandlerTable.cs
@@ -22,7 +22,15 @@ internal sealed class TelegramHandlerTable
         ChatMemberHandlers = OrderForRouteSelection(orderedDescriptors
             .Where(static descriptor => descriptor.Kind == TelegramHandlerKind.ChatMember)
             .ToArray());
-        HasStatefulHandlers = orderedDescriptors.Any(static descriptor => descriptor.States.Count > 0);
+
+        CommandHandlerCandidates = TelegramHandlerCandidateSet.Create(CommandHandlers);
+        MessageHandlerCandidates = TelegramHandlerCandidateSet.Create(MessageHandlers);
+        CallbackHandlerCandidates = TelegramCallbackHandlerCandidateSet.Create(CallbackHandlers);
+        ChatMemberHandlerCandidates = TelegramHandlerCandidateSet.Create(ChatMemberHandlers);
+        HasStatefulHandlers = CommandHandlerCandidates.HasStatefulCandidates ||
+                              MessageHandlerCandidates.HasStatefulCandidates ||
+                              CallbackHandlerCandidates.HasStatefulCandidates ||
+                              ChatMemberHandlerCandidates.HasStatefulCandidates;
 
         EnsureNoDuplicateCallbackPrefixes(CallbackHandlers);
     }
@@ -34,6 +42,14 @@ internal sealed class TelegramHandlerTable
     public IReadOnlyList<TelegramHandlerDescriptor> CallbackHandlers { get; }
 
     public IReadOnlyList<TelegramHandlerDescriptor> ChatMemberHandlers { get; }
+
+    public TelegramHandlerCandidateSet CommandHandlerCandidates { get; }
+
+    public TelegramHandlerCandidateSet MessageHandlerCandidates { get; }
+
+    public TelegramCallbackHandlerCandidateSet CallbackHandlerCandidates { get; }
+
+    public TelegramHandlerCandidateSet ChatMemberHandlerCandidates { get; }
 
     public bool HasStatefulHandlers { get; }
 

--- a/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramRouteFilterPlan.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/Handlers/TelegramRouteFilterPlan.cs
@@ -1,0 +1,75 @@
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Stores route filters in the order the dispatcher actually evaluates them so handler selection does not
+/// split built-in filters, custom filters, and role requirements on every incoming Telegram update.
+/// </summary>
+internal sealed class TelegramRouteFilterPlan
+{
+    private static readonly IReadOnlyList<TelegramFilterDescriptor> EmptyBuiltInFilters = [];
+    private static readonly IReadOnlyList<Type> EmptyCustomFilterTypes = [];
+    private static readonly IReadOnlyList<TelegramRoleRequirementDescriptor> EmptyRoleRequirements = [];
+    private static readonly TelegramRouteFilterPlan Empty = new(
+        EmptyBuiltInFilters,
+        EmptyCustomFilterTypes,
+        EmptyRoleRequirements);
+
+    private TelegramRouteFilterPlan(
+        IReadOnlyList<TelegramFilterDescriptor> builtInFilters,
+        IReadOnlyList<Type> customFilterTypes,
+        IReadOnlyList<TelegramRoleRequirementDescriptor> roleRequirements)
+    {
+        BuiltInFilters = builtInFilters;
+        CustomFilterTypes = customFilterTypes;
+        RoleRequirements = roleRequirements;
+    }
+
+    public IReadOnlyList<TelegramFilterDescriptor> BuiltInFilters { get; }
+
+    public IReadOnlyList<Type> CustomFilterTypes { get; }
+
+    public IReadOnlyList<TelegramRoleRequirementDescriptor> RoleRequirements { get; }
+
+    public static TelegramRouteFilterPlan Create(TelegramRouteDescriptor route)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+
+        return Create(route.Filters, route.RoleRequirements);
+    }
+
+    private static TelegramRouteFilterPlan Create(
+        IReadOnlyList<TelegramFilterDescriptor> filters,
+        IReadOnlyList<TelegramRoleRequirementDescriptor> roleRequirements)
+    {
+        ArgumentNullException.ThrowIfNull(filters);
+        ArgumentNullException.ThrowIfNull(roleRequirements);
+
+        if (filters.Count == 0 && roleRequirements.Count == 0)
+        {
+            return Empty;
+        }
+
+        List<TelegramFilterDescriptor>? builtInFilters = null;
+        List<Type>? customFilterTypes = null;
+
+        for (var index = 0; index < filters.Count; index++)
+        {
+            var filter = filters[index];
+
+            if (filter.CustomFilterType is { } customFilterType)
+            {
+                customFilterTypes ??= [];
+                customFilterTypes.Add(customFilterType);
+                continue;
+            }
+
+            builtInFilters ??= [];
+            builtInFilters.Add(filter);
+        }
+
+        return new TelegramRouteFilterPlan(
+            builtInFilters?.ToArray() ?? EmptyBuiltInFilters,
+            customFilterTypes?.ToArray() ?? EmptyCustomFilterTypes,
+            roleRequirements);
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2648,6 +2648,32 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task MultiStateHandler_DispatchesFromEachDeclaredState()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddMemoryStateStorage();
+                services.AddTelegramHandler<MultiStateMessageHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+        var stateKey = StateKey.Create("telegram", "user:5", "chat:100");
+        var stateStore = serviceProvider.GetRequiredService<IStateStore>();
+
+        await stateStore.SetStateAsync(stateKey, MultiState.First.Id);
+        await DispatchThroughMiddlewareAsync(serviceProvider, CreateMessageUpdate("one"));
+
+        await stateStore.SetStateAsync(stateKey, MultiState.Second.Id);
+        await DispatchThroughMiddlewareAsync(serviceProvider, CreateMessageUpdate("two"));
+
+        await stateStore.SetStateAsync(stateKey, "other");
+        await DispatchThroughMiddlewareAsync(serviceProvider, CreateMessageUpdate("fallback"));
+
+        Assert.Equal(["multi-state:one", "multi-state:two", "message:fallback"], probe.Events);
+    }
+
+    [Fact]
     public async Task SceneStep_DispatchesBySceneStateAndUsesStateData()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -4262,6 +4288,26 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(MessageContext context, HandlerProbe probe)
         {
             probe.Events.Add($"typed-state:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
+    [StateGroup("multi")]
+    public sealed class MultiState
+    {
+        public static State First => State.Create("multi:first");
+
+        public static State Second => State.Create("multi:second");
+    }
+
+    public sealed class MultiStateMessageHandler
+    {
+        [Message]
+        [State<MultiState>(nameof(MultiState.First))]
+        [State<MultiState>(nameof(MultiState.Second))]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"multi-state:{context.TelegramMessage.Text}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary

- build internal pre-indexed handler candidate groups when `TelegramHandlerTable` is created
- route command, message, callback, and chat-member selection through prepared stateful/stateless and typed/raw candidate lists
- evaluate route filters through a prepared filter plan instead of splitting built-in/custom filters during every handler selection pass
- add regression coverage for handlers declared for multiple states

## Touched hot paths

- `TelegramHandlerSelector`: no longer scans the full handler list to separate stateful/stateless or typed/raw candidates per update.
- `TelegramFilterEvaluator`: now consumes `TelegramRouteFilterPlan`, preserving built-in filters before custom filters and role checks after filters.
- `TelegramHandlerTable`: does a little more startup work to keep dispatch-time selection smaller and more direct.

## Behavior notes

- Public API is unchanged.
- Existing route priority semantics are unchanged.
- Callback priority remains `stateful typed -> stateful raw -> stateless typed -> stateless raw`.
- Command handlers still run before message fallback handlers.
- Built-in filters still run before custom filters, and role requirements still run after filters.

## Validation

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj`
- `dotnet test TeleFlow.sln`
- `git diff --check`

## Benchmark note

No public performance numbers are claimed in this PR. Dispatch benchmarks should be run from a clean baseline/current comparison before publishing any alpha.5 performance table.

Closes #62
