### PR TITLE
docs(registration): define explicit handler registration contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 ### Changed
 
 - Typed inline keyboard callback payloads now serialize through the configured `ICallbackDataSerializer` via `InlineKeyboardBuilder.Build(callbackData)`, while raw callback strings are preserved exactly.
+- Handler registration docs and API comments now define generated assembly registration, explicit direct registration, and deprecated reflection assembly registration as separate contracts.
 
 ## 1.0.0-alpha.4 - 2026-06-30
 

--- a/docs/en/advanced/generated-registration.md
+++ b/docs/en/advanced/generated-registration.md
@@ -57,6 +57,36 @@ If metadata is not found, it throws. It does not silently scan the assembly with
 
 This is important for production code. A missing generator package is a configuration mistake, not a reason to change runtime behavior.
 
+## Registration Contract
+
+TeleFlow intentionally keeps assembly registration and explicit type registration separate.
+
+`AddTelegramHandlersFromAssembly(assembly)` means:
+
+- register generated metadata for that assembly;
+- require `IWF.TeleFlow.Generators`;
+- fail if generated metadata is missing;
+- never scan the assembly for handlers as a fallback.
+
+`AddTelegramHandler<THandler>()` means:
+
+- register exactly the named handler type;
+- build metadata for that type at startup;
+- do not scan the containing assembly;
+- do not require the generator.
+
+`AddTelegramModule<TModule>()` means:
+
+- register exactly the named module type;
+- require `[TelegramModule]` on the module type;
+- use generated metadata for that module when available;
+- otherwise build metadata for that module type at startup;
+- do not scan the containing assembly.
+
+The direct path is explicit by design. It is useful for tests, tiny examples,
+and manually composed modules. It is not the recommended default for large
+applications because every handler must be listed manually.
+
 ## Direct Registration
 
 Direct registration does not need the generator:

--- a/docs/en/fundamentals/handlers-and-routing.md
+++ b/docs/en/fundamentals/handlers-and-routing.md
@@ -153,7 +153,8 @@ builder.Services.AddTelegramHandler<StartHandler>();
 builder.Services.AddTelegramModule<AdminHandlers>();
 ```
 
-Use it for small apps, tests, or narrow modules.
+Use it for small apps, tests, or narrow modules. Direct registration registers
+only the named handler or module type; it does not scan the assembly around it.
 
 ## Assembly Registration
 

--- a/docs/en/getting-started/packages.md
+++ b/docs/en/getting-started/packages.md
@@ -110,6 +110,11 @@ services.AddTelegramHandler<StartHandler>();
 services.AddTelegramModule<AdminModule>();
 ```
 
+Direct registration registers only the named type. It builds metadata for that
+type at startup and does not scan the containing assembly. `AddTelegramModule<T>()`
+uses generated metadata when available, then falls back to direct metadata for
+the named module type only.
+
 Reflection assembly registration is deprecated and will be removed before `1.0`:
 
 ```csharp

--- a/docs/ru/advanced/generated-registration.md
+++ b/docs/ru/advanced/generated-registration.md
@@ -57,6 +57,36 @@ public sealed class StartHandler
 
 Это важно для production code. Missing generator package - configuration mistake, а не причина менять runtime behavior.
 
+## Контракт регистрации
+
+TeleFlow намеренно разделяет assembly registration и explicit type registration.
+
+`AddTelegramHandlersFromAssembly(assembly)` означает:
+
+- зарегистрировать generated metadata для этого assembly;
+- требовать `IWF.TeleFlow.Generators`;
+- упасть, если generated metadata отсутствует;
+- никогда не сканировать assembly как fallback.
+
+`AddTelegramHandler<THandler>()` означает:
+
+- зарегистрировать ровно указанный handler type;
+- построить metadata для этого type на startup;
+- не сканировать containing assembly;
+- не требовать generator.
+
+`AddTelegramModule<TModule>()` означает:
+
+- зарегистрировать ровно указанный module type;
+- требовать `[TelegramModule]` на module type;
+- использовать generated metadata для этого module, если она доступна;
+- иначе построить metadata для этого module type на startup;
+- не сканировать containing assembly.
+
+Direct path сделан явным специально. Он удобен для tests, маленьких examples
+и manually composed modules. Для больших приложений это не recommended default,
+потому что каждый handler нужно перечислять руками.
+
 ## Прямая регистрация
 
 Direct registration не требует generator:

--- a/docs/ru/fundamentals/handlers-and-routing.md
+++ b/docs/ru/fundamentals/handlers-and-routing.md
@@ -153,7 +153,9 @@ builder.Services.AddTelegramHandler<StartHandler>();
 builder.Services.AddTelegramModule<AdminHandlers>();
 ```
 
-Используй её для маленьких apps, tests или узких modules.
+Используй её для маленьких apps, tests или узких modules. Direct registration
+регистрирует только указанный handler или module type и не сканирует assembly
+вокруг него.
 
 ## Assembly registration
 

--- a/docs/ru/getting-started/packages.md
+++ b/docs/ru/getting-started/packages.md
@@ -110,6 +110,11 @@ services.AddTelegramHandler<StartHandler>();
 services.AddTelegramModule<AdminModule>();
 ```
 
+Direct registration регистрирует только указанный type. Он строит metadata для
+этого type на startup и не сканирует containing assembly. `AddTelegramModule<T>()`
+использует generated metadata, когда она доступна, а затем fallback на direct
+metadata только для указанного module type.
+
 Reflection assembly registration объявлен deprecated и будет удалён до `1.0`:
 
 ```csharp

--- a/src/TeleFlow.Telegram.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Telegram.Framework/TelegramServiceCollectionExtensions.cs
@@ -10,6 +10,9 @@ using TeleFlow.Telegram.Internal.Options;
 
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Registers Telegram bot framework services, handler metadata, and Telegram-specific extension points.
+/// </summary>
 public static class TelegramServiceCollectionExtensions
 {
     private const string ReflectionAssemblyRegistrationObsoleteDiagnosticId = "TLF900";
@@ -89,6 +92,10 @@ public static class TelegramServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers all generated Telegram handler metadata from an assembly.
+    /// This API requires build-time metadata from <c>IWF.TeleFlow.Generators</c> and never falls back to assembly scanning.
+    /// </summary>
     public static IServiceCollection AddTelegramHandlersFromAssembly(
         this IServiceCollection services,
         Assembly assembly)
@@ -111,6 +118,10 @@ public static class TelegramServiceCollectionExtensions
             $"Use {nameof(AddTelegramHandler)}<THandler>() or {nameof(AddTelegramModule)}<TModule>() for explicit direct registration.");
     }
 
+    /// <summary>
+    /// Registers all Telegram handler types discovered by scanning an assembly at startup.
+    /// This API is a deprecated migration path and should not be used by new applications.
+    /// </summary>
     [Obsolete(
         ReflectionAssemblyRegistrationObsoleteMessage,
         DiagnosticId = ReflectionAssemblyRegistrationObsoleteDiagnosticId)]
@@ -133,6 +144,9 @@ public static class TelegramServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers one explicitly named handler type by building its metadata at startup without scanning its assembly.
+    /// </summary>
     public static IServiceCollection AddTelegramHandler<THandler>(this IServiceCollection services)
         where THandler : class
     {
@@ -144,6 +158,10 @@ public static class TelegramServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers one explicitly named Telegram module type. Generated metadata is used when available; otherwise
+    /// metadata is built at startup for the named module type only.
+    /// </summary>
     public static IServiceCollection AddTelegramModule<TModule>(this IServiceCollection services)
         where TModule : class
     {

--- a/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
@@ -317,6 +317,28 @@ public sealed class StageEightGeneratedRegistrationTests
     }
 
     [Fact]
+    public async Task AddTelegramModule_FallsBackToDirectRegistrationWithoutScanningAssembly()
+    {
+        var services = new ServiceCollection();
+
+        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddSingleton<GeneratedHandlerProbe>();
+        services.AddTelegramModule<DirectOnlyGeneratedAssemblyModule>();
+
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/direct-module"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/reflection-only"));
+
+        Assert.Equal(["direct-module:/direct-module"], probe.Events);
+    }
+
+    [Fact]
     public async Task GeneratedRouteValueParameter_FailsClearlyWhenRouteDoesNotProvideValue()
     {
         using var serviceProvider = CreateServiceProvider();
@@ -1576,6 +1598,17 @@ public sealed class GeneratedModuleHandler
     public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
     {
         probe.Events.Add($"module:{context.TelegramMessage.Text}");
+        return Task.CompletedTask;
+    }
+}
+
+[TelegramModule("direct-only")]
+public sealed class DirectOnlyGeneratedAssemblyModule
+{
+    [Command("direct-module")]
+    public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
+    {
+        probe.Events.Add($"direct-module:{context.TelegramMessage.Text}");
         return Task.CompletedTask;
     }
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -1595,6 +1595,20 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task AddTelegramHandler_RegistersOnlyExplicitHandlerType()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<DirectOnlyCommandHandler>());
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/direct-only"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/direct-sibling"));
+
+        Assert.Equal(["direct-only:/direct-only"], probe.Events);
+    }
+
+    [Fact]
     public async Task MyChatMemberUpdatedHandler_DispatchesMyChatMemberUpdate()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -3293,6 +3307,26 @@ public sealed class TelegramHandlerDispatcherTests
         [Command("start")]
         public Task Handle(MessageContext context)
         {
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class DirectOnlyCommandHandler
+    {
+        [Command("direct-only")]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"direct-only:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class DirectSiblingCommandHandler
+    {
+        [Command("direct-sibling")]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"direct-sibling:{context.TelegramMessage.Text}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- document the registration contract for generated assembly registration, explicit direct registration, and deprecated reflection assembly registration
- add API summaries that make the registration behavior visible from IDE tooling
- add regression/spec tests proving direct handler/module registration does not scan the containing assembly

## Behavior
No runtime dispatch behavior changes are intended.

The PR clarifies the existing policy:
- `AddTelegramHandlersFromAssembly(...)` requires generated metadata and never falls back to assembly scanning.
- `AddTelegramHandler<THandler>()` registers exactly the named handler type.
- `AddTelegramModule<TModule>()` uses generated metadata when available and otherwise builds metadata for the named module type only.
- `AddTelegramHandlersFromAssemblyReflection(...)` remains a deprecated migration path.

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~AddTelegramHandler_RegistersOnlyExplicitHandlerType|FullyQualifiedName~AddTelegramModule_FallsBackToDirectRegistrationWithoutScanningAssembly|FullyQualifiedName~AddTelegramModule_UsesGeneratedRegistrarForSingleModuleOnly|FullyQualifiedName~AddTelegramHandlersFromAssembly_RequiresGeneratedHandlerMetadata"`
- `dotnet test TeleFlow.sln`
- `git diff --check`

Closes #91