### PR TITLE
feat(hosting): add Generic Host integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The documentation is available as a GitHub Pages site and as Markdown in this re
 - Typed callback payloads with compact callback data serialization.
 - State, state data, wizard navigation, and replaceable storage contracts.
 - Long polling and ASP.NET Core webhook framework adapters.
+- Optional Generic Host integration through `IWF.TeleFlow.Hosting`.
 - Raw long polling and raw webhook packages for applications that do not want the handler framework.
 - Normal .NET dependency injection for handlers, services, repositories, filters, storage, and infrastructure.
 
@@ -76,6 +77,12 @@ For direct Bot API access without the framework:
 
 ```bash
 dotnet add package IWF.TeleFlow.Telegram --prerelease
+```
+
+For a .NET worker that should run TeleFlow through Microsoft.Extensions.Hosting, also install:
+
+```bash
+dotnet add package IWF.TeleFlow.Hosting --prerelease
 ```
 
 ## First Bot

--- a/TeleFlow.sln
+++ b/TeleFlow.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeleFlow.Telegram.Framework
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeleFlow.Telegram.Framework.Webhooks", "src\TeleFlow.Telegram.Framework.Webhooks\TeleFlow.Telegram.Framework.Webhooks.csproj", "{F527F38E-F289-4972-B95A-06991D3A8F91}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeleFlow.Hosting", "src\TeleFlow.Hosting\TeleFlow.Hosting.csproj", "{B6F62891-B781-4237-8CAA-C24A8024559B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -192,6 +194,18 @@ Global
 		{F527F38E-F289-4972-B95A-06991D3A8F91}.Release|x64.Build.0 = Release|Any CPU
 		{F527F38E-F289-4972-B95A-06991D3A8F91}.Release|x86.ActiveCfg = Release|Any CPU
 		{F527F38E-F289-4972-B95A-06991D3A8F91}.Release|x86.Build.0 = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|x64.Build.0 = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|x64.ActiveCfg = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|x64.Build.0 = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6F62891-B781-4237-8CAA-C24A8024559B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/en/enterprise/architecture.md
+++ b/docs/en/enterprise/architecture.md
@@ -4,6 +4,8 @@ TeleFlow has a deliberately simple dependency direction.
 
 ```text
 Application
+  -> TeleFlow.Hosting when using Microsoft.Extensions.Hosting
+      -> TeleFlow.Core
   -> TeleFlow.Telegram.Framework.LongPolling or Webhooks
       -> TeleFlow.Telegram.Framework
           -> TeleFlow.Telegram.Client
@@ -18,6 +20,7 @@ Application
 ## Package Ownership
 
 - `TeleFlow.Core`: application, middleware, update processing, state contracts, replacement points.
+- `TeleFlow.Hosting`: Microsoft.Extensions.Hosting adapter that runs a configured TeleFlow application as an `IHostedService`.
 - `TeleFlow.Annotations`: compile-time metadata attributes. Files are grouped by responsibility, but every public annotation type stays in the stable `TeleFlow.Annotations` namespace.
 - `IWF.TeleFlow.Generators`: source generator and analyzer package.
 - `TeleFlow.Telegram.Schema`: generated Telegram DTOs and method models.

--- a/docs/en/enterprise/deployment.md
+++ b/docs/en/enterprise/deployment.md
@@ -10,7 +10,26 @@ Choose the transport first:
 
 ## Long Polling Worker
 
-Long polling is easiest to deploy as a worker process:
+Long polling is easiest to deploy as a worker process. In a normal .NET worker, use `IWF.TeleFlow.Hosting` and let the Generic Host own startup, shutdown, logging, and cancellation:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+using TeleFlow.Telegram;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+The hosted service creates the TeleFlow application from the host service provider. It does not create a second DI container and does not dispose the host-owned provider.
+
+For a smaller console process without Generic Host, run the TeleFlow application directly:
 
 ```csharp
 var builder = TeleFlowApplication.CreateBuilder(args);
@@ -51,6 +70,8 @@ app.MapTelegramWebhook();
 
 await app.RunAsync();
 ```
+
+Do not add `AddTeleFlowHostedService()` to webhook apps. Webhooks are driven by ASP.NET Core endpoint routing; the process lifetime is already owned by `WebApplication`.
 
 Operational rules:
 

--- a/docs/en/enterprise/versioning.md
+++ b/docs/en/enterprise/versioning.md
@@ -16,6 +16,7 @@ IWF.TeleFlow.Telegram.Framework.Webhooks
 IWF.TeleFlow.Telegram.LongPolling
 IWF.TeleFlow.Telegram.Webhooks
 IWF.TeleFlow.Core
+IWF.TeleFlow.Hosting
 IWF.TeleFlow.Annotations
 IWF.TeleFlow.Generators
 IWF.TeleFlow.Storage.Memory

--- a/docs/en/fundamentals/application-model.md
+++ b/docs/en/fundamentals/application-model.md
@@ -21,6 +21,25 @@ await using var app = builder.Build();
 await app.RunAsync();
 ```
 
+For applications that already use Microsoft.Extensions.Hosting, register the optional hosting adapter instead of calling `Build()` on `TeleFlowApplication` yourself:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddMemoryStateStorage();
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+The hosted service uses the host's service provider. It does not create a second DI container and it does not own provider disposal. Do not use the hosted service for ASP.NET Core webhook apps; webhook processing is driven by endpoint routing.
+
 ## Core Concepts
 
 ### Update Source

--- a/docs/en/getting-started/packages.md
+++ b/docs/en/getting-started/packages.md
@@ -16,6 +16,7 @@ NuGet package IDs use the `IWF.TeleFlow.*` prefix. C# namespaces stay concise fo
 | Direct client through the owner package | `IWF.TeleFlow.Telegram.Client` | Same client runtime through the explicit package-boundary name |
 | Handler framework with long polling | `IWF.TeleFlow.Telegram.Framework.LongPolling` | Handler framework plus long-polling transport |
 | Handler framework with webhooks | `IWF.TeleFlow.Telegram.Framework.Webhooks` | Handler framework plus ASP.NET Core webhook transport |
+| Generic Host integration | `IWF.TeleFlow.Hosting` | `IHostedService` adapter for running a configured TeleFlow application through Microsoft.Extensions.Hosting |
 | Raw long polling without handlers | `IWF.TeleFlow.Telegram.LongPolling` | `getUpdates` runner and acknowledged update stream over raw Telegram `Update` values |
 | Raw ASP.NET Core webhooks without handlers | `IWF.TeleFlow.Telegram.Webhooks` | ASP.NET Core endpoint helpers over raw Telegram `Update` values |
 | In-memory state storage | `IWF.TeleFlow.Storage.Memory` | Process-local state, state data, wizard history, and state middleware registration |
@@ -32,6 +33,7 @@ Recommended alpha install for a long polling bot:
 
 ```bash
 dotnet add package IWF.TeleFlow.Telegram.Framework.LongPolling --prerelease
+dotnet add package IWF.TeleFlow.Hosting --prerelease
 dotnet add package IWF.TeleFlow.Generators --prerelease
 dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
 ```
@@ -39,6 +41,32 @@ dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
 ## Recommended Defaults
 
 For a handler-based long polling bot:
+
+```xml
+<PackageReference Include="IWF.TeleFlow.Telegram.Framework.LongPolling" Version="..." />
+<PackageReference Include="IWF.TeleFlow.Hosting" Version="..." />
+<PackageReference Include="IWF.TeleFlow.Generators" Version="..." PrivateAssets="all" />
+<PackageReference Include="IWF.TeleFlow.Storage.Memory" Version="..." />
+```
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+using TeleFlow.Storage.Memory;
+using TeleFlow.Telegram;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddMemoryStateStorage();
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+For a smaller console-style long polling bot without Generic Host:
 
 ```xml
 <PackageReference Include="IWF.TeleFlow.Telegram.Framework.LongPolling" Version="..." />
@@ -57,6 +85,9 @@ builder.Services.AddTelegramBot(options => options.Token = token);
 builder.Services.AddMemoryStateStorage();
 builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
 builder.Services.AddLongPolling();
+
+await using var app = builder.Build();
+await app.RunAsync();
 ```
 
 For a handler-based webhook bot:

--- a/docs/ru/enterprise/architecture.md
+++ b/docs/ru/enterprise/architecture.md
@@ -4,6 +4,8 @@ TeleFlow имеет намеренно простую dependency direction.
 
 ```text
 Application
+  -> TeleFlow.Hosting when using Microsoft.Extensions.Hosting
+      -> TeleFlow.Core
   -> TeleFlow.Telegram.Framework.LongPolling or Webhooks
       -> TeleFlow.Telegram.Framework
           -> TeleFlow.Telegram.Client
@@ -18,6 +20,7 @@ Application
 ## Владение пакетами
 
 - `TeleFlow.Core`: application, middleware, update processing, state contracts, replacement points.
+- `TeleFlow.Hosting`: Microsoft.Extensions.Hosting adapter, который запускает настроенное TeleFlow application как `IHostedService`.
 - `TeleFlow.Annotations`: compile-time metadata attributes. Файлы сгруппированы по ответственности, но все public annotation types остаются в стабильном namespace `TeleFlow.Annotations`.
 - `IWF.TeleFlow.Generators`: source generator and analyzer package.
 - `TeleFlow.Telegram.Schema`: generated Telegram DTOs and method models.

--- a/docs/ru/enterprise/deployment.md
+++ b/docs/ru/enterprise/deployment.md
@@ -10,7 +10,26 @@ TeleFlow deployment - это обычный .NET deployment. Framework не тр
 
 ## Long polling worker
 
-Long polling проще всего deploy-ить как worker process:
+Long polling проще всего deploy-ить как worker process. В обычном .NET worker используй `IWF.TeleFlow.Hosting`, чтобы Generic Host владел startup, shutdown, logging и cancellation:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+using TeleFlow.Telegram;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+Hosted service создаёт TeleFlow application из host service provider. Он не создаёт второй DI container и не dispose-ит provider, которым владеет host.
+
+Для маленького console process без Generic Host запускай TeleFlow application напрямую:
 
 ```csharp
 var builder = TeleFlowApplication.CreateBuilder(args);
@@ -51,6 +70,8 @@ app.MapTelegramWebhook();
 
 await app.RunAsync();
 ```
+
+Не добавляй `AddTeleFlowHostedService()` в webhook apps. Webhooks управляются ASP.NET Core endpoint routing, а process lifetime уже принадлежит `WebApplication`.
 
 Operational rules:
 

--- a/docs/ru/enterprise/versioning.md
+++ b/docs/ru/enterprise/versioning.md
@@ -16,6 +16,7 @@ IWF.TeleFlow.Telegram.Framework.Webhooks
 IWF.TeleFlow.Telegram.LongPolling
 IWF.TeleFlow.Telegram.Webhooks
 IWF.TeleFlow.Core
+IWF.TeleFlow.Hosting
 IWF.TeleFlow.Annotations
 IWF.TeleFlow.Generators
 IWF.TeleFlow.Storage.Memory

--- a/docs/ru/fundamentals/application-model.md
+++ b/docs/ru/fundamentals/application-model.md
@@ -21,6 +21,25 @@ await using var app = builder.Build();
 await app.RunAsync();
 ```
 
+Если приложение уже использует Microsoft.Extensions.Hosting, подключай optional hosting adapter вместо ручного `Build()` у `TeleFlowApplication`:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddMemoryStateStorage();
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+Hosted service использует service provider от host-а. Он не создаёт второй DI container и не владеет provider disposal. Не используй hosted service для ASP.NET Core webhook apps: webhook processing управляется endpoint routing.
+
 ## Основные понятия
 
 ### Update source

--- a/docs/ru/getting-started/packages.md
+++ b/docs/ru/getting-started/packages.md
@@ -16,6 +16,7 @@ NuGet package IDs используют prefix `IWF.TeleFlow.*`. C# namespaces о
 | Прямой client через owner package | `IWF.TeleFlow.Telegram.Client` | Тот же client runtime через явное package-boundary имя |
 | Handler framework с long polling | `IWF.TeleFlow.Telegram.Framework.LongPolling` | Handler framework плюс long-polling transport |
 | Handler framework с webhooks | `IWF.TeleFlow.Telegram.Framework.Webhooks` | Handler framework плюс ASP.NET Core webhook transport |
+| Generic Host integration | `IWF.TeleFlow.Hosting` | `IHostedService` adapter для запуска настроенного TeleFlow application через Microsoft.Extensions.Hosting |
 | Raw long polling без handlers | `IWF.TeleFlow.Telegram.LongPolling` | `getUpdates` runner и acknowledged update stream поверх raw Telegram `Update` values |
 | Raw ASP.NET Core webhooks без handlers | `IWF.TeleFlow.Telegram.Webhooks` | ASP.NET Core endpoint helpers поверх raw Telegram `Update` values |
 | In-memory state storage | `IWF.TeleFlow.Storage.Memory` | Process-local state, state data, wizard history и регистрация state middleware |
@@ -32,6 +33,7 @@ TeleFlow сейчас опубликован как public alpha. Использ
 
 ```bash
 dotnet add package IWF.TeleFlow.Telegram.Framework.LongPolling --prerelease
+dotnet add package IWF.TeleFlow.Hosting --prerelease
 dotnet add package IWF.TeleFlow.Generators --prerelease
 dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
 ```
@@ -39,6 +41,32 @@ dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
 ## Рекомендуемый дефолт
 
 Для handler-based long polling bot:
+
+```xml
+<PackageReference Include="IWF.TeleFlow.Telegram.Framework.LongPolling" Version="..." />
+<PackageReference Include="IWF.TeleFlow.Hosting" Version="..." />
+<PackageReference Include="IWF.TeleFlow.Generators" Version="..." PrivateAssets="all" />
+<PackageReference Include="IWF.TeleFlow.Storage.Memory" Version="..." />
+```
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Hosting;
+using TeleFlow.Storage.Memory;
+using TeleFlow.Telegram;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddTelegramBot(options => options.Token = token);
+builder.Services.AddMemoryStateStorage();
+builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
+builder.Services.AddLongPolling();
+builder.Services.AddTeleFlowHostedService();
+
+await builder.Build().RunAsync();
+```
+
+Для более маленького console-style long polling bot без Generic Host:
 
 ```xml
 <PackageReference Include="IWF.TeleFlow.Telegram.Framework.LongPolling" Version="..." />
@@ -57,6 +85,9 @@ builder.Services.AddTelegramBot(options => options.Token = token);
 builder.Services.AddMemoryStateStorage();
 builder.Services.AddTelegramHandlersFromAssembly(typeof(Program).Assembly);
 builder.Services.AddLongPolling();
+
+await using var app = builder.Build();
+await app.RunAsync();
 ```
 
 Для handler-based webhook bot:

--- a/src/TeleFlow.Core/Application/TeleFlowApplication.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplication.cs
@@ -10,18 +10,21 @@ public sealed class TeleFlowApplication : ITeleFlowApplication
     private readonly IUpdateSource _updateSource;
     private readonly IUpdateProcessor _updateProcessor;
     private readonly TeleFlowApplicationLifecycleRunner _lifecycle;
+    private readonly bool _ownsServices;
     private bool _disposed;
 
     internal TeleFlowApplication(
         IServiceProvider services,
         IUpdateSource updateSource,
         IUpdateProcessor updateProcessor,
-        TeleFlowApplicationLifecycleRunner lifecycle)
+        TeleFlowApplicationLifecycleRunner lifecycle,
+        bool ownsServices)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
         _updateSource = updateSource ?? throw new ArgumentNullException(nameof(updateSource));
         _updateProcessor = updateProcessor ?? throw new ArgumentNullException(nameof(updateProcessor));
         _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+        _ownsServices = ownsServices;
     }
 
     public static ITeleFlowApplicationBuilder CreateBuilder(string[]? args = null)
@@ -82,6 +85,11 @@ public sealed class TeleFlowApplication : ITeleFlowApplication
 
         _disposed = true;
 
+        if (!_ownsServices)
+        {
+            return;
+        }
+
         if (_services is IDisposable disposable)
         {
             disposable.Dispose();
@@ -96,6 +104,11 @@ public sealed class TeleFlowApplication : ITeleFlowApplication
         }
 
         _disposed = true;
+
+        if (!_ownsServices)
+        {
+            return;
+        }
 
         if (_services is IAsyncDisposable asyncDisposable)
         {

--- a/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplicationBuilder.cs
@@ -1,8 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using TeleFlow.Core.DependencyInjection;
-using TeleFlow.Core.Dispatching;
-using TeleFlow.Core.Middleware;
-using TeleFlow.Core.Updates;
 
 namespace TeleFlow.Core.Application;
 
@@ -18,72 +14,6 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
 
     public ITeleFlowApplication Build()
     {
-        ValidateMiddlewareRegistrations();
-        ValidateLifecycleTaskRegistrations();
-
-        var serviceProvider = Services.BuildServiceProvider(new ServiceProviderOptions
-        {
-            ValidateOnBuild = true,
-            ValidateScopes = true
-        });
-
-        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
-        var updateSource = ResolveSingleRequiredService<IUpdateSource>(serviceProvider);
-        var dispatcher = ResolveSingleRequiredService<IUpdateDispatcher>(serviceProvider);
-        var middleware = serviceProvider.GetServices<UpdateMiddlewareRegistration>().ToArray();
-        var startupTasks = serviceProvider.GetServices<TeleFlowStartupTaskRegistration>().ToArray();
-        var shutdownTasks = serviceProvider.GetServices<TeleFlowShutdownTaskRegistration>().ToArray();
-        var processor = new DefaultUpdateProcessor(scopeFactory, dispatcher, middleware);
-        var lifecycle = new TeleFlowApplicationLifecycleRunner(scopeFactory, startupTasks, shutdownTasks);
-
-        return new TeleFlowApplication(serviceProvider, updateSource, processor, lifecycle);
-    }
-
-    private static TService ResolveSingleRequiredService<TService>(IServiceProvider serviceProvider)
-        where TService : class
-    {
-        var services = serviceProvider.GetServices<TService>().ToArray();
-
-        return services.Length switch
-        {
-            0 => throw new InvalidOperationException(
-                $"A single {typeof(TService).Name} registration is required to build the TeleFlow application."),
-            > 1 => throw new InvalidOperationException(
-                $"Only one {typeof(TService).Name} registration is supported when building the TeleFlow application."),
-            _ => services[0]
-        };
-    }
-
-    private void ValidateMiddlewareRegistrations()
-    {
-        if (!Services.Any(static descriptor => descriptor.ServiceType == typeof(IUpdateMiddleware)))
-        {
-            return;
-        }
-
-        throw new InvalidOperationException(
-            "Direct IUpdateMiddleware service registrations are not used by the TeleFlow update pipeline. " +
-            $"Register middleware with {nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware)}<TMiddleware>() " +
-            $"or {nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware)}<TMiddleware>() so TeleFlow can " +
-            "resolve it from the correct update scope.");
-    }
-
-    private void ValidateLifecycleTaskRegistrations()
-    {
-        if (Services.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowStartupTask)))
-        {
-            throw new InvalidOperationException(
-                "Direct ITeleFlowStartupTask service registrations are not used by the TeleFlow application lifecycle. " +
-                $"Register startup tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowStartupTask)}<TTask>() " +
-                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
-        }
-
-        if (Services.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowShutdownTask)))
-        {
-            throw new InvalidOperationException(
-                "Direct ITeleFlowShutdownTask service registrations are not used by the TeleFlow application lifecycle. " +
-                $"Register shutdown tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowShutdownTask)}<TTask>() " +
-                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
-        }
+        return TeleFlowApplicationRuntimeFactory.CreateOwned(Services);
     }
 }

--- a/src/TeleFlow.Core/Application/TeleFlowApplicationRuntimeFactory.cs
+++ b/src/TeleFlow.Core/Application/TeleFlowApplicationRuntimeFactory.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Core.DependencyInjection;
+using TeleFlow.Core.Dispatching;
+using TeleFlow.Core.Middleware;
+using TeleFlow.Core.Updates;
+
+namespace TeleFlow.Core.Application;
+
+/// <summary>
+/// Composes the Core runtime pipeline from registered services: update source, update processor,
+/// dispatcher, middleware, and application lifecycle tasks.
+/// </summary>
+internal static class TeleFlowApplicationRuntimeFactory
+{
+    public static ITeleFlowApplication CreateOwned(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        ValidateServiceDescriptors(services);
+
+        var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        try
+        {
+            return Create(serviceProvider, ownsServices: true);
+        }
+        catch
+        {
+            serviceProvider.Dispose();
+            throw;
+        }
+    }
+
+    public static ITeleFlowApplication CreateBorrowed(
+        IServiceProvider serviceProvider,
+        IEnumerable<ServiceDescriptor>? serviceDescriptors = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        if (serviceDescriptors is not null)
+        {
+            ValidateServiceDescriptors(serviceDescriptors);
+        }
+
+        return Create(serviceProvider, ownsServices: false);
+    }
+
+    private static ITeleFlowApplication Create(IServiceProvider serviceProvider, bool ownsServices)
+    {
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var updateSource = ResolveSingleRequiredService<IUpdateSource>(serviceProvider);
+        var dispatcher = ResolveSingleRequiredService<IUpdateDispatcher>(serviceProvider);
+        var middleware = serviceProvider.GetServices<UpdateMiddlewareRegistration>().ToArray();
+        var startupTasks = serviceProvider.GetServices<TeleFlowStartupTaskRegistration>().ToArray();
+        var shutdownTasks = serviceProvider.GetServices<TeleFlowShutdownTaskRegistration>().ToArray();
+        var processor = new DefaultUpdateProcessor(scopeFactory, dispatcher, middleware);
+        var lifecycle = new TeleFlowApplicationLifecycleRunner(scopeFactory, startupTasks, shutdownTasks);
+
+        return new TeleFlowApplication(serviceProvider, updateSource, processor, lifecycle, ownsServices);
+    }
+
+    private static TService ResolveSingleRequiredService<TService>(IServiceProvider serviceProvider)
+        where TService : class
+    {
+        var services = serviceProvider.GetServices<TService>().ToArray();
+
+        return services.Length switch
+        {
+            0 => throw new InvalidOperationException(
+                $"A single {typeof(TService).Name} registration is required to build the TeleFlow application."),
+            > 1 => throw new InvalidOperationException(
+                $"Only one {typeof(TService).Name} registration is supported when building the TeleFlow application."),
+            _ => services[0]
+        };
+    }
+
+    private static void ValidateServiceDescriptors(IEnumerable<ServiceDescriptor> services)
+    {
+        var descriptors = services as ICollection<ServiceDescriptor> ?? services.ToArray();
+
+        if (descriptors.Any(static descriptor => descriptor.ServiceType == typeof(IUpdateMiddleware)))
+        {
+            throw new InvalidOperationException(
+                "Direct IUpdateMiddleware service registrations are not used by the TeleFlow update pipeline. " +
+                $"Register middleware with {nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware)}<TMiddleware>() " +
+                $"or {nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware)}<TMiddleware>() so TeleFlow can " +
+                "resolve it from the correct update scope.");
+        }
+
+        if (descriptors.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowStartupTask)))
+        {
+            throw new InvalidOperationException(
+                "Direct ITeleFlowStartupTask service registrations are not used by the TeleFlow application lifecycle. " +
+                $"Register startup tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowStartupTask)}<TTask>() " +
+                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
+        }
+
+        if (descriptors.Any(static descriptor => descriptor.ServiceType == typeof(ITeleFlowShutdownTask)))
+        {
+            throw new InvalidOperationException(
+                "Direct ITeleFlowShutdownTask service registrations are not used by the TeleFlow application lifecycle. " +
+                $"Register shutdown tasks with {nameof(ApplicationLifecycleServiceCollectionExtensions.AddTeleFlowShutdownTask)}<TTask>() " +
+                "so TeleFlow can resolve them from a dedicated lifecycle scope.");
+        }
+    }
+}

--- a/src/TeleFlow.Core/Properties/AssemblyInfo.cs
+++ b/src/TeleFlow.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TeleFlow.ArchitectureTests")]
+[assembly: InternalsVisibleTo("TeleFlow.Hosting")]
 [assembly: InternalsVisibleTo("TeleFlow.Telegram.Framework.Webhooks")]

--- a/src/TeleFlow.Hosting/TeleFlow.Hosting.csproj
+++ b/src/TeleFlow.Hosting/TeleFlow.Hosting.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Microsoft.Extensions.Hosting integration for running TeleFlow applications as hosted services.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TeleFlow.Core\TeleFlow.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/TeleFlow.Hosting/TeleFlowHostedService.cs
+++ b/src/TeleFlow.Hosting/TeleFlowHostedService.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Core.Application;
+
+namespace TeleFlow.Hosting;
+
+/// <summary>
+/// Bridges the Generic Host background-service lifecycle to a configured TeleFlow application without taking ownership
+/// of the host service provider. StartAsync enters the TeleFlow update source, and StopAsync cancels it through the host token.
+/// </summary>
+internal sealed class TeleFlowHostedService(
+    IServiceProvider services,
+    TeleFlowHostedServiceCollectionState serviceCollectionState) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await using var application = TeleFlowApplicationRuntimeFactory.CreateBorrowed(
+            services,
+            serviceCollectionState.Services);
+
+        await application.RunAsync(stoppingToken).ConfigureAwait(false);
+    }
+}

--- a/src/TeleFlow.Hosting/TeleFlowHostedServiceCollectionState.cs
+++ b/src/TeleFlow.Hosting/TeleFlowHostedServiceCollectionState.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeleFlow.Hosting;
+
+/// <summary>
+/// Keeps the host service collection available until the hosted service starts, so Core can apply the same
+/// configuration validation that the manual TeleFlow application builder applies before creating the runtime pipeline.
+/// </summary>
+internal sealed class TeleFlowHostedServiceCollectionState
+{
+    public TeleFlowHostedServiceCollectionState(IServiceCollection services)
+    {
+        Services = services ?? throw new ArgumentNullException(nameof(services));
+    }
+
+    public IServiceCollection Services { get; }
+}

--- a/src/TeleFlow.Hosting/TeleFlowHostingServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Hosting/TeleFlowHostingServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace TeleFlow.Hosting;
+
+/// <summary>
+/// Adds the Microsoft.Extensions.Hosting adapter that runs a configured TeleFlow application through the Generic Host lifecycle.
+/// Use this with long-running update sources such as long polling; ASP.NET Core webhooks are driven by endpoint routing instead.
+/// </summary>
+public static class TeleFlowHostingServiceCollectionExtensions
+{
+    public static IServiceCollection AddTeleFlowHostedService(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(new TeleFlowHostedServiceCollectionState(services));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, TeleFlowHostedService>());
+
+        return services;
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/HostingIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/HostingIntegrationTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Core.Application;
+using TeleFlow.Core.DependencyInjection;
+using TeleFlow.Core.Dispatching;
+using TeleFlow.Core.Middleware;
+using TeleFlow.Core.Updates;
+using TeleFlow.Hosting;
+
+namespace TeleFlow.ArchitectureTests;
+
+public sealed class HostingIntegrationTests
+{
+    [Fact]
+    public void AddTeleFlowHostedService_RegistersSingleTeleFlowHostedService()
+    {
+        var services = CreateBaseServices();
+
+        services.AddTeleFlowHostedService();
+        services.AddTeleFlowHostedService();
+
+        using var provider = BuildProvider(services);
+
+        Assert.Single(provider.GetServices<IHostedService>());
+    }
+
+    [Fact]
+    public void AddTeleFlowHostedService_DoesNotRemoveExistingHostedServices()
+    {
+        var services = CreateBaseServices();
+
+        services.AddSingleton<IHostedService, OtherHostedService>();
+        services.AddTeleFlowHostedService();
+
+        using var provider = BuildProvider(services);
+
+        Assert.Equal(2, provider.GetServices<IHostedService>().Count());
+    }
+
+    [Fact]
+    public async Task HostedService_StartsApplicationAndStopCancelsUpdateSource()
+    {
+        var services = CreateBaseServices();
+        var trace = new List<string>();
+
+        services.AddSingleton(trace);
+        services.AddSingleton<BlockingUpdateSource>();
+        services.AddSingleton<IUpdateSource>(static provider => provider.GetRequiredService<BlockingUpdateSource>());
+        services.AddTeleFlowShutdownTask<RecordingShutdownTask>();
+        services.AddTeleFlowHostedService();
+
+        using var provider = BuildProvider(services);
+        var source = provider.GetRequiredService<BlockingUpdateSource>();
+        var hostedService = provider.GetRequiredService<IHostedService>();
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await source.Started.Task.WaitAsync(TestTimeout);
+
+        await hostedService.StopAsync(CancellationToken.None);
+
+        await source.CancellationObserved.Task.WaitAsync(TestTimeout);
+        Assert.Equal(["shutdown"], trace);
+    }
+
+    [Fact]
+    public async Task HostedService_DoesNotDisposeHostOwnedServiceProvider()
+    {
+        var services = CreateBaseServices();
+
+        services.AddSingleton<DisposableProbe>();
+        services.AddSingleton<BlockingUpdateSource>();
+        services.AddSingleton<IUpdateSource>(static provider => provider.GetRequiredService<BlockingUpdateSource>());
+        services.AddTeleFlowHostedService();
+
+        var provider = BuildProvider(services);
+        var probe = provider.GetRequiredService<DisposableProbe>();
+        var source = provider.GetRequiredService<BlockingUpdateSource>();
+        var hostedService = provider.GetRequiredService<IHostedService>();
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await source.Started.Task.WaitAsync(TestTimeout);
+        await hostedService.StopAsync(CancellationToken.None);
+
+        Assert.False(probe.IsDisposed);
+
+        provider.Dispose();
+
+        Assert.True(probe.IsDisposed);
+    }
+
+    [Fact]
+    public async Task HostedService_ExposesStartupTaskFailureThroughBackgroundServiceTask()
+    {
+        var services = CreateBaseServices();
+        var exception = new InvalidOperationException("startup failed");
+
+        services.AddSingleton(exception);
+        services.AddSingleton<IUpdateSource, CompletingUpdateSource>();
+        services.AddTeleFlowStartupTask<ThrowingStartupTask>();
+        services.AddTeleFlowHostedService();
+
+        using var provider = BuildProvider(services);
+        var hostedService = provider.GetRequiredService<IHostedService>();
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => GetExecuteTask(hostedService));
+
+        Assert.Same(exception, thrown);
+    }
+
+    [Fact]
+    public async Task HostedService_ExposesDirectRegistrationValidationThroughBackgroundServiceTask()
+    {
+        var services = CreateBaseServices();
+
+        services.AddSingleton<IUpdateSource, CompletingUpdateSource>();
+        services.AddTeleFlowHostedService();
+        services.AddScoped<IUpdateMiddleware, DirectMiddleware>();
+
+        using var provider = BuildProvider(services);
+        var hostedService = provider.GetRequiredService<IHostedService>();
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => GetExecuteTask(hostedService));
+
+        Assert.Contains(nameof(IUpdateMiddleware), exception.Message);
+        Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddUpdateMiddleware), exception.Message);
+        Assert.Contains(nameof(ServiceCollectionMiddlewareExtensions.AddSingletonUpdateMiddleware), exception.Message);
+    }
+
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    private static IServiceCollection CreateBaseServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IUpdateDispatcher, NoOpDispatcher>();
+
+        return services;
+    }
+
+    private static ServiceProvider BuildProvider(IServiceCollection services)
+    {
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+    }
+
+    private static Task GetExecuteTask(IHostedService hostedService)
+    {
+        var backgroundService = Assert.IsAssignableFrom<BackgroundService>(hostedService);
+
+        return backgroundService.ExecuteTask
+            ?? throw new InvalidOperationException("The background service has not been started.");
+    }
+
+    private sealed class BlockingUpdateSource : IUpdateSource
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource CancellationObserved { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task StartAsync(
+            Func<IUpdatePayload, CancellationToken, Task> updateHandler,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(updateHandler);
+
+            Started.TrySetResult();
+
+            await using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource)state!).TrySetResult(),
+                CancellationObserved);
+
+            await CancellationObserved.Task.ConfigureAwait(false);
+        }
+    }
+
+    private sealed class CompletingUpdateSource : IUpdateSource
+    {
+        public Task StartAsync(
+            Func<IUpdatePayload, CancellationToken, Task> updateHandler,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(updateHandler);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpDispatcher : IUpdateDispatcher
+    {
+        public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingShutdownTask(List<string> trace) : ITeleFlowShutdownTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            trace.Add("shutdown");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingStartupTask(InvalidOperationException exception) : ITeleFlowStartupTask
+    {
+        public ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromException(exception);
+        }
+    }
+
+    private sealed class DirectMiddleware : IUpdateMiddleware
+    {
+        public Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+        {
+            return next(context);
+        }
+    }
+
+    private sealed class OtherHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DisposableProbe : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
@@ -17,6 +17,7 @@ public sealed class PackageSmokeTests
     [
         new("IWF.TeleFlow.Annotations", "src/TeleFlow.Annotations/TeleFlow.Annotations.csproj"),
         new("IWF.TeleFlow.Core", "src/TeleFlow.Core/TeleFlow.Core.csproj"),
+        new("IWF.TeleFlow.Hosting", "src/TeleFlow.Hosting/TeleFlow.Hosting.csproj"),
         new("IWF.TeleFlow.Storage.Memory", "src/TeleFlow.Storage.Memory/TeleFlow.Storage.Memory.csproj"),
         new("IWF.TeleFlow.Telegram.Schema", "src/TeleFlow.Telegram.Schema/TeleFlow.Telegram.Schema.csproj"),
         new("IWF.TeleFlow.Telegram.Client", "src/TeleFlow.Telegram.Client/TeleFlow.Telegram.Client.csproj"),
@@ -462,6 +463,51 @@ public sealed class PackageSmokeTests
                 ForbiddenPackages:
                 [
                     "IWF.TeleFlow.Annotations",
+                    "IWF.TeleFlow.Hosting",
+                    "IWF.TeleFlow.Telegram",
+                    "IWF.TeleFlow.Telegram.Client",
+                    "IWF.TeleFlow.Telegram.Framework",
+                    "IWF.TeleFlow.Telegram.Framework.LongPolling",
+                    "IWF.TeleFlow.Telegram.Framework.Webhooks",
+                    "IWF.TeleFlow.Telegram.LongPolling",
+                    "IWF.TeleFlow.Telegram.Schema",
+                    "IWF.TeleFlow.Telegram.Webhooks"
+                ]),
+
+            new PackageConsumerScenario(
+                Name: "HostingPackageConsumer",
+                PackageId: "IWF.TeleFlow.Hosting",
+                RequiresAspNetCore: false,
+                Source:
+                """
+                using System.Collections.Generic;
+                using System.Linq;
+                using Microsoft.Extensions.DependencyInjection;
+                using Microsoft.Extensions.Hosting;
+                using TeleFlow.Hosting;
+
+                public static class HostingPackageConsumer
+                {
+                    public static void Configure(IServiceCollection services)
+                    {
+                        services.AddTeleFlowHostedService();
+                    }
+
+                    public static int CountHostedServices(IEnumerable<IHostedService> services)
+                    {
+                        return services.Count();
+                    }
+                }
+                """,
+                ExpectedPackages:
+                [
+                    "IWF.TeleFlow.Core",
+                    "IWF.TeleFlow.Hosting"
+                ],
+                ForbiddenPackages:
+                [
+                    "IWF.TeleFlow.Annotations",
+                    "IWF.TeleFlow.Storage.Memory",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Client",
                     "IWF.TeleFlow.Telegram.Framework",
@@ -507,6 +553,7 @@ public sealed class PackageSmokeTests
                 [
                     "IWF.TeleFlow.Annotations",
                     "IWF.TeleFlow.Core",
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Framework",
                     "IWF.TeleFlow.Telegram.Framework.LongPolling",
@@ -553,6 +600,7 @@ public sealed class PackageSmokeTests
                 [
                     "IWF.TeleFlow.Annotations",
                     "IWF.TeleFlow.Core",
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Framework",
                     "IWF.TeleFlow.Telegram.Framework.LongPolling",
@@ -597,6 +645,7 @@ public sealed class PackageSmokeTests
                 [
                     "IWF.TeleFlow.Annotations",
                     "IWF.TeleFlow.Core",
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Framework",
                     "IWF.TeleFlow.Telegram.Framework.LongPolling",
@@ -642,6 +691,7 @@ public sealed class PackageSmokeTests
                 ],
                 ForbiddenPackages:
                 [
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Framework.Webhooks",
                     "IWF.TeleFlow.Telegram.Webhooks"
@@ -686,6 +736,7 @@ public sealed class PackageSmokeTests
                 ],
                 ForbiddenPackages:
                 [
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram",
                     "IWF.TeleFlow.Telegram.Framework.LongPolling",
                     "IWF.TeleFlow.Telegram.LongPolling"
@@ -727,6 +778,7 @@ public sealed class PackageSmokeTests
                 [
                     "IWF.TeleFlow.Annotations",
                     "IWF.TeleFlow.Core",
+                    "IWF.TeleFlow.Hosting",
                     "IWF.TeleFlow.Telegram.Framework",
                     "IWF.TeleFlow.Telegram.Framework.LongPolling",
                     "IWF.TeleFlow.Telegram.Framework.Webhooks",

--- a/tests/TeleFlow.ArchitectureTests/ProjectGraphTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/ProjectGraphTests.cs
@@ -21,6 +21,7 @@ public sealed class ProjectGraphTests
         Assert.Contains("TeleFlow.Telegram.Schema", solutionText);
         Assert.Contains("TeleFlow.Annotations", solutionText);
         Assert.Contains("TeleFlow.Generators", solutionText);
+        Assert.Contains("TeleFlow.Hosting", solutionText);
         Assert.Contains("TeleFlow.Storage.Memory", solutionText);
         Assert.Contains("TeleFlow.Telegram.Webhooks", solutionText);
         Assert.DoesNotContain("Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"TeleFlow\"", solutionText);
@@ -125,6 +126,14 @@ public sealed class ProjectGraphTests
         Assert.Equal(
             ["..\\TeleFlow.Core\\TeleFlow.Core.csproj"],
             GetProjectReferences("src/TeleFlow.Storage.Memory/TeleFlow.Storage.Memory.csproj"));
+    }
+
+    [Fact]
+    public void Hosting_ReferencesCoreOnly()
+    {
+        Assert.Equal(
+            ["..\\TeleFlow.Core\\TeleFlow.Core.csproj"],
+            GetProjectReferences("src/TeleFlow.Hosting/TeleFlow.Hosting.csproj"));
     }
 
     [Fact]

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -130,6 +130,11 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Storage.Memory.MemoryStateStore"
     ];
 
+    private static readonly string[] HostingTypeNames =
+    [
+        "TeleFlow.Hosting.TeleFlowHostingServiceCollectionExtensions"
+    ];
+
     private static readonly string[] ClientOnlyTeleFlowReferenceFileNames =
     [
         "TeleFlow.Telegram.Client.dll",
@@ -150,6 +155,12 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.Client.dll",
         "TeleFlow.Telegram.LongPolling.dll",
         "TeleFlow.Telegram.Schema.dll"
+    ];
+
+    private static readonly string[] HostingOnlyTeleFlowReferenceFileNames =
+    [
+        "TeleFlow.Core.dll",
+        "TeleFlow.Hosting.dll"
     ];
 
     private static readonly string[] FrameworkLongPollingOnlyTeleFlowReferenceFileNames =
@@ -274,6 +285,37 @@ public sealed class PublicSurfaceTests
 
         Assert.Equal(
             MemoryStorageTypeNames.Order(StringComparer.Ordinal),
+            exportedTypeNames.Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Hosting_DoesNotReferenceTelegramAssemblies()
+    {
+        var referencedAssemblies = LoadProjectAssembly("TeleFlow.Hosting")
+            .GetReferencedAssemblies()
+            .Select(static assembly => assembly.Name)
+            .ToArray();
+
+        Assert.Contains("TeleFlow.Core", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.Schema", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.Framework", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.Framework.LongPolling", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.Framework.Webhooks", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.LongPolling", referencedAssemblies);
+        Assert.DoesNotContain("TeleFlow.Telegram.Webhooks", referencedAssemblies);
+    }
+
+    [Fact]
+    public void Hosting_PublicSurface_ExportsHostingTypesOnly()
+    {
+        var exportedTypeNames = LoadProjectAssembly("TeleFlow.Hosting")
+            .GetExportedTypes()
+            .Select(static type => type.FullName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            HostingTypeNames.Order(StringComparer.Ordinal),
             exportedTypeNames.Order(StringComparer.Ordinal));
     }
 
@@ -937,6 +979,42 @@ public sealed class PublicSurfaceTests
     }
 
     [Fact]
+    public void Hosting_Surface_CompilesWithoutTelegramPackages()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Microsoft.Extensions.DependencyInjection;
+            using Microsoft.Extensions.Hosting;
+            using TeleFlow.Hosting;
+
+            public static class HostingOnlySmoke
+            {
+                public static void Configure(IServiceCollection services)
+                {
+                    services.AddTeleFlowHostedService();
+                }
+
+                public static int CountHostedServices(IEnumerable<IHostedService> services)
+                {
+                    return services.Count();
+                }
+            }
+            """;
+
+        var compilation = CreateHostingOnlyCompilation(source);
+        using var stream = new MemoryStream();
+
+        var result = compilation.Emit(stream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .Select(static diagnostic => diagnostic.ToString())));
+    }
+
+    [Fact]
     public void TelegramFramework_PublicSurface_DoesNotExposeRawTransportPackageTypes()
     {
         var publicTypes = LoadProjectAssembly("TeleFlow.Telegram.Framework")
@@ -1022,6 +1100,28 @@ public sealed class PublicSurfaceTests
 
         return CSharpCompilation.Create(
             "TelegramRawLongPollingOnlySmoke",
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static CSharpCompilation CreateHostingOnlyCompilation(string source)
+    {
+        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trustedAssemblies
+            ? trustedAssemblies
+                .Split(Path.PathSeparator)
+                .Where(static path => !IsTeleFlowAssemblyReference(path))
+                .Select(static path => MetadataReference.CreateFromFile(path))
+                .Cast<MetadataReference>()
+                .ToList()
+            : [];
+
+        references.Add(MetadataReference.CreateFromFile(LoadProjectAssembly("TeleFlow.Core").Location));
+        references.Add(MetadataReference.CreateFromFile(LoadProjectAssembly("TeleFlow.Hosting").Location));
+        Assert.Equal(HostingOnlyTeleFlowReferenceFileNames, GetTeleFlowReferenceFileNames(references));
+
+        return CSharpCompilation.Create(
+            "TeleFlowHostingOnlySmoke",
             [CSharpSyntaxTree.ParseText(source)],
             references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));

--- a/tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj
+++ b/tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\src\TeleFlow.Annotations\TeleFlow.Annotations.csproj" />
     <ProjectReference Include="..\..\src\TeleFlow.Core\TeleFlow.Core.csproj" />
     <ProjectReference Include="..\..\src\TeleFlow.Generators\TeleFlow.Generators.csproj" />
+    <ProjectReference Include="..\..\src\TeleFlow.Hosting\TeleFlow.Hosting.csproj" />
     <ProjectReference Include="..\..\src\TeleFlow.Storage.Memory\TeleFlow.Storage.Memory.csproj" />
     <ProjectReference Include="..\..\src\TeleFlow.Telegram\TeleFlow.Telegram.csproj" />
     <ProjectReference Include="..\..\src\TeleFlow.Telegram.Client\TeleFlow.Telegram.Client.csproj" />


### PR DESCRIPTION
## Summary
- add `IWF.TeleFlow.Hosting` with `AddTeleFlowHostedService()` for Microsoft.Extensions.Hosting applications
- move TeleFlow runtime composition into a shared Core runtime factory used by both manual startup and host-owned service providers
- keep Hosting as a thin `BackgroundService` adapter without Telegram dependencies or host provider ownership
- add architecture, public surface, package graph, package smoke, and runtime integration coverage
- update README and EN/RU documentation for package selection, application model, deployment, architecture, and versioning

## Design Notes
- `TeleFlow.Core` remains transport-agnostic and does not reference Microsoft.Extensions.Hosting.
- `TeleFlow.Hosting` references Core only and does not know Telegram framework internals.
- The hosted service uses the host-owned `IServiceProvider` and does not dispose it.
- Webhook apps remain endpoint-driven and should not use `AddTeleFlowHostedService()`.

## Validation
- `dotnet build TeleFlow.sln --configuration Release /nodeReuse:false`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --configuration Release --no-build /nodeReuse:false`
- `git diff --check`

Closes #35
