### PR TITLE
feat(core): add application lifecycle tasks

### DIFF
--- a/docs/en/enterprise/deployment.md
+++ b/docs/en/enterprise/deployment.md
@@ -92,6 +92,31 @@ For containers:
 
 Long polling containers should usually run as one replica per bot token. Webhook containers can scale horizontally if your handlers and storage are safe for concurrency.
 
+## Lifecycle Tasks In Production
+
+TeleFlow startup and shutdown tasks run per application instance:
+
+```csharp
+builder.Services.AddTeleFlowStartupTask<ConfigureBotCommands>();
+builder.Services.AddTeleFlowShutdownTask<FlushMetrics>();
+```
+
+Good startup task examples:
+
+- configure Telegram bot commands;
+- warm local caches;
+- validate required external dependencies;
+- prepare process-local resources.
+
+Bad startup task examples:
+
+- non-idempotent database migrations;
+- global resource creation without a distributed lock;
+- long-running background loops;
+- work that should belong to deployment infrastructure.
+
+In multi-replica deployments, every replica runs the same startup tasks. Keep them idempotent or guard them with infrastructure-level coordination. Shutdown tasks run after the update source stops and should stay short enough to fit the platform's graceful shutdown window.
+
 ## systemd
 
 For a small Linux host, run long polling under `systemd`:
@@ -140,4 +165,3 @@ Before production:
 - logs and errors are observable;
 - CI runs build and tests;
 - smoke test covers `/start`, one callback, one state flow, and one Telegram API call.
-

--- a/docs/en/fundamentals/application-model.md
+++ b/docs/en/fundamentals/application-model.md
@@ -43,6 +43,46 @@ The dispatcher selects and invokes the matching handler. Telegram-specific dispa
 
 A handler is a normal class with a method that TeleFlow can invoke. Routing metadata comes from attributes.
 
+## Application Lifecycle
+
+TeleFlow lifecycle tasks run around the update source:
+
+1. startup tasks run in registration order;
+2. the update source starts and processes updates;
+3. shutdown tasks run in reverse registration order after the update source stops.
+
+Use lifecycle tasks for application startup and shutdown work that belongs to the bot process:
+
+```csharp
+builder.Services.AddTeleFlowStartupTask<ConfigureBotCommands>();
+builder.Services.AddTeleFlowShutdownTask<FlushMetrics>();
+```
+
+```csharp
+public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartupTask
+{
+    public async ValueTask ExecuteAsync(CancellationToken ct = default)
+    {
+        await bot.SetMyCommandsAsync(
+            commands:
+            [
+                new BotCommand
+                {
+                    Command = "start",
+                    Description = "Start"
+                }
+            ],
+            cancellationToken: ct);
+    }
+}
+```
+
+Lifecycle tasks are not Telegram handlers. They do not receive `MessageContext`, `CallbackQueryContext`, or fake updates. They are resolved through dependency injection from a dedicated lifecycle scope, so scoped application services can be used safely.
+
+If a startup task fails, update processing does not start. If the update source fails after startup has completed, shutdown tasks still run and the original failure is surfaced. If shutdown also fails, TeleFlow reports both failures.
+
+Do not use lifecycle tasks for long-running background jobs. Use normal .NET hosting primitives such as `IHostedService` or `BackgroundService` when the work is a separate background process.
+
 ## Telegram Contexts
 
 Telegram handlers receive context objects that expose the current update, the Telegram client, state, and small action helpers.
@@ -171,6 +211,8 @@ services.AddStateStore<MyStateStore>();
 services.AddStateDataStore<MyStateDataStore>();
 services.AddStateHistoryStore<MyHistoryStore>();
 services.AddStateKeyFactory<MyStateKeyFactory>();
+services.AddTeleFlowStartupTask<MyStartupTask>();
+services.AddTeleFlowShutdownTask<MyShutdownTask>();
 ```
 
 These are advanced APIs. Most applications should start with framework transports and memory storage, then replace only the part that has become an infrastructure requirement.

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -90,6 +90,8 @@ services.AddUpdateMiddleware<MyMiddleware>();
 services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 services.AddDefaultUpdateRateLimiting();
 services.AddUpdateRateLimiter<MyLimiter>();
+services.AddTeleFlowStartupTask<MyStartupTask>();
+services.AddTeleFlowShutdownTask<MyShutdownTask>();
 ```
 
 State:
@@ -125,3 +127,5 @@ services.AddDeepLinkPayloadSerializer<MySerializer>();
 ## Guidance
 
 Replace extension points only when the application owns the behavior. Keep defaults until there is a concrete reason to change them.
+
+Use lifecycle tasks for short application startup and shutdown work. Do not register `ITeleFlowStartupTask` or `ITeleFlowShutdownTask` directly in `IServiceCollection`; TeleFlow ignores direct lifecycle service registrations and fails clearly during application build. Register tasks through `AddTeleFlowStartupTask<TTask>()` and `AddTeleFlowShutdownTask<TTask>()` so they are resolved from the correct lifecycle scope.

--- a/docs/ru/enterprise/deployment.md
+++ b/docs/ru/enterprise/deployment.md
@@ -92,6 +92,31 @@ dotnet publish -c Release -o publish
 
 Long polling containers обычно должны работать в одном replica на bot token. Webhook containers можно масштабировать горизонтально, если handlers и storage готовы к concurrency.
 
+## Lifecycle tasks в production
+
+TeleFlow startup и shutdown tasks выполняются на каждом application instance:
+
+```csharp
+builder.Services.AddTeleFlowStartupTask<ConfigureBotCommands>();
+builder.Services.AddTeleFlowShutdownTask<FlushMetrics>();
+```
+
+Хорошие примеры startup tasks:
+
+- настроить Telegram bot commands;
+- прогреть local caches;
+- проверить обязательные external dependencies;
+- подготовить process-local resources.
+
+Плохие примеры startup tasks:
+
+- non-idempotent database migrations;
+- создание global resources без distributed lock;
+- long-running background loops;
+- работа, которая должна жить в deployment infrastructure.
+
+В multi-replica deployments каждая replica запускает одни и те же startup tasks. Делай их idempotent или защищай infrastructure-level coordination. Shutdown tasks выполняются после остановки update source и должны укладываться в graceful shutdown window платформы.
+
 ## systemd
 
 Для небольшого Linux host можно запустить long polling под `systemd`:
@@ -140,4 +165,3 @@ Current public TeleFlow docs не заявляют `drop_pending_updates` option
 - logs и errors observable;
 - CI запускает build и tests;
 - smoke test покрывает `/start`, один callback, один state flow и один Telegram API call.
-

--- a/docs/ru/fundamentals/application-model.md
+++ b/docs/ru/fundamentals/application-model.md
@@ -43,6 +43,46 @@ Dispatcher выбирает и вызывает подходящий handler. Te
 
 Handler - обычный class с method, который TeleFlow может вызвать. Routing metadata задаётся атрибутами.
 
+## Application lifecycle
+
+TeleFlow lifecycle tasks выполняются вокруг update source:
+
+1. startup tasks запускаются в порядке регистрации;
+2. update source стартует и обрабатывает updates;
+3. shutdown tasks запускаются в обратном порядке регистрации после остановки update source.
+
+Используй lifecycle tasks для startup/shutdown работы, которая принадлежит процессу бота:
+
+```csharp
+builder.Services.AddTeleFlowStartupTask<ConfigureBotCommands>();
+builder.Services.AddTeleFlowShutdownTask<FlushMetrics>();
+```
+
+```csharp
+public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartupTask
+{
+    public async ValueTask ExecuteAsync(CancellationToken ct = default)
+    {
+        await bot.SetMyCommandsAsync(
+            commands:
+            [
+                new BotCommand
+                {
+                    Command = "start",
+                    Description = "Start"
+                }
+            ],
+            cancellationToken: ct);
+    }
+}
+```
+
+Lifecycle tasks не являются Telegram handlers. Они не получают `MessageContext`, `CallbackQueryContext` или fake updates. TeleFlow создаёт их через dependency injection в отдельном lifecycle scope, поэтому scoped application services можно использовать безопасно.
+
+Если startup task падает, update processing не стартует. Если update source падает уже после успешного startup, shutdown tasks всё равно выполняются, а исходная ошибка пробрасывается наружу. Если shutdown тоже падает, TeleFlow сообщает обе ошибки.
+
+Не используй lifecycle tasks для long-running background jobs. Для отдельной фоновой работы используй обычные .NET primitives: `IHostedService` или `BackgroundService`.
+
 ## Telegram contexts
 
 Telegram handlers получают context objects, в которых есть текущий update, Telegram client, state и небольшие action helpers.
@@ -171,6 +211,8 @@ services.AddStateStore<MyStateStore>();
 services.AddStateDataStore<MyStateDataStore>();
 services.AddStateHistoryStore<MyHistoryStore>();
 services.AddStateKeyFactory<MyStateKeyFactory>();
+services.AddTeleFlowStartupTask<MyStartupTask>();
+services.AddTeleFlowShutdownTask<MyShutdownTask>();
 ```
 
 Это advanced APIs. Большинству приложений лучше начать с framework transports и memory storage, а потом заменить только то, что стало инфраструктурным требованием.

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -90,6 +90,8 @@ services.AddUpdateMiddleware<MyMiddleware>();
 services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 services.AddDefaultUpdateRateLimiting();
 services.AddUpdateRateLimiter<MyLimiter>();
+services.AddTeleFlowStartupTask<MyStartupTask>();
+services.AddTeleFlowShutdownTask<MyShutdownTask>();
 ```
 
 State:
@@ -125,3 +127,5 @@ services.AddDeepLinkPayloadSerializer<MySerializer>();
 ## Рекомендации
 
 Replacement points заменяй только когда приложение владеет behavior. Держи defaults, пока нет конкретной причины их менять.
+
+Lifecycle tasks используй для короткой startup/shutdown работы приложения. Не регистрируй `ITeleFlowStartupTask` или `ITeleFlowShutdownTask` напрямую в `IServiceCollection`: TeleFlow не использует direct lifecycle service registrations и понятно падает во время application build. Регистрируй tasks через `AddTeleFlowStartupTask<TTask>()` и `AddTeleFlowShutdownTask<TTask>()`, чтобы они создавались из правильного lifecycle scope.

--- a/src/TeleFlow.Core/Application/ITeleFlowShutdownTask.cs
+++ b/src/TeleFlow.Core/Application/ITeleFlowShutdownTask.cs
@@ -1,0 +1,14 @@
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Runs application shutdown work after the configured update source stops receiving updates.
+/// Use shutdown tasks for DI-composable cleanup such as flushing local buffers, metrics, or
+/// application-owned resources that should be finalized after update processing ends.
+/// </summary>
+public interface ITeleFlowShutdownTask
+{
+    /// <summary>
+    /// Executes the shutdown task after update processing stops.
+    /// </summary>
+    ValueTask ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/TeleFlow.Core/Application/ITeleFlowStartupTask.cs
+++ b/src/TeleFlow.Core/Application/ITeleFlowStartupTask.cs
@@ -1,0 +1,14 @@
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Runs application startup work before the configured update source starts receiving updates.
+/// Use startup tasks for DI-composable initialization such as Telegram command setup, cache warmup,
+/// or local resource checks that belong to the TeleFlow application lifecycle.
+/// </summary>
+public interface ITeleFlowStartupTask
+{
+    /// <summary>
+    /// Executes the startup task before update processing begins.
+    /// </summary>
+    ValueTask ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/TeleFlow.Core/Application/TeleFlowApplication.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplication.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using TeleFlow.Core.Updates;
 
 namespace TeleFlow.Core.Application;
@@ -7,16 +9,19 @@ public sealed class TeleFlowApplication : ITeleFlowApplication
     private readonly IServiceProvider _services;
     private readonly IUpdateSource _updateSource;
     private readonly IUpdateProcessor _updateProcessor;
+    private readonly TeleFlowApplicationLifecycleRunner _lifecycle;
     private bool _disposed;
 
     internal TeleFlowApplication(
         IServiceProvider services,
         IUpdateSource updateSource,
-        IUpdateProcessor updateProcessor)
+        IUpdateProcessor updateProcessor,
+        TeleFlowApplicationLifecycleRunner lifecycle)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
         _updateSource = updateSource ?? throw new ArgumentNullException(nameof(updateSource));
         _updateProcessor = updateProcessor ?? throw new ArgumentNullException(nameof(updateProcessor));
+        _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
     }
 
     public static ITeleFlowApplicationBuilder CreateBuilder(string[]? args = null)
@@ -24,10 +29,40 @@ public sealed class TeleFlowApplication : ITeleFlowApplication
         return new TeleFlowApplicationBuilder(args);
     }
 
-    public Task RunAsync(CancellationToken cancellationToken = default)
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "The application must run shutdown tasks for any update-source failure while preserving and rethrowing the original exception.")]
+    public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return _updateSource.StartAsync(ProcessUpdateAsync, cancellationToken);
+
+        await _lifecycle.RunStartupAsync(cancellationToken).ConfigureAwait(false);
+
+        ExceptionDispatchInfo? updateSourceException = null;
+
+        try
+        {
+            await _updateSource.StartAsync(ProcessUpdateAsync, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            updateSourceException = ExceptionDispatchInfo.Capture(exception);
+        }
+
+        try
+        {
+            await _lifecycle.RunShutdownAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception shutdownException) when (updateSourceException is not null)
+        {
+            throw new AggregateException(updateSourceException.SourceException, shutdownException);
+        }
+
+        if (updateSourceException is not null)
+        {
+            updateSourceException.Throw();
+        }
     }
 
     internal Task ProcessUpdateAsync(IUpdatePayload payload, CancellationToken cancellationToken)

--- a/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Core.DependencyInjection;
 using TeleFlow.Core.Dispatching;
 using TeleFlow.Core.Middleware;
 using TeleFlow.Core.Updates;
@@ -18,6 +19,7 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
     public ITeleFlowApplication Build()
     {
         ValidateMiddlewareRegistrations();
+        ValidateLifecycleTaskRegistrations();
 
         var serviceProvider = Services.BuildServiceProvider(new ServiceProviderOptions
         {
@@ -29,9 +31,12 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
         var updateSource = ResolveSingleRequiredService<IUpdateSource>(serviceProvider);
         var dispatcher = ResolveSingleRequiredService<IUpdateDispatcher>(serviceProvider);
         var middleware = serviceProvider.GetServices<UpdateMiddlewareRegistration>().ToArray();
+        var startupTasks = serviceProvider.GetServices<TeleFlowStartupTaskRegistration>().ToArray();
+        var shutdownTasks = serviceProvider.GetServices<TeleFlowShutdownTaskRegistration>().ToArray();
         var processor = new DefaultUpdateProcessor(scopeFactory, dispatcher, middleware);
+        var lifecycle = new TeleFlowApplicationLifecycleRunner(scopeFactory, startupTasks, shutdownTasks);
 
-        return new TeleFlowApplication(serviceProvider, updateSource, processor);
+        return new TeleFlowApplication(serviceProvider, updateSource, processor, lifecycle);
     }
 
     private static TService ResolveSingleRequiredService<TService>(IServiceProvider serviceProvider)
@@ -61,5 +66,24 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
             $"Register middleware with {nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware)}<TMiddleware>() " +
             $"or {nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware)}<TMiddleware>() so TeleFlow can " +
             "resolve it from the correct update scope.");
+    }
+
+    private void ValidateLifecycleTaskRegistrations()
+    {
+        if (Services.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowStartupTask)))
+        {
+            throw new InvalidOperationException(
+                "Direct ITeleFlowStartupTask service registrations are not used by the TeleFlow application lifecycle. " +
+                $"Register startup tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowStartupTask)}<TTask>() " +
+                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
+        }
+
+        if (Services.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowShutdownTask)))
+        {
+            throw new InvalidOperationException(
+                "Direct ITeleFlowShutdownTask service registrations are not used by the TeleFlow application lifecycle. " +
+                $"Register shutdown tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowShutdownTask)}<TTask>() " +
+                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
+        }
     }
 }

--- a/src/TeleFlow.Core/Application/TeleFlowApplicationLifecycleRunner.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplicationLifecycleRunner.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Executes TeleFlow application lifecycle tasks around update source execution.
+/// This runner is transport-agnostic so plain application execution and future hosting integration
+/// can share the same startup and shutdown semantics.
+/// </summary>
+internal sealed class TeleFlowApplicationLifecycleRunner
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IReadOnlyList<TeleFlowStartupTaskRegistration> _startupTasks;
+    private readonly IReadOnlyList<TeleFlowShutdownTaskRegistration> _shutdownTasks;
+
+    public TeleFlowApplicationLifecycleRunner(
+        IServiceScopeFactory scopeFactory,
+        IReadOnlyList<TeleFlowStartupTaskRegistration> startupTasks,
+        IReadOnlyList<TeleFlowShutdownTaskRegistration> shutdownTasks)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _startupTasks = startupTasks ?? throw new ArgumentNullException(nameof(startupTasks));
+        _shutdownTasks = shutdownTasks ?? throw new ArgumentNullException(nameof(shutdownTasks));
+    }
+
+    public async ValueTask RunStartupAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var registration in _startupTasks)
+        {
+            await ExecuteStartupTaskAsync(registration.TaskType, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask RunShutdownAsync(CancellationToken cancellationToken = default)
+    {
+        for (var index = _shutdownTasks.Count - 1; index >= 0; index--)
+        {
+            await ExecuteShutdownTaskAsync(_shutdownTasks[index].TaskType, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ExecuteStartupTaskAsync(
+        Type taskType,
+        CancellationToken cancellationToken)
+    {
+        var scope = _scopeFactory.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var task = (ITeleFlowStartupTask)ActivatorUtilities.CreateInstance(scope.ServiceProvider, taskType);
+
+            await task.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ExecuteShutdownTaskAsync(
+        Type taskType,
+        CancellationToken cancellationToken)
+    {
+        var scope = _scopeFactory.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var task = (ITeleFlowShutdownTask)ActivatorUtilities.CreateInstance(scope.ServiceProvider, taskType);
+
+            await task.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/TeleFlow.Core/Application/TeleFlowShutdownTaskRegistration.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowShutdownTaskRegistration.cs
@@ -1,0 +1,25 @@
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Stores a shutdown task type registered through TeleFlow lifecycle registration APIs.
+/// The application lifecycle runner consumes these descriptors in reverse registration order
+/// after the update source has stopped.
+/// </summary>
+internal sealed class TeleFlowShutdownTaskRegistration
+{
+    public TeleFlowShutdownTaskRegistration(Type taskType)
+    {
+        ArgumentNullException.ThrowIfNull(taskType);
+
+        if (!typeof(ITeleFlowShutdownTask).IsAssignableFrom(taskType))
+        {
+            throw new ArgumentException(
+                $"Type '{taskType.FullName}' must implement {nameof(ITeleFlowShutdownTask)}.",
+                nameof(taskType));
+        }
+
+        TaskType = taskType;
+    }
+
+    public Type TaskType { get; }
+}

--- a/src/TeleFlow.Core/Application/TeleFlowStartupTaskRegistration.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowStartupTaskRegistration.cs
@@ -1,0 +1,25 @@
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Stores a startup task type registered through TeleFlow lifecycle registration APIs.
+/// The application lifecycle runner uses this descriptor to create the task from a dedicated
+/// dependency injection scope at runtime instead of resolving task instances from the root provider.
+/// </summary>
+internal sealed class TeleFlowStartupTaskRegistration
+{
+    public TeleFlowStartupTaskRegistration(Type taskType)
+    {
+        ArgumentNullException.ThrowIfNull(taskType);
+
+        if (!typeof(ITeleFlowStartupTask).IsAssignableFrom(taskType))
+        {
+            throw new ArgumentException(
+                $"Type '{taskType.FullName}' must implement {nameof(ITeleFlowStartupTask)}.",
+                nameof(taskType));
+        }
+
+        TaskType = taskType;
+    }
+
+    public Type TaskType { get; }
+}

--- a/src/TeleFlow.Core/DependencyInjection/ApplicationLifecycleServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Core/DependencyInjection/ApplicationLifecycleServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Core.Application;
+
+namespace TeleFlow.Core.DependencyInjection;
+
+/// <summary>
+/// Registers TeleFlow application lifecycle tasks that execute before and after update source processing.
+/// These registration APIs store task types so the runtime can create each task from the correct lifecycle scope.
+/// </summary>
+public static class ApplicationLifecycleServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a startup task that runs before the configured update source starts processing updates.
+    /// </summary>
+    public static IServiceCollection AddTeleFlowStartupTask<TTask>(this IServiceCollection services)
+        where TTask : class, ITeleFlowStartupTask
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(new TeleFlowStartupTaskRegistration(typeof(TTask)));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a shutdown task that runs after the configured update source stops processing updates.
+    /// </summary>
+    public static IServiceCollection AddTeleFlowShutdownTask<TTask>(this IServiceCollection services)
+        where TTask : class, ITeleFlowShutdownTask
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(new TeleFlowShutdownTaskRegistration(typeof(TTask)));
+        return services;
+    }
+}

--- a/src/TeleFlow.Core/Updates/DefaultUpdateProcessor.cs
+++ b/src/TeleFlow.Core/Updates/DefaultUpdateProcessor.cs
@@ -26,11 +26,14 @@ internal sealed class DefaultUpdateProcessor : IUpdateProcessor
     {
         ArgumentNullException.ThrowIfNull(payload);
 
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var context = new UpdateContext(scope.ServiceProvider, payload, cancellationToken);
-        var pipeline = BuildPipeline(scope.ServiceProvider, _dispatcher, _middleware);
+        var scope = _scopeFactory.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var context = new UpdateContext(scope.ServiceProvider, payload, cancellationToken);
+            var pipeline = BuildPipeline(scope.ServiceProvider, _dispatcher, _middleware);
 
-        await pipeline(context).ConfigureAwait(false);
+            await pipeline(context).ConfigureAwait(false);
+        }
     }
 
     private static UpdateDelegate BuildPipeline(

--- a/tests/TeleFlow.ArchitectureTests/RuntimeExecutionTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/RuntimeExecutionTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using TeleFlow.Core.Application;
+using TeleFlow.Core.DependencyInjection;
 using TeleFlow.Core.Dispatching;
 using TeleFlow.Core.Middleware;
 using TeleFlow.Core.Updates;
@@ -24,6 +25,186 @@ public sealed class RuntimeExecutionTests
         await application.RunAsync();
 
         Assert.Equal(1, source.StartCallCount);
+    }
+
+    [Fact]
+    public async Task StartupTasks_ExecuteBeforeUpdateSourceInRegistrationOrder()
+    {
+        var trace = new List<string>();
+        var source = new RecordingUpdateSource([new TestUpdatePayload("only")], trace);
+        var dispatcher = new RecordingDispatcher(trace);
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(trace);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowStartupTask<FirstStartupTask>();
+                services.AddTeleFlowStartupTask<SecondStartupTask>();
+            });
+
+        await application.RunAsync();
+
+        Assert.Equal(
+        [
+            "startup:1",
+            "startup:2",
+            "source:start",
+            "dispatch"
+        ], trace);
+    }
+
+    [Fact]
+    public async Task StartupTaskFailure_PreventsUpdateSourceAndShutdownTasks()
+    {
+        var trace = new List<string>();
+        var source = new RecordingUpdateSource([], trace);
+        var dispatcher = new RecordingDispatcher(trace);
+        var exception = new InvalidOperationException("startup failed");
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(trace);
+                services.AddSingleton(exception);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowStartupTask<ThrowingStartupTask>();
+                services.AddTeleFlowShutdownTask<FirstShutdownTask>();
+            });
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => application.RunAsync());
+
+        Assert.Same(exception, thrown);
+        Assert.Equal(0, source.StartCallCount);
+        Assert.Equal(["startup:throw"], trace);
+    }
+
+    [Fact]
+    public async Task ShutdownTasks_ExecuteAfterUpdateSourceInReverseRegistrationOrder()
+    {
+        var trace = new List<string>();
+        var source = new RecordingUpdateSource([], trace);
+        var dispatcher = new RecordingDispatcher(trace);
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(trace);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowShutdownTask<FirstShutdownTask>();
+                services.AddTeleFlowShutdownTask<SecondShutdownTask>();
+            });
+
+        await application.RunAsync();
+
+        Assert.Equal(
+        [
+            "source:start",
+            "shutdown:2",
+            "shutdown:1"
+        ], trace);
+    }
+
+    [Fact]
+    public async Task ShutdownTasks_RunWhenUpdateSourceFails()
+    {
+        var trace = new List<string>();
+        var exception = new InvalidOperationException("source failed");
+        var source = new ThrowingUpdateSource(trace, exception);
+        var dispatcher = new RecordingDispatcher(trace);
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(trace);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowShutdownTask<FirstShutdownTask>();
+            });
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => application.RunAsync());
+
+        Assert.Same(exception, thrown);
+        Assert.Equal(["source:throw", "shutdown:1"], trace);
+    }
+
+    [Fact]
+    public async Task ShutdownTaskFailureAfterUpdateSourceFailure_PreservesBothFailures()
+    {
+        var trace = new List<string>();
+        var sourceException = new InvalidOperationException("source failed");
+        var shutdownException = new ApplicationException("shutdown failed");
+        var source = new ThrowingUpdateSource(trace, sourceException);
+        var dispatcher = new RecordingDispatcher(trace);
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(trace);
+                services.AddSingleton(shutdownException);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowShutdownTask<ThrowingShutdownTask>();
+            });
+
+        var thrown = await Assert.ThrowsAsync<AggregateException>(() => application.RunAsync());
+
+        Assert.Contains(sourceException, thrown.InnerExceptions);
+        Assert.Contains(shutdownException, thrown.InnerExceptions);
+        Assert.Equal(["source:throw", "shutdown:throw"], trace);
+    }
+
+    [Fact]
+    public async Task LifecycleTasks_CanUseScopedConstructorDependencies()
+    {
+        var source = new RecordingUpdateSource([]);
+        var dispatcher = new RecordingDispatcher();
+        var recorder = new ScopedProbeRecorder();
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(recorder);
+                services.AddScoped<ScopedProbe>();
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowStartupTask<ScopedStartupTask>();
+                services.AddTeleFlowStartupTask<SecondScopedStartupTask>();
+                services.AddTeleFlowShutdownTask<ScopedShutdownTask>();
+            });
+
+        await application.RunAsync();
+
+        Assert.Equal(2, recorder.StartupProbeIds.Count);
+        Assert.Single(recorder.ShutdownProbeIds);
+        Assert.NotEqual(recorder.StartupProbeIds[0], recorder.StartupProbeIds[1]);
+    }
+
+    [Fact]
+    public async Task LifecycleTasks_ReceiveRunCancellationToken()
+    {
+        var source = new RecordingUpdateSource([]);
+        var dispatcher = new RecordingDispatcher();
+        var recorder = new CancellationTokenRecorder();
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateApplication(
+            services =>
+            {
+                services.AddSingleton(recorder);
+                services.AddSingleton<IUpdateSource>(source);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+                services.AddTeleFlowStartupTask<TokenRecordingStartupTask>();
+                services.AddTeleFlowShutdownTask<TokenRecordingShutdownTask>();
+            });
+
+        await application.RunAsync(cancellation.Token);
+
+        Assert.Equal(cancellation.Token, recorder.StartupToken);
+        Assert.Equal(cancellation.Token, recorder.ShutdownToken);
     }
 
     [Fact]
@@ -119,6 +300,36 @@ public sealed class RuntimeExecutionTests
         Assert.Contains(nameof(IUpdateMiddleware), exception.Message);
         Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware), exception.Message);
         Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware), exception.Message);
+    }
+
+    [Fact]
+    public void Build_FailsClearlyForDirectStartupTaskServiceRegistration()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<IUpdateSource>(new RecordingUpdateSource([]));
+        builder.Services.AddSingleton<IUpdateDispatcher>(new RecordingDispatcher());
+        builder.Services.AddSingleton<ITeleFlowStartupTask, DirectStartupTask>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.Contains(nameof(ITeleFlowStartupTask), exception.Message);
+        Assert.Contains(nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowStartupTask), exception.Message);
+    }
+
+    [Fact]
+    public void Build_FailsClearlyForDirectShutdownTaskServiceRegistration()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<IUpdateSource>(new RecordingUpdateSource([]));
+        builder.Services.AddSingleton<IUpdateDispatcher>(new RecordingDispatcher());
+        builder.Services.AddSingleton<ITeleFlowShutdownTask, DirectShutdownTask>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.Contains(nameof(ITeleFlowShutdownTask), exception.Message);
+        Assert.Contains(nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowShutdownTask), exception.Message);
     }
 
     [Fact]
@@ -350,7 +561,9 @@ public sealed class RuntimeExecutionTests
 
     private sealed record TestUpdatePayload(string Name) : IUpdatePayload;
 
-    private sealed class RecordingUpdateSource(IReadOnlyList<IUpdatePayload> payloads) : IUpdateSource
+    private sealed class RecordingUpdateSource(
+        IReadOnlyList<IUpdatePayload> payloads,
+        List<string>? trace = null) : IUpdateSource
     {
         public int StartCallCount { get; private set; }
 
@@ -362,11 +575,25 @@ public sealed class RuntimeExecutionTests
         {
             StartCallCount++;
             ReceivedCancellationToken = cancellationToken;
+            trace?.Add("source:start");
 
             foreach (var payload in payloads)
             {
                 await updateHandler(payload, cancellationToken);
             }
+        }
+    }
+
+    private sealed class ThrowingUpdateSource(
+        List<string> trace,
+        Exception exception) : IUpdateSource
+    {
+        public Task StartAsync(
+            Func<IUpdatePayload, CancellationToken, Task> updateHandler,
+            CancellationToken cancellationToken = default)
+        {
+            trace.Add("source:throw");
+            return Task.FromException(exception);
         }
     }
 
@@ -499,6 +726,10 @@ public sealed class RuntimeExecutionTests
     private sealed class ScopedProbeRecorder
     {
         public List<Guid> MiddlewareProbeIds { get; } = [];
+
+        public List<Guid> StartupProbeIds { get; } = [];
+
+        public List<Guid> ShutdownProbeIds { get; } = [];
     }
 
     private sealed class SingletonMiddlewareRecorder
@@ -509,5 +740,137 @@ public sealed class RuntimeExecutionTests
     private sealed class ScopedProbe
     {
         public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private sealed class CancellationTokenRecorder
+    {
+        public CancellationToken StartupToken { get; set; }
+
+        public CancellationToken ShutdownToken { get; set; }
+    }
+
+    private sealed class FirstStartupTask(List<string> trace) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("startup:1");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class SecondStartupTask(List<string> trace) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("startup:2");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingStartupTask(
+        List<string> trace,
+        InvalidOperationException exception) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("startup:throw");
+            return ValueTask.FromException(exception);
+        }
+    }
+
+    private sealed class FirstShutdownTask(List<string> trace) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("shutdown:1");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class SecondShutdownTask(List<string> trace) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("shutdown:2");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingShutdownTask(
+        List<string> trace,
+        ApplicationException exception) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("shutdown:throw");
+            return ValueTask.FromException(exception);
+        }
+    }
+
+    private sealed class ScopedStartupTask(
+        ScopedProbe probe,
+        ScopedProbeRecorder recorder) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            recorder.StartupProbeIds.Add(probe.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class SecondScopedStartupTask(
+        ScopedProbe probe,
+        ScopedProbeRecorder recorder) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            recorder.StartupProbeIds.Add(probe.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ScopedShutdownTask(
+        ScopedProbe probe,
+        ScopedProbeRecorder recorder) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            recorder.ShutdownProbeIds.Add(probe.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TokenRecordingStartupTask(CancellationTokenRecorder recorder) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            recorder.StartupToken = cancellationToken;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TokenRecordingShutdownTask(CancellationTokenRecorder recorder) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            recorder.ShutdownToken = cancellationToken;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class DirectStartupTask : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class DirectShutdownTask : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add explicit TeleFlow startup and shutdown task contracts for application lifecycle work
- run startup tasks before update sources and shutdown tasks after update sources with deterministic ordering
- validate invalid direct lifecycle task registrations during application build
- document lifecycle hooks in EN/RU docs

## Runtime semantics
- startup tasks run in registration order before the update source starts
- startup failure prevents update source execution and skips shutdown tasks
- shutdown tasks run in reverse registration order after the update source stops
- shutdown tasks still run when the update source fails
- if update processing and shutdown both fail, TeleFlow throws an AggregateException with both failures
- each lifecycle task is created through DI in its own async scope

## Validation
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj -c Release --no-restore --logger "console;verbosity=minimal"`
- `git diff --check`

Closes #101