### PR TITLE
docs(middleware): document options configuration

### DIFF
--- a/docs/en/advanced/middleware-and-rate-limiting.md
+++ b/docs/en/advanced/middleware-and-rate-limiting.md
@@ -113,6 +113,50 @@ builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 
 `AddUpdateMiddleware<T>()` registers middleware in the update pipeline and creates the middleware from the current update scope. This means middleware can use scoped constructor dependencies such as repositories, unit-of-work services, database contexts, and request/update-scoped application services.
 
+Use the normal .NET options pattern when middleware needs application configuration. In a minimal console project, add the options package explicitly:
+
+```bash
+dotnet add package Microsoft.Extensions.Options
+```
+
+```csharp
+using Microsoft.Extensions.Options;
+
+public sealed class UserGateOptions
+{
+    public bool RecordStatistics { get; set; } = true;
+
+    public TimeSpan BlockCacheWindow { get; set; } = TimeSpan.FromSeconds(15);
+}
+
+builder.Services.Configure<UserGateOptions>(options =>
+{
+    options.RecordStatistics = true;
+    options.BlockCacheWindow = TimeSpan.FromSeconds(15);
+});
+```
+
+Then inject `IOptions<TOptions>` into the middleware constructor:
+
+```csharp
+public sealed class UserGateMiddleware(
+    IUserRepository users,
+    IAntiSpamService antiSpam,
+    IOptions<UserGateOptions> options) : IUpdateMiddleware
+{
+    public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+    {
+        var configuration = options.Value;
+
+        // Use configuration together with scoped services.
+
+        await next(context);
+    }
+}
+```
+
+Do not pass pre-created middleware instances to the pipeline. Let the container construct middleware so dependency lifetimes, disposal, and scoped services stay predictable.
+
 Use `context.Services` only when a middleware intentionally needs dynamic service resolution. Constructor injection is the recommended path for normal application dependencies.
 
 If a middleware is stateless and must be reused as one process-wide instance, register it explicitly:

--- a/docs/ru/advanced/middleware-and-rate-limiting.md
+++ b/docs/ru/advanced/middleware-and-rate-limiting.md
@@ -113,6 +113,50 @@ builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 
 `AddUpdateMiddleware<T>()` добавляет middleware в update pipeline и создаёт его из текущего update scope. Поэтому middleware может принимать scoped-зависимости в конструкторе: repositories, unit-of-work services, database contexts и другие update-scoped application services.
 
+Если middleware нужна application configuration, используй обычный .NET options pattern. В минимальном console-проекте пакет с options лучше добавить явно:
+
+```bash
+dotnet add package Microsoft.Extensions.Options
+```
+
+```csharp
+using Microsoft.Extensions.Options;
+
+public sealed class UserGateOptions
+{
+    public bool RecordStatistics { get; set; } = true;
+
+    public TimeSpan BlockCacheWindow { get; set; } = TimeSpan.FromSeconds(15);
+}
+
+builder.Services.Configure<UserGateOptions>(options =>
+{
+    options.RecordStatistics = true;
+    options.BlockCacheWindow = TimeSpan.FromSeconds(15);
+});
+```
+
+Затем передай `IOptions<TOptions>` в constructor middleware:
+
+```csharp
+public sealed class UserGateMiddleware(
+    IUserRepository users,
+    IAntiSpamService antiSpam,
+    IOptions<UserGateOptions> options) : IUpdateMiddleware
+{
+    public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+    {
+        var configuration = options.Value;
+
+        // Use configuration together with scoped services.
+
+        await next(context);
+    }
+}
+```
+
+Не передавай заранее созданные middleware instances в pipeline. Пусть container создаёт middleware сам: так lifetimes, disposal и scoped services остаются предсказуемыми.
+
 `context.Services` используй только когда middleware намеренно нужен dynamic service resolution. Для обычных application dependencies рекомендуемый путь - constructor injection.
 
 Если middleware stateless и должен переиспользоваться как один process-wide instance, регистрируй это явно:


### PR DESCRIPTION
## Summary
- document using the .NET options pattern for update middleware configuration
- call out `Microsoft.Extensions.Options` for minimal console projects
- keep DI/container-owned middleware construction as the recommended path

## Validation
- `git diff --check`

Docs-only change; no build or test run required.