### PR TITLE
feat(keyboards): pack typed callbacks without serializer

### DIFF
--- a/docs/en/features/callbacks-and-keyboards.md
+++ b/docs/en/features/callbacks-and-keyboards.md
@@ -50,7 +50,6 @@ Create buttons:
 public Task Ticket(
     MessageContext ctx,
     long id,
-    ICallbackDataSerializer callbackData,
     CancellationToken ct)
 {
     var keyboard = InlineKeyboardBuilder.Create()
@@ -62,7 +61,7 @@ public Task Ticket(
             "Resolve",
             new TicketAction(id, "resolve"),
             new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-        .Build(callbackData);
+        .Build();
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
 }
@@ -86,10 +85,14 @@ public async Task Handle(
 
 Telegram callback data is limited to 64 UTF-8 bytes. Keep payloads compact.
 
-Typed callback buttons use the configured `ICallbackDataSerializer`.
-Raw callback strings are preserved exactly and do not go through the serializer.
+Typed callback buttons use `[CallbackData]` compact metadata directly.
+Raw callback strings are preserved exactly and do not go through typed payload packing.
 
-`[CallbackData("ticket")]` enables TeleFlow's compact default serializer for that payload type. A payload like `new TicketAction(42, "take")` is serialized as a short prefix-plus-fields string instead of verbose JSON. If the serialized value exceeds Telegram's 64-byte limit, TeleFlow fails before sending the keyboard.
+`[CallbackData("ticket")]` enables TeleFlow's compact callback data format for that payload type. A payload like `new TicketAction(42, "take")` is packed as a short prefix-plus-fields string instead of verbose JSON. If the packed value exceeds Telegram's 64-byte limit, TeleFlow fails before sending the keyboard.
+
+Typed inline keyboard payloads must be marked with `[CallbackData]`. If you need an external key, Redis key, or your own opaque format, pass raw string callback data instead.
+
+Custom `ICallbackDataSerializer` implementations remain available for advanced callback payload serialization and route deserialization, but typed inline keyboard buttons use `[CallbackData]` metadata directly.
 
 Invalid typed callback data does not match the typed handler. Serializer failures that are not normal parse/format failures are treated as real failures and remain observable.
 

--- a/docs/en/tutorials/support-desk.md
+++ b/docs/en/tutorials/support-desk.md
@@ -329,7 +329,6 @@ public sealed class AdminTicketHandlers
     public async Task Show(
         MessageContext ctx,
         long id,
-        ICallbackDataSerializer callbackData,
         CancellationToken ct)
     {
         if (ctx.Sender is null || !_admins.IsAdmin(ctx.Sender.Id))
@@ -354,7 +353,7 @@ public sealed class AdminTicketHandlers
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
                 new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build(callbackData);
+            .Build();
 
         await ctx.Message.AnswerAsync(
             $"Ticket #{ticket.Id}\nStatus: {ticket.Status}\n{ticket.Description}",

--- a/docs/ru/features/callbacks-and-keyboards.md
+++ b/docs/ru/features/callbacks-and-keyboards.md
@@ -50,7 +50,6 @@ public sealed record TicketAction(long Id, string Action);
 public Task Ticket(
     MessageContext ctx,
     long id,
-    ICallbackDataSerializer callbackData,
     CancellationToken ct)
 {
     var keyboard = InlineKeyboardBuilder.Create()
@@ -62,7 +61,7 @@ public Task Ticket(
             "Resolve",
             new TicketAction(id, "resolve"),
             new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-        .Build(callbackData);
+        .Build();
 
     return ctx.Message.AnswerAsync($"Ticket #{id}", keyboard, ct);
 }
@@ -86,10 +85,14 @@ public async Task Handle(
 
 Telegram callback data ограничен 64 UTF-8 bytes. Payloads должны быть компактными.
 
-Typed callback buttons используют настроенный `ICallbackDataSerializer`.
-Raw callback strings сохраняются как есть и не проходят через serializer.
+Typed callback buttons используют compact metadata из `[CallbackData]` напрямую.
+Raw callback strings сохраняются как есть и не проходят через typed payload packing.
 
-`[CallbackData("ticket")]` включает compact default serializer для этого payload type. Payload вроде `new TicketAction(42, "take")` сериализуется в короткую строку prefix-plus-fields вместо verbose JSON. Если serialized value превышает Telegram limit в 64 bytes, TeleFlow падает до отправки keyboard.
+`[CallbackData("ticket")]` включает compact callback data format для этого payload type. Payload вроде `new TicketAction(42, "take")` упаковывается в короткую строку prefix-plus-fields вместо verbose JSON. Если packed value превышает Telegram limit в 64 bytes, TeleFlow падает до отправки keyboard.
+
+Typed inline keyboard payloads должны быть помечены `[CallbackData]`. Если нужен внешний ключ, Redis key или свой opaque format, передавай raw string callback data.
+
+Custom `ICallbackDataSerializer` implementations остаются доступны для advanced callback payload serialization и route deserialization, но typed inline keyboard buttons используют `[CallbackData]` metadata напрямую.
 
 Invalid typed callback data не матчится с typed handler. Serializer failures, которые не являются обычными parse/format failures, считаются реальными failures и остаются observable.
 

--- a/docs/ru/tutorials/support-desk.md
+++ b/docs/ru/tutorials/support-desk.md
@@ -329,7 +329,6 @@ public sealed class AdminTicketHandlers
     public async Task Show(
         MessageContext ctx,
         long id,
-        ICallbackDataSerializer callbackData,
         CancellationToken ct)
     {
         if (ctx.Sender is null || !_admins.IsAdmin(ctx.Sender.Id))
@@ -354,7 +353,7 @@ public sealed class AdminTicketHandlers
                 "Resolve",
                 new TicketAction(ticket.Id, "resolve"),
                 new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build(callbackData);
+            .Build();
 
         await ctx.Message.AnswerAsync(
             $"Ticket #{ticket.Id}\nStatus: {ticket.Status}\n{ticket.Description}",

--- a/src/TeleFlow.Telegram.Framework/InlineKeyboardBuilder.cs
+++ b/src/TeleFlow.Telegram.Framework/InlineKeyboardBuilder.cs
@@ -1,5 +1,4 @@
-using System.Text;
-using TeleFlow.Core.Callbacks;
+using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram;
@@ -10,8 +9,6 @@ namespace TeleFlow.Telegram;
 /// </summary>
 public sealed class InlineKeyboardBuilder
 {
-    private const int MaxTelegramCallbackDataBytes = 64;
-
     private readonly List<List<InlineKeyboardButtonIntent>> _rows = [[]];
 
     private InlineKeyboardBuilder()
@@ -96,22 +93,15 @@ public sealed class InlineKeyboardBuilder
 
     public InlineKeyboardMarkup Build()
     {
-        return BuildCore(callbackData: null);
+        return BuildCore();
     }
 
-    public InlineKeyboardMarkup Build(ICallbackDataSerializer callbackData)
-    {
-        ArgumentNullException.ThrowIfNull(callbackData);
-
-        return BuildCore(callbackData);
-    }
-
-    private InlineKeyboardMarkup BuildCore(ICallbackDataSerializer? callbackData)
+    private InlineKeyboardMarkup BuildCore()
     {
         var rows = _rows
             .Where(static row => row.Count > 0)
             .Select(row => row
-                .Select(intent => intent.ToButton(callbackData))
+                .Select(static intent => intent.ToButton())
                 .ToArray())
             .ToArray();
 
@@ -139,16 +129,7 @@ public sealed class InlineKeyboardBuilder
 
     private static void ValidateCallbackData(string callbackData)
     {
-        if (string.IsNullOrWhiteSpace(callbackData))
-        {
-            throw new InvalidOperationException("Telegram callback data must not be empty.");
-        }
-
-        if (Encoding.UTF8.GetByteCount(callbackData) > MaxTelegramCallbackDataBytes)
-        {
-            throw new InvalidOperationException(
-                $"Telegram callback data must be at most {MaxTelegramCallbackDataBytes} UTF-8 bytes.");
-        }
+        CallbackDataCodec.ValidateCallbackData(callbackData, "Telegram callback data");
     }
 
     private static void ValidateOptions(InlineKeyboardButtonOptions? options)
@@ -171,7 +152,7 @@ public sealed class InlineKeyboardBuilder
 
     private sealed record InlineKeyboardButtonIntent(
         string Text,
-        Func<ICallbackDataSerializer, string>? SerializePayload,
+        object? Payload,
         Type? PayloadType,
         string? CallbackData,
         string? Url,
@@ -182,10 +163,12 @@ public sealed class InlineKeyboardBuilder
             TPayload payload,
             InlineKeyboardButtonOptions? options)
         {
+            ArgumentNullException.ThrowIfNull(payload);
+
             return new InlineKeyboardButtonIntent(
                 text,
-                serializer => serializer.Serialize(payload),
-                typeof(TPayload),
+                payload,
+                payload.GetType(),
                 CallbackData: null,
                 Url: null,
                 options);
@@ -198,7 +181,7 @@ public sealed class InlineKeyboardBuilder
         {
             return new InlineKeyboardButtonIntent(
                 text,
-                SerializePayload: null,
+                Payload: null,
                 PayloadType: null,
                 callbackData,
                 Url: null,
@@ -212,26 +195,23 @@ public sealed class InlineKeyboardBuilder
         {
             return new InlineKeyboardButtonIntent(
                 text,
-                SerializePayload: null,
+                Payload: null,
                 PayloadType: null,
                 CallbackData: null,
                 url,
                 options);
         }
 
-        public InlineKeyboardButton ToButton(ICallbackDataSerializer? callbackData)
+        public InlineKeyboardButton ToButton()
         {
-            if (SerializePayload is not null)
+            if (Payload is not null)
             {
-                if (callbackData is null)
+                if (PayloadType is null)
                 {
-                    throw new InvalidOperationException(
-                        $"Inline keyboard typed callback payload '{PayloadType?.FullName}' requires ICallbackDataSerializer. " +
-                        "Use Build(callbackData) or pass raw string callback data.");
+                    throw new InvalidOperationException("Inline keyboard typed callback payload type is missing.");
                 }
 
-                var serializedPayload = SerializePayload(callbackData);
-                ValidateCallbackData(serializedPayload);
+                var serializedPayload = CallbackDataCodec.PackRequired(Payload, PayloadType);
 
                 return ApplyOptions(new InlineKeyboardButton
                 {

--- a/src/TeleFlow.Telegram.Framework/Internal/CallbackDataCodec.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/CallbackDataCodec.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using System.Text.Json;
+using TeleFlow.Annotations;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Packs and unpacks compact Telegram callback payloads used by typed callback handlers
+/// and inline keyboard builders before data is sent to or received from Telegram.
+/// </summary>
+internal static class CallbackDataCodec
+{
+    public const int MaxTelegramCallbackDataBytes = 64;
+
+    public static string PackRequired(object payload, Type payloadType)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(payloadType);
+
+        if (!CallbackDataMetadata.TryCreate(payloadType, out var metadata))
+        {
+            throw new InvalidOperationException(
+                $"Inline keyboard typed callback payload '{payloadType.FullName}' must be marked with " +
+                $"{nameof(CallbackDataAttribute)}. Add [CallbackData(\"prefix\")] to the payload type or pass raw string callback data.");
+        }
+
+        return Pack(payload, metadata);
+    }
+
+    public static string Pack(object payload, CallbackDataMetadata metadata)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var serializedPayload = metadata.Pack(payload);
+        ValidateCallbackData(serializedPayload, "Serialized Telegram callback data");
+        return serializedPayload;
+    }
+
+    public static object Unpack(string serializedPayload, CallbackDataMetadata metadata)
+    {
+        ArgumentNullException.ThrowIfNull(serializedPayload);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var parts = serializedPayload.Split(':');
+
+        if (parts.Length == 0 ||
+            !string.Equals(parts[0], metadata.Prefix, StringComparison.Ordinal))
+        {
+            throw new JsonException(
+                $"Telegram callback data prefix does not match payload type '{metadata.PayloadType.FullName}'.");
+        }
+
+        if (parts.Length - 1 != metadata.Fields.Count)
+        {
+            throw new JsonException(
+                $"Telegram callback data field count does not match payload type '{metadata.PayloadType.FullName}'.");
+        }
+
+        var values = metadata.Fields
+            .Select((field, index) => metadata.ParseField(parts[index + 1], field.Property.PropertyType))
+            .ToArray();
+
+        if (metadata.Constructor is not null)
+        {
+            return metadata.Constructor.Invoke(values);
+        }
+
+        var payload = Activator.CreateInstance(metadata.PayloadType)
+            ?? throw new JsonException($"Unable to create callback data payload type '{metadata.PayloadType.FullName}'.");
+
+        for (var index = 0; index < metadata.Fields.Count; index++)
+        {
+            metadata.Fields[index].Property.SetValue(payload, values[index]);
+        }
+
+        return payload;
+    }
+
+    public static void ValidateCallbackData(string callbackData, string subject)
+    {
+        ArgumentNullException.ThrowIfNull(callbackData);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        if (string.IsNullOrWhiteSpace(callbackData))
+        {
+            throw new InvalidOperationException($"{subject} must not be empty.");
+        }
+
+        if (Encoding.UTF8.GetByteCount(callbackData) > MaxTelegramCallbackDataBytes)
+        {
+            throw new InvalidOperationException(
+                $"{subject} must be at most {MaxTelegramCallbackDataBytes} UTF-8 bytes.");
+        }
+    }
+}

--- a/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
+++ b/src/TeleFlow.Telegram.Framework/Internal/CallbackDataMetadata.cs
@@ -6,6 +6,10 @@ using TeleFlow.Annotations;
 
 namespace TeleFlow.Telegram.Internal;
 
+/// <summary>
+/// Caches compact callback payload metadata discovered from <see cref="CallbackDataAttribute"/>
+/// so typed callback routing and keyboard packing share one prefix-plus-fields contract.
+/// </summary>
 internal sealed class CallbackDataMetadata
 {
     private static readonly ConcurrentDictionary<Type, Lazy<MetadataLookup>> MetadataCache = new();

--- a/src/TeleFlow.Telegram.Framework/JsonCallbackDataSerializer.cs
+++ b/src/TeleFlow.Telegram.Framework/JsonCallbackDataSerializer.cs
@@ -1,14 +1,15 @@
-using System.Text;
 using System.Text.Json;
 using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram.Internal;
 
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Serializes callback payloads for typed callback handlers, using compact
+/// <see cref="TeleFlow.Annotations.CallbackDataAttribute"/> metadata when available and JSON otherwise.
+/// </summary>
 public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
 {
-    private const int MaxTelegramCallbackDataBytes = 64;
-
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
     public JsonCallbackDataSerializer(TelegramJsonOptions jsonOptions)
@@ -22,16 +23,10 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
         ArgumentNullException.ThrowIfNull(payload);
 
         var serializedPayload = CallbackDataMetadata.TryCreate(typeof(TPayload), out var metadata)
-            ? SerializeCompact(payload, metadata)
+            ? CallbackDataCodec.Pack(payload!, metadata)
             : JsonSerializer.Serialize(payload, _jsonSerializerOptions);
 
-        var bytes = Encoding.UTF8.GetBytes(serializedPayload);
-
-        if (bytes.Length > MaxTelegramCallbackDataBytes)
-        {
-            throw new InvalidOperationException(
-                $"Serialized Telegram callback data must be at most {MaxTelegramCallbackDataBytes} UTF-8 bytes.");
-        }
+        CallbackDataCodec.ValidateCallbackData(serializedPayload, "Serialized Telegram callback data");
 
         return serializedPayload;
     }
@@ -42,7 +37,7 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
 
         if (CallbackDataMetadata.TryCreate(typeof(TPayload), out var metadata))
         {
-            return (TPayload)DeserializeCompact(serializedPayload, metadata);
+            return (TPayload)CallbackDataCodec.Unpack(serializedPayload, metadata);
         }
 
         return JsonSerializer.Deserialize<TPayload>(serializedPayload, _jsonSerializerOptions)
@@ -65,7 +60,7 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
                 return false;
             }
 
-            payload = DeserializeCompact(serializedPayload, metadata);
+            payload = CallbackDataCodec.Unpack(serializedPayload, metadata);
             return true;
         }
 
@@ -73,51 +68,9 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
         return true;
     }
 
-    private static string SerializeCompact<TPayload>(TPayload payload, CallbackDataMetadata metadata)
-    {
-        return metadata.Pack(payload!);
-    }
-
     private object DeserializeJson(Type payloadType, string serializedPayload)
     {
         return JsonSerializer.Deserialize(serializedPayload, payloadType, _jsonSerializerOptions)
             ?? throw new JsonException("Telegram callback data deserialized to null.");
-    }
-
-    private static object DeserializeCompact(string serializedPayload, CallbackDataMetadata metadata)
-    {
-        var parts = serializedPayload.Split(':');
-
-        if (parts.Length == 0 ||
-            !string.Equals(parts[0], metadata.Prefix, StringComparison.Ordinal))
-        {
-            throw new JsonException(
-                $"Telegram callback data prefix does not match payload type '{metadata.PayloadType.FullName}'.");
-        }
-
-        if (parts.Length - 1 != metadata.Fields.Count)
-        {
-            throw new JsonException(
-                $"Telegram callback data field count does not match payload type '{metadata.PayloadType.FullName}'.");
-        }
-
-        var values = metadata.Fields
-            .Select((field, index) => metadata.ParseField(parts[index + 1], field.Property.PropertyType))
-            .ToArray();
-
-        if (metadata.Constructor is not null)
-        {
-            return metadata.Constructor.Invoke(values);
-        }
-
-        var payload = Activator.CreateInstance(metadata.PayloadType)
-            ?? throw new JsonException($"Unable to create callback data payload type '{metadata.PayloadType.FullName}'.");
-
-        for (var index = 0; index < metadata.Fields.Count; index++)
-        {
-            metadata.Fields[index].Property.SetValue(payload, values[index]);
-        }
-
-        return payload;
     }
 }

--- a/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/KeyboardBuilderTests.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
 using TeleFlow.Annotations;
-using TeleFlow.Core.Callbacks;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Types;
@@ -24,7 +22,7 @@ public sealed class KeyboardBuilderTests
             .Button("Raw", "raw:42", new InlineKeyboardButtonOptions { Style = ButtonStyles.Primary })
             .Row()
             .Url("Open", "https://example.com", new InlineKeyboardButtonOptions { Style = ButtonStyles.Success })
-            .Build(CreateDefaultCallbackDataSerializer());
+            .Build();
 
         Assert.Equal(2, markup.InlineKeyboard.Count);
         Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
@@ -47,68 +45,47 @@ public sealed class KeyboardBuilderTests
     }
 
     [Fact]
-    public void InlineKeyboardBuilder_TypedCallbackPayload_RequiresSerializer()
-    {
-        var keyboard = InlineKeyboardBuilder.Create()
-            .Button("Delete", new InlineKeyboardDeleteCallback(42));
-
-        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build());
-
-        Assert.Contains(nameof(ICallbackDataSerializer), exception.Message);
-        Assert.Contains("Build(callbackData)", exception.Message);
-        Assert.Contains("raw string callback data", exception.Message);
-    }
-
-    [Fact]
-    public void InlineKeyboardBuilder_TypedCallbackPayload_UsesDefaultCompactSerializer()
+    public void InlineKeyboardBuilder_TypedCallbackPayload_BuildsCompactCallbackData()
     {
         var markup = InlineKeyboardBuilder.Create()
             .Button("Delete", new InlineKeyboardDeleteCallback(42))
-            .Build(CreateDefaultCallbackDataSerializer());
+            .Build();
 
         Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
     }
 
     [Fact]
-    public void InlineKeyboardBuilder_TypedCallbackPayload_UsesCustomSerializer()
+    public void InlineKeyboardBuilder_TypedCallbackPayload_UsesRuntimePayloadType()
     {
-        var markup = InlineKeyboardBuilder.Create()
-            .Button("Delete", new InlineKeyboardDeleteCallback(42))
-            .Build(new CustomInlineKeyboardCallbackDataSerializer());
+        object payload = new InlineKeyboardDeleteCallback(42);
 
-        Assert.Equal("custom:42", markup.InlineKeyboard[0][0].CallbackData);
+        var markup = InlineKeyboardBuilder.Create()
+            .Button("Delete", payload)
+            .Build();
+
+        Assert.Equal("del:42", markup.InlineKeyboard[0][0].CallbackData);
     }
 
     [Fact]
-    public void InlineKeyboardBuilder_TypedCallbackPayload_SupportsJsonFallbackThroughDefaultSerializer()
+    public void InlineKeyboardBuilder_UnannotatedTypedCallbackPayload_FailsClearly()
     {
-        var markup = InlineKeyboardBuilder.Create()
-            .Button("Json", new UnannotatedInlineKeyboardCallback(42))
-            .Build(CreateDefaultCallbackDataSerializer());
+        var keyboard = InlineKeyboardBuilder.Create()
+            .Button("Json", new UnannotatedInlineKeyboardCallback(42));
 
-        Assert.Equal("""{"id":42}""", markup.InlineKeyboard[0][0].CallbackData);
+        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build());
+
+        Assert.Contains(nameof(CallbackDataAttribute), exception.Message);
+        Assert.Contains("raw string callback data", exception.Message);
     }
 
     [Fact]
-    public void InlineKeyboardBuilder_RawCallbackData_DoesNotUseSerializer()
+    public void InlineKeyboardBuilder_RawCallbackData_DoesNotRequireCallbackDataAttribute()
     {
         var markup = InlineKeyboardBuilder.Create()
             .Button("Raw", "raw:42")
-            .Build(new ThrowingInlineKeyboardCallbackDataSerializer());
+            .Build();
 
         Assert.Equal("raw:42", markup.InlineKeyboard[0][0].CallbackData);
-    }
-
-    [Fact]
-    public void InlineKeyboardBuilder_RejectsEmptySerializedTypedCallbackData()
-    {
-        var keyboard = InlineKeyboardBuilder.Create()
-            .Button("Empty", new InlineKeyboardDeleteCallback(42));
-
-        var exception = Assert.Throws<InvalidOperationException>(
-            () => keyboard.Build(new EmptyInlineKeyboardCallbackDataSerializer()));
-
-        Assert.Contains("must not be empty", exception.Message);
     }
 
     [Fact]
@@ -126,7 +103,7 @@ public sealed class KeyboardBuilderTests
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Large", new LargeInlineKeyboardCallback(new string('x', 80)));
 
-        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build(CreateDefaultCallbackDataSerializer()));
+        var exception = Assert.Throws<InvalidOperationException>(() => keyboard.Build());
 
         Assert.Contains("64", exception.Message);
     }
@@ -242,50 +219,4 @@ public sealed class KeyboardBuilderTests
     private sealed record LargeInlineKeyboardCallback(string Value);
 
     private sealed record UnannotatedInlineKeyboardCallback(int Id);
-
-    private static ICallbackDataSerializer CreateDefaultCallbackDataSerializer()
-    {
-        return new JsonCallbackDataSerializer(TelegramJsonOptions.CreateDefault());
-    }
-
-    private sealed class CustomInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
-    {
-        public string Serialize<TPayload>(TPayload payload)
-        {
-            return payload is InlineKeyboardDeleteCallback callback
-                ? $"custom:{callback.Id}"
-                : throw new InvalidOperationException("Unexpected callback payload type.");
-        }
-
-        public TPayload Deserialize<TPayload>(string serializedPayload)
-        {
-            throw new JsonException("This test serializer only supports serialization.");
-        }
-    }
-
-    private sealed class ThrowingInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
-    {
-        public string Serialize<TPayload>(TPayload payload)
-        {
-            throw new InvalidOperationException("Raw callback data must not use callback data serializer.");
-        }
-
-        public TPayload Deserialize<TPayload>(string serializedPayload)
-        {
-            throw new JsonException("This test serializer only supports serialization.");
-        }
-    }
-
-    private sealed class EmptyInlineKeyboardCallbackDataSerializer : ICallbackDataSerializer
-    {
-        public string Serialize<TPayload>(TPayload payload)
-        {
-            return string.Empty;
-        }
-
-        public TPayload Deserialize<TPayload>(string serializedPayload)
-        {
-            throw new JsonException("This test serializer only supports serialization.");
-        }
-    }
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2044,6 +2044,24 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task InlineKeyboardBuilder_CompactCallbackData_DispatchesToTypedCallbackHandler()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<CompactCallbackHandler>());
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        var keyboard = InlineKeyboardBuilder.Create()
+            .Button("Delete", new CompactDeleteCallback("x", 7))
+            .Build();
+        var callbackData = keyboard.InlineKeyboard[0][0].CallbackData;
+
+        await DispatchAsync(serviceProvider, CreateCallbackUpdate(callbackData));
+
+        Assert.Equal("del:x:7", callbackData);
+        Assert.Equal(["compact-callback:x:7"], probe.Events);
+    }
+
+    [Fact]
     public async Task TypedCallbackHandler_RunsBeforeRawFallback()
     {
         using var serviceProvider = CreateServiceProvider(

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -2061,7 +2061,7 @@ public sealed class TelegramRuntimeIntegrationTests
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Delete", new KeyboardDeleteCallback(42))
             .Url("Open", "https://example.com")
-            .Build(messageContext.CallbackData);
+            .Build();
 
         await messageContext.Message.AnswerAsync("choose", keyboard);
 
@@ -2323,7 +2323,7 @@ public sealed class TelegramRuntimeIntegrationTests
         var messageContext = context.GetMessageContext();
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Delete", new KeyboardDeleteCallback(42))
-            .Build(messageContext.CallbackData);
+            .Build();
 
         await messageContext.Message.AnswerPhotoAsync(
             InputFileString.From("photo-file-id"),
@@ -2873,7 +2873,7 @@ public sealed class TelegramRuntimeIntegrationTests
         var callbackContext = context.GetCallbackQueryContext();
         var keyboard = InlineKeyboardBuilder.Create()
             .Button("Next", new KeyboardDeleteCallback(99))
-            .Build(callbackContext.CallbackData);
+            .Build();
 
         await callbackContext.Callback.EditTextAsync("edited", keyboard);
 


### PR DESCRIPTION
## Summary
- make `InlineKeyboardBuilder.Build()` pack typed `[CallbackData]` payloads without requiring `ICallbackDataSerializer`
- move compact callback pack/unpack into a shared internal codec used by keyboard building and default route deserialization
- keep raw string callback data as an exact pass-through path
- update keyboard, dispatcher, runtime integration tests, and EN/RU docs for the new explicit builder contract

## Validation
- `dotnet build TeleFlow.sln`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-build`
- `git diff --cached --check`

Closes #100