### PR TITLE
fix(keyboards): serialize typed callbacks through configured serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
-No unreleased changes.
+### Changed
+
+- Typed inline keyboard callback payloads now serialize through the configured `ICallbackDataSerializer` via `InlineKeyboardBuilder.Build(callbackData)`, while raw callback strings are preserved exactly.
 
 ## 1.0.0-alpha.4 - 2026-06-30
 

--- a/docs/en/features/callbacks-and-keyboards.md
+++ b/docs/en/features/callbacks-and-keyboards.md
@@ -47,7 +47,11 @@ Create buttons:
 
 ```csharp
 [CommandTemplate("ticket {id:long}")]
-public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
+public Task Ticket(
+    MessageContext ctx,
+    long id,
+    ICallbackDataSerializer callbackData,
+    CancellationToken ct)
 {
     var keyboard = InlineKeyboardBuilder.Create()
         .Button(
@@ -58,7 +62,7 @@ public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
             "Resolve",
             new TicketAction(id, "resolve"),
             new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-        .Build();
+        .Build(callbackData);
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
 }
@@ -82,7 +86,10 @@ public async Task Handle(
 
 Telegram callback data is limited to 64 UTF-8 bytes. Keep payloads compact.
 
-`[CallbackData("ticket")]` enables TeleFlow's compact serializer for that payload type. A payload like `new TicketAction(42, "take")` is serialized as a short prefix-plus-fields string instead of verbose JSON. If the serialized value exceeds Telegram's 64-byte limit, TeleFlow fails before sending the keyboard.
+Typed callback buttons use the configured `ICallbackDataSerializer`.
+Raw callback strings are preserved exactly and do not go through the serializer.
+
+`[CallbackData("ticket")]` enables TeleFlow's compact default serializer for that payload type. A payload like `new TicketAction(42, "take")` is serialized as a short prefix-plus-fields string instead of verbose JSON. If the serialized value exceeds Telegram's 64-byte limit, TeleFlow fails before sending the keyboard.
 
 Invalid typed callback data does not match the typed handler. Serializer failures that are not normal parse/format failures are treated as real failures and remain observable.
 

--- a/docs/en/tutorials/support-desk.md
+++ b/docs/en/tutorials/support-desk.md
@@ -326,7 +326,11 @@ public sealed class AdminTicketHandlers
     }
 
     [CommandTemplate("ticket {id:long}")]
-    public async Task Show(MessageContext ctx, long id, CancellationToken ct)
+    public async Task Show(
+        MessageContext ctx,
+        long id,
+        ICallbackDataSerializer callbackData,
+        CancellationToken ct)
     {
         if (ctx.Sender is null || !_admins.IsAdmin(ctx.Sender.Id))
         {
@@ -350,7 +354,7 @@ public sealed class AdminTicketHandlers
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
                 new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build();
+            .Build(callbackData);
 
         await ctx.Message.AnswerAsync(
             $"Ticket #{ticket.Id}\nStatus: {ticket.Status}\n{ticket.Description}",

--- a/docs/ru/features/callbacks-and-keyboards.md
+++ b/docs/ru/features/callbacks-and-keyboards.md
@@ -47,7 +47,11 @@ public sealed record TicketAction(long Id, string Action);
 
 ```csharp
 [CommandTemplate("ticket {id:long}")]
-public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
+public Task Ticket(
+    MessageContext ctx,
+    long id,
+    ICallbackDataSerializer callbackData,
+    CancellationToken ct)
 {
     var keyboard = InlineKeyboardBuilder.Create()
         .Button(
@@ -58,7 +62,7 @@ public Task Ticket(MessageContext ctx, long id, CancellationToken ct)
             "Resolve",
             new TicketAction(id, "resolve"),
             new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-        .Build();
+        .Build(callbackData);
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
 }
@@ -82,7 +86,10 @@ public async Task Handle(
 
 Telegram callback data ограничен 64 UTF-8 bytes. Payloads должны быть компактными.
 
-`[CallbackData("ticket")]` включает compact serializer для этого payload type. Payload вроде `new TicketAction(42, "take")` сериализуется в короткую строку prefix-plus-fields вместо verbose JSON. Если serialized value превышает Telegram limit в 64 bytes, TeleFlow падает до отправки keyboard.
+Typed callback buttons используют настроенный `ICallbackDataSerializer`.
+Raw callback strings сохраняются как есть и не проходят через serializer.
+
+`[CallbackData("ticket")]` включает compact default serializer для этого payload type. Payload вроде `new TicketAction(42, "take")` сериализуется в короткую строку prefix-plus-fields вместо verbose JSON. Если serialized value превышает Telegram limit в 64 bytes, TeleFlow падает до отправки keyboard.
 
 Invalid typed callback data не матчится с typed handler. Serializer failures, которые не являются обычными parse/format failures, считаются реальными failures и остаются observable.
 

--- a/docs/ru/tutorials/support-desk.md
+++ b/docs/ru/tutorials/support-desk.md
@@ -326,7 +326,11 @@ public sealed class AdminTicketHandlers
     }
 
     [CommandTemplate("ticket {id:long}")]
-    public async Task Show(MessageContext ctx, long id, CancellationToken ct)
+    public async Task Show(
+        MessageContext ctx,
+        long id,
+        ICallbackDataSerializer callbackData,
+        CancellationToken ct)
     {
         if (ctx.Sender is null || !_admins.IsAdmin(ctx.Sender.Id))
         {
@@ -350,7 +354,7 @@ public sealed class AdminTicketHandlers
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
                 new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build();
+            .Build(callbackData);
 
         await ctx.Message.AnswerAsync(
             $"Ticket #{ticket.Id}\nStatus: {ticket.Status}\n{ticket.Description}",

--- a/src/TeleFlow.Telegram.Framework/InlineKeyboardBuilder.cs
+++ b/src/TeleFlow.Telegram.Framework/InlineKeyboardBuilder.cs
@@ -1,9 +1,13 @@
 using System.Text;
-using TeleFlow.Telegram.Internal;
+using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Builds Telegram inline keyboard markup for common button scenarios while keeping native
+/// <see cref="InlineKeyboardMarkup"/> available for full Bot API control.
+/// </summary>
 public sealed class InlineKeyboardBuilder
 {
     private const int MaxTelegramCallbackDataBytes = 64;
@@ -39,7 +43,7 @@ public sealed class InlineKeyboardBuilder
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
         ArgumentException.ThrowIfNullOrWhiteSpace(callbackData);
-        ValidateCallbackDataLength(callbackData);
+        ValidateCallbackData(callbackData);
 
         ValidateOptions(options);
         CurrentRow.Add(InlineKeyboardButtonIntent.RawCallbackData(text, callbackData, options));
@@ -92,10 +96,22 @@ public sealed class InlineKeyboardBuilder
 
     public InlineKeyboardMarkup Build()
     {
+        return BuildCore(callbackData: null);
+    }
+
+    public InlineKeyboardMarkup Build(ICallbackDataSerializer callbackData)
+    {
+        ArgumentNullException.ThrowIfNull(callbackData);
+
+        return BuildCore(callbackData);
+    }
+
+    private InlineKeyboardMarkup BuildCore(ICallbackDataSerializer? callbackData)
+    {
         var rows = _rows
             .Where(static row => row.Count > 0)
-            .Select(static row => row
-                .Select(static intent => intent.ToButton())
+            .Select(row => row
+                .Select(intent => intent.ToButton(callbackData))
                 .ToArray())
             .ToArray();
 
@@ -121,24 +137,13 @@ public sealed class InlineKeyboardBuilder
         return this;
     }
 
-    private static string PackTypedCallbackPayload(object payload)
+    private static void ValidateCallbackData(string callbackData)
     {
-        var payloadType = payload.GetType();
-
-        if (!CallbackDataMetadata.TryCreate(payloadType, out var metadata))
+        if (string.IsNullOrWhiteSpace(callbackData))
         {
-            throw new InvalidOperationException(
-                $"Inline keyboard callback payload type '{payloadType.FullName}' must declare CallbackDataAttribute. " +
-                "Pass raw string callback data when using a custom callback data format.");
+            throw new InvalidOperationException("Telegram callback data must not be empty.");
         }
 
-        var callbackData = metadata.Pack(payload);
-        ValidateCallbackDataLength(callbackData);
-        return callbackData;
-    }
-
-    private static void ValidateCallbackDataLength(string callbackData)
-    {
         if (Encoding.UTF8.GetByteCount(callbackData) > MaxTelegramCallbackDataBytes)
         {
             throw new InvalidOperationException(
@@ -166,17 +171,24 @@ public sealed class InlineKeyboardBuilder
 
     private sealed record InlineKeyboardButtonIntent(
         string Text,
-        object? Payload,
+        Func<ICallbackDataSerializer, string>? SerializePayload,
+        Type? PayloadType,
         string? CallbackData,
         string? Url,
         InlineKeyboardButtonOptions? Options)
     {
-        public static InlineKeyboardButtonIntent TypedPayload(
+        public static InlineKeyboardButtonIntent TypedPayload<TPayload>(
             string text,
-            object payload,
+            TPayload payload,
             InlineKeyboardButtonOptions? options)
         {
-            return new InlineKeyboardButtonIntent(text, payload, CallbackData: null, Url: null, options);
+            return new InlineKeyboardButtonIntent(
+                text,
+                serializer => serializer.Serialize(payload),
+                typeof(TPayload),
+                CallbackData: null,
+                Url: null,
+                options);
         }
 
         public static InlineKeyboardButtonIntent RawCallbackData(
@@ -184,7 +196,13 @@ public sealed class InlineKeyboardBuilder
             string callbackData,
             InlineKeyboardButtonOptions? options)
         {
-            return new InlineKeyboardButtonIntent(text, Payload: null, callbackData, Url: null, options);
+            return new InlineKeyboardButtonIntent(
+                text,
+                SerializePayload: null,
+                PayloadType: null,
+                callbackData,
+                Url: null,
+                options);
         }
 
         public static InlineKeyboardButtonIntent Link(
@@ -192,17 +210,33 @@ public sealed class InlineKeyboardBuilder
             string url,
             InlineKeyboardButtonOptions? options)
         {
-            return new InlineKeyboardButtonIntent(text, Payload: null, CallbackData: null, url, options);
+            return new InlineKeyboardButtonIntent(
+                text,
+                SerializePayload: null,
+                PayloadType: null,
+                CallbackData: null,
+                url,
+                options);
         }
 
-        public InlineKeyboardButton ToButton()
+        public InlineKeyboardButton ToButton(ICallbackDataSerializer? callbackData)
         {
-            if (Payload is not null)
+            if (SerializePayload is not null)
             {
+                if (callbackData is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Inline keyboard typed callback payload '{PayloadType?.FullName}' requires ICallbackDataSerializer. " +
+                        "Use Build(callbackData) or pass raw string callback data.");
+                }
+
+                var serializedPayload = SerializePayload(callbackData);
+                ValidateCallbackData(serializedPayload);
+
                 return ApplyOptions(new InlineKeyboardButton
                 {
                     Text = Text,
-                    CallbackData = PackTypedCallbackPayload(Payload)
+                    CallbackData = serializedPayload
                 });
             }
 

--- a/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using TeleFlow.Annotations;
+using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Types;
@@ -22,7 +24,7 @@ public sealed class KeyboardBuilderTests
             .Button("Raw", "raw:42", new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
             .Row()
             .Url("Open", "https://example.com", new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build();
+            .Build(CreateDefaultCallbackDataSerializer());
 
         Assert.Equal(2, markup.InlineKeyboard.Count);
         Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
@@ -45,15 +47,68 @@ public sealed class KeyboardBuilderTests
     }
 
     [Fact]
-    public void InlineKeyboardBuilder_TypedCallbackPayload_RequiresCallbackDataAttribute()
+    public void InlineKeyboardBuilder_TypedCallbackPayload_RequiresSerializer()
     {
         var keyboard = InlineKeyboardBuilder.Create()
-            .Button("Invalid", new UnannotatedInlineKeyboardCallback(42));
+            .Button("Delete", new InlineKeyboardDeleteCallback(42));
 
         var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build());
 
-        Assert.Contains(nameof(CallbackDataAttribute), exception.Message);
+        Assert.Contains(nameof(ICallbackDataSerializer), exception.Message);
+        Assert.Contains("Build(callbackData)", exception.Message);
         Assert.Contains("raw string callback data", exception.Message);
+    }
+
+    [Fact]
+    public void InlineKeyboardBuilder_TypedCallbackPayload_UsesDefaultCompactSerializer()
+    {
+        var markup = InlineKeyboardBuilder.Create()
+            .Button("Delete", new InlineKeyboardDeleteCallback(42))
+            .Build(CreateDefaultCallbackDataSerializer());
+
+        Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
+    }
+
+    [Fact]
+    public void InlineKeyboardBuilder_TypedCallbackPayload_UsesCustomSerializer()
+    {
+        var markup = InlineKeyboardBuilder.Create()
+            .Button("Delete", new InlineKeyboardDeleteCallback(42))
+            .Build(new CustomInlineKeyboardCallbackDataSerializer());
+
+        Assert.Equal("custom:42", markup.InlineKeyboard[0][0].CallbackData);
+    }
+
+    [Fact]
+    public void InlineKeyboardBuilder_TypedCallbackPayload_SupportsJsonFallbackThroughDefaultSerializer()
+    {
+        var markup = InlineKeyboardBuilder.Create()
+            .Button("Json", new UnannotatedInlineKeyboardCallback(42))
+            .Build(CreateDefaultCallbackDataSerializer());
+
+        Assert.Equal("""{"id":42}""", markup.InlineKeyboard[0][0].CallbackData);
+    }
+
+    [Fact]
+    public void InlineKeyboardBuilder_RawCallbackData_DoesNotUseSerializer()
+    {
+        var markup = InlineKeyboardBuilder.Create()
+            .Button("Raw", "raw:42")
+            .Build(new ThrowingInlineKeyboardCallbackDataSerializer());
+
+        Assert.Equal("raw:42", markup.InlineKeyboard[0][0].CallbackData);
+    }
+
+    [Fact]
+    public void InlineKeyboardBuilder_RejectsEmptySerializedTypedCallbackData()
+    {
+        var keyboard = InlineKeyboardBuilder.Create()
+            .Button("Empty", new InlineKeyboardDeleteCallback(42));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => keyboard.Build(new EmptyInlineKeyboardCallbackDataSerializer()));
+
+        Assert.Contains("must not be empty", exception.Message);
     }
 
     [Fact]
@@ -71,7 +126,7 @@ public sealed class KeyboardBuilderTests
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Large", new LargeInlineKeyboardCallback(new string('x', 80)));
 
-        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build());
+        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build(CreateDefaultCallbackDataSerializer()));
 
         Assert.Contains("64", exception.Message);
     }
@@ -187,4 +242,50 @@ public sealed class KeyboardBuilderTests
     private sealed record LargeInlineKeyboardCallback(string Value);
 
     private sealed record UnannotatedInlineKeyboardCallback(int Id);
+
+    private static ICallbackDataSerializer CreateDefaultCallbackDataSerializer()
+    {
+        return new JsonCallbackDataSerializer(TelegramJsonOptions.CreateDefault());
+    }
+
+    private sealed class CustomInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
+    {
+        public string Serialize<TPayload>(TPayload payload)
+        {
+            return payload is InlineKeyboardDeleteCallback callback
+                ? $"custom:{callback.Id}"
+                : throw new InvalidOperationException("Unexpected callback payload type.");
+        }
+
+        public TPayload Deserialize<TPayload>(string serializedPayload)
+        {
+            throw new JsonException("This test serializer only supports serialization.");
+        }
+    }
+
+    private sealed class ThrowingInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
+    {
+        public string Serialize<TPayload>(TPayload payload)
+        {
+            throw new InvalidOperationException("Raw callback data must not use callback data serializer.");
+        }
+
+        public TPayload Deserialize<TPayload>(string serializedPayload)
+        {
+            throw new JsonException("This test serializer only supports serialization.");
+        }
+    }
+
+    private sealed class EmptyInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
+    {
+        public string Serialize<TPayload>(TPayload payload)
+        {
+            return string.Empty;
+        }
+
+        public TPayload Deserialize<TPayload>(string serializedPayload)
+        {
+            throw new JsonException("This test serializer only supports serialization.");
+        }
+    }
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -2057,12 +2057,13 @@ public sealed class TelegramRuntimeIntegrationTests
                     }
                 }));
 
+        var messageContext = context.GetMessageContext();
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Delete", new KeyboardDeleteCallback(42))
             .Url("Open", "https://example.com")
-            .Build();
+            .Build(messageContext.CallbackData);
 
-        await context.GetMessageContext().Message.AnswerAsync("choose", keyboard);
+        await messageContext.Message.AnswerAsync("choose", keyboard);
 
         var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
         Assert.Null(sendMessage.ReplyParameters);
@@ -2319,11 +2320,12 @@ public sealed class TelegramRuntimeIntegrationTests
         using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
         var context = CreateScopedMessageUpdateContext(serviceProvider);
 
+        var messageContext = context.GetMessageContext();
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Delete", new KeyboardDeleteCallback(42))
-            .Build();
+            .Build(messageContext.CallbackData);
 
-        await context.GetMessageContext().Message.AnswerPhotoAsync(
+        await messageContext.Message.AnswerPhotoAsync(
             InputFileString.From("photo-file-id"),
             ReplyMarkup.From(keyboard),
             caption: "choose");
@@ -2868,11 +2870,12 @@ public sealed class TelegramRuntimeIntegrationTests
                     }
                 }));
 
+        var callbackContext = context.GetCallbackQueryContext();
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Next", new KeyboardDeleteCallback(99))
-            .Build();
+            .Build(callbackContext.CallbackData);
 
-        await context.GetCallbackQueryContext().Callback.EditTextAsync("edited", keyboard);
+        await callbackContext.Callback.EditTextAsync("edited", keyboard);
 
         var edit = Assert.IsType<EditMessageText>(fakeClient.Methods.Single());
         Assert.Equal("inline-42", edit.InlineMessageId);


### PR DESCRIPTION
## Summary
- route typed inline keyboard callback payloads through the configured `ICallbackDataSerializer`
- keep raw callback strings untouched so custom opaque callback formats remain cheap and explicit
- update keyboard documentation and runtime integration tests for the new `Build(callbackData)` contract

## Behavior
Typed callback buttons now require `InlineKeyboardBuilder.Build(callbackData)`. Calling parameterless `Build()` with typed payloads fails early with a clear message. Parameterless `Build()` still works for raw callback data and URL-only keyboards.

This keeps keyboard serialization aligned with callback route deserialization and with applications that replace the default callback serializer.

## Validation
- `dotnet test TeleFlow.sln`
- `git diff --cached --check`
- `git diff --check`

Closes #86