### PR TITLE
docs(packages): clarify NuGet entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The documentation is available as a GitHub Pages site and as Markdown in this re
 
 TeleFlow is currently published as a public alpha. Use `--prerelease` or pin an exact alpha version.
 
+Most applications start from one scenario package. The lower-level packages are pulled in transitively and are documented separately for advanced use.
+
 For a handler-based long polling bot:
 
 ```bash
@@ -84,6 +86,8 @@ For a .NET worker that should run TeleFlow through Microsoft.Extensions.Hosting,
 ```bash
 dotnet add package IWF.TeleFlow.Framework.Hosting --prerelease
 ```
+
+You normally do not install `IWF.TeleFlow.Framework.Core`, `IWF.TeleFlow.Framework`, `IWF.TeleFlow.Telegram.Client`, `IWF.TeleFlow.Telegram.Schema`, or `IWF.TeleFlow.Annotations` directly. They are dependency or advanced packages behind the recommended entry points above.
 
 ## First Bot
 

--- a/docs/en/getting-started/packages.md
+++ b/docs/en/getting-started/packages.md
@@ -10,32 +10,47 @@ NuGet package IDs use the `IWF.TeleFlow.*` prefix. C# namespaces stay concise fo
 
 ## Quick Choice
 
+Most applications install a small set of entry packages. The rest of the package graph exists to keep internal boundaries clean and is usually restored transitively.
+
+### Recommended Entry Packages
+
 | Scenario | Package reference | What you get |
 | --- | --- | --- |
-| Direct Telegram Bot API access | `IWF.TeleFlow.Telegram` | Low-level `ITelegramClient`, generated Bot API methods, defaults, JSON, transport, exceptions, deep links |
-| Direct client through the owner package | `IWF.TeleFlow.Telegram.Client` | Same client runtime through the explicit package-boundary name |
 | Handler framework with long polling | `IWF.TeleFlow.Framework.LongPolling` | Handler framework plus long-polling transport |
 | Handler framework with webhooks | `IWF.TeleFlow.Framework.Webhooks` | Handler framework plus ASP.NET Core webhook transport |
-| Generic Host integration | `IWF.TeleFlow.Framework.Hosting` | `IHostedService` adapter for running a configured TeleFlow application through Microsoft.Extensions.Hosting |
-| Raw long polling without handlers | `IWF.TeleFlow.Telegram.LongPolling` | `getUpdates` runner and acknowledged update stream over raw Telegram `Update` values |
-| Raw ASP.NET Core webhooks without handlers | `IWF.TeleFlow.Telegram.Webhooks` | ASP.NET Core endpoint helpers over raw Telegram `Update` values |
+| Direct Telegram Bot API access | `IWF.TeleFlow.Telegram` | Low-level `ITelegramClient`, generated Bot API methods, defaults, JSON, transport, exceptions, deep links |
+| Generated handler metadata | `IWF.TeleFlow.Generators` | Source generator and analyzer package for build-time handler registration. Reference it directly with `PrivateAssets="all"` |
 | In-memory state storage | `IWF.TeleFlow.Storage.Memory` | Process-local state, state data, wizard history, and state middleware registration |
-| Handler attributes | `IWF.TeleFlow.Annotations` | Attributes such as `[Command]`, `[Text]`, `[Callback]`, `[State]`, and filters |
-| Generated handler metadata | `IWF.TeleFlow.Generators` | Source generator and analyzer package for build-time handler registration |
+| Generic Host integration | `IWF.TeleFlow.Framework.Hosting` | Optional `IHostedService` adapter for running a configured TeleFlow application through Microsoft.Extensions.Hosting |
 
-`IWF.TeleFlow.Telegram.Schema` is normally pulled in by Telegram packages. Reference it directly only when you intentionally work with generated Telegram DTOs and method models without the client or framework runtime.
+### Advanced And Dependency Packages
+
+| Scenario | Package reference | When to reference directly |
+| --- | --- | --- |
+| Framework runtime without bundled transport | `IWF.TeleFlow.Framework` | Only when you provide a custom framework update source or transport package |
+| Framework primitives | `IWF.TeleFlow.Framework.Core` | Normally never in bot projects. Storage and framework packages reference it transitively |
+| Direct client runtime boundary | `IWF.TeleFlow.Telegram.Client` | Only when you intentionally want the explicit lower-level client package instead of the owner package `IWF.TeleFlow.Telegram` |
+| Generated Telegram schema | `IWF.TeleFlow.Telegram.Schema` | Only when you intentionally work with generated Telegram DTOs and method models without the client or framework runtime |
+| Handler attributes | `IWF.TeleFlow.Annotations` | Normally restored through framework packages. Reference directly only for advanced compile-only scenarios |
+| Raw long polling without handlers | `IWF.TeleFlow.Telegram.LongPolling` | When you want `getUpdates` and acknowledged update streaming over raw Telegram `Update` values |
+| Raw ASP.NET Core webhooks without handlers | `IWF.TeleFlow.Telegram.Webhooks` | When you want ASP.NET Core endpoint helpers over raw Telegram `Update` values |
 
 ## Installing Alpha Packages
 
 TeleFlow is currently published as a public alpha. Use `--prerelease` with `dotnet add package`, or pin an exact alpha version in the project file.
 
-Recommended alpha install for a long polling bot:
+Recommended alpha install for a small long polling bot:
 
 ```bash
 dotnet add package IWF.TeleFlow.Framework.LongPolling --prerelease
-dotnet add package IWF.TeleFlow.Framework.Hosting --prerelease
 dotnet add package IWF.TeleFlow.Generators --prerelease
 dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
+```
+
+Add Generic Host integration only when the application is a worker service or an ASP.NET Core host:
+
+```bash
+dotnet add package IWF.TeleFlow.Framework.Hosting --prerelease
 ```
 
 ## Recommended Defaults
@@ -44,9 +59,14 @@ For a handler-based long polling bot:
 
 ```xml
 <PackageReference Include="IWF.TeleFlow.Framework.LongPolling" Version="..." />
-<PackageReference Include="IWF.TeleFlow.Framework.Hosting" Version="..." />
 <PackageReference Include="IWF.TeleFlow.Generators" Version="..." PrivateAssets="all" />
 <PackageReference Include="IWF.TeleFlow.Storage.Memory" Version="..." />
+```
+
+For a worker-service style application, add hosting:
+
+```xml
+<PackageReference Include="IWF.TeleFlow.Framework.Hosting" Version="..." />
 ```
 
 ```csharp

--- a/docs/ru/getting-started/packages.md
+++ b/docs/ru/getting-started/packages.md
@@ -10,32 +10,47 @@ NuGet package IDs используют prefix `IWF.TeleFlow.*`. C# namespaces о
 
 ## Быстрый выбор
 
+Большинство приложений ставит небольшой набор входных пакетов. Остальная часть package graph нужна для чистых внутренних границ и обычно подтягивается транзитивно.
+
+### Рекомендуемые входные пакеты
+
 | Сценарий | Package reference | Что даёт |
 | --- | --- | --- |
-| Прямой доступ к Telegram Bot API | `IWF.TeleFlow.Telegram` | Low-level `ITelegramClient`, generated Bot API methods, defaults, JSON, transport, exceptions, deep links |
-| Прямой client через owner package | `IWF.TeleFlow.Telegram.Client` | Тот же client runtime через явное package-boundary имя |
 | Handler framework с long polling | `IWF.TeleFlow.Framework.LongPolling` | Handler framework плюс long-polling transport |
 | Handler framework с webhooks | `IWF.TeleFlow.Framework.Webhooks` | Handler framework плюс ASP.NET Core webhook transport |
-| Generic Host integration | `IWF.TeleFlow.Framework.Hosting` | `IHostedService` adapter для запуска настроенного TeleFlow application через Microsoft.Extensions.Hosting |
-| Raw long polling без handlers | `IWF.TeleFlow.Telegram.LongPolling` | `getUpdates` runner и acknowledged update stream поверх raw Telegram `Update` values |
-| Raw ASP.NET Core webhooks без handlers | `IWF.TeleFlow.Telegram.Webhooks` | ASP.NET Core endpoint helpers поверх raw Telegram `Update` values |
+| Прямой доступ к Telegram Bot API | `IWF.TeleFlow.Telegram` | Low-level `ITelegramClient`, generated Bot API methods, defaults, JSON, transport, exceptions, deep links |
+| Generated handler metadata | `IWF.TeleFlow.Generators` | Source generator и analyzer package для build-time handler registration. Подключай напрямую с `PrivateAssets="all"` |
 | In-memory state storage | `IWF.TeleFlow.Storage.Memory` | Process-local state, state data, wizard history и регистрация state middleware |
-| Handler attributes | `IWF.TeleFlow.Annotations` | Атрибуты вроде `[Command]`, `[Text]`, `[Callback]`, `[State]` и filters |
-| Generated handler metadata | `IWF.TeleFlow.Generators` | Source generator и analyzer package для build-time handler registration |
+| Generic Host integration | `IWF.TeleFlow.Framework.Hosting` | Optional `IHostedService` adapter для запуска настроенного TeleFlow application через Microsoft.Extensions.Hosting |
 
-`IWF.TeleFlow.Telegram.Schema` обычно подтягивается Telegram-пакетами. Подключай его напрямую только если намеренно работаешь с generated Telegram DTOs и method models без client/framework runtime.
+### Advanced и dependency packages
+
+| Сценарий | Package reference | Когда подключать напрямую |
+| --- | --- | --- |
+| Framework runtime без bundled transport | `IWF.TeleFlow.Framework` | Только если ты делаешь custom framework update source или transport package |
+| Framework primitives | `IWF.TeleFlow.Framework.Core` | В обычных bot projects почти никогда. Storage и framework packages подтягивают его транзитивно |
+| Direct client runtime boundary | `IWF.TeleFlow.Telegram.Client` | Только если намеренно нужен явный lower-level client package вместо owner package `IWF.TeleFlow.Telegram` |
+| Generated Telegram schema | `IWF.TeleFlow.Telegram.Schema` | Только если намеренно работаешь с generated Telegram DTOs и method models без client/framework runtime |
+| Handler attributes | `IWF.TeleFlow.Annotations` | Обычно подтягивается framework packages. Подключай напрямую только для advanced compile-only сценариев |
+| Raw long polling без handlers | `IWF.TeleFlow.Telegram.LongPolling` | Когда нужны `getUpdates` и acknowledged update streaming поверх raw Telegram `Update` values |
+| Raw ASP.NET Core webhooks без handlers | `IWF.TeleFlow.Telegram.Webhooks` | Когда нужны ASP.NET Core endpoint helpers поверх raw Telegram `Update` values |
 
 ## Установка alpha packages
 
 TeleFlow сейчас опубликован как public alpha. Используй `--prerelease` с `dotnet add package` или фиксируй конкретную alpha version в project file.
 
-Рекомендуемая alpha-установка для long polling bot:
+Рекомендуемая alpha-установка для маленького long polling bot:
 
 ```bash
 dotnet add package IWF.TeleFlow.Framework.LongPolling --prerelease
-dotnet add package IWF.TeleFlow.Framework.Hosting --prerelease
 dotnet add package IWF.TeleFlow.Generators --prerelease
 dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
+```
+
+Generic Host integration добавляй только если приложение является worker service или ASP.NET Core host:
+
+```bash
+dotnet add package IWF.TeleFlow.Framework.Hosting --prerelease
 ```
 
 ## Рекомендуемый дефолт
@@ -44,9 +59,14 @@ dotnet add package IWF.TeleFlow.Storage.Memory --prerelease
 
 ```xml
 <PackageReference Include="IWF.TeleFlow.Framework.LongPolling" Version="..." />
-<PackageReference Include="IWF.TeleFlow.Framework.Hosting" Version="..." />
 <PackageReference Include="IWF.TeleFlow.Generators" Version="..." PrivateAssets="all" />
 <PackageReference Include="IWF.TeleFlow.Storage.Memory" Version="..." />
+```
+
+Для worker-service style приложения добавь hosting:
+
+```xml
+<PackageReference Include="IWF.TeleFlow.Framework.Hosting" Version="..." />
 ```
 
 ```csharp

--- a/src/TeleFlow.Annotations/TeleFlow.Annotations.csproj
+++ b/src/TeleFlow.Annotations/TeleFlow.Annotations.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Compile-time attributes for TeleFlow Telegram handlers, including commands, text routes, callbacks, filters, state, scenes, modules, and errors.</Description>
+    <Description>Dependency package with compile-time attributes for TeleFlow Telegram handlers. Most applications get it transitively from IWF.TeleFlow.Framework.LongPolling or IWF.TeleFlow.Framework.Webhooks.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>

--- a/src/TeleFlow.Framework.Core/TeleFlow.Framework.Core.csproj
+++ b/src/TeleFlow.Framework.Core/TeleFlow.Framework.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Transport-agnostic application, middleware, update processing, state, and rate-limiting primitives for TeleFlow.</Description>
+    <Description>Dependency package with transport-agnostic TeleFlow framework primitives for application lifetime, middleware, update processing, state, and rate limiting. Most bot applications should install a framework entry package instead.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TeleFlow.Framework.Hosting/TeleFlow.Framework.Hosting.csproj
+++ b/src/TeleFlow.Framework.Hosting/TeleFlow.Framework.Hosting.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Microsoft.Extensions.Hosting integration for running TeleFlow applications as hosted services.</Description>
+    <Description>Optional TeleFlow framework entry add-on for running a configured TeleFlow application through Microsoft.Extensions.Hosting as an IHostedService.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TeleFlow.Framework.LongPolling/TeleFlow.Framework.LongPolling.csproj
+++ b/src/TeleFlow.Framework.LongPolling/TeleFlow.Framework.LongPolling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Long polling framework package for TeleFlow Telegram bots, combining handler dispatch with the raw getUpdates transport adapter.</Description>
+    <Description>Recommended TeleFlow framework entry package for Telegram bots that use handler dispatch with long polling over getUpdates.</Description>
     <RootNamespace>TeleFlow.Telegram</RootNamespace>
   </PropertyGroup>
 

--- a/src/TeleFlow.Framework.Webhooks/TeleFlow.Framework.Webhooks.csproj
+++ b/src/TeleFlow.Framework.Webhooks/TeleFlow.Framework.Webhooks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>ASP.NET Core webhook framework package for TeleFlow Telegram bots, combining handler dispatch with raw Telegram webhook endpoints.</Description>
+    <Description>Recommended TeleFlow framework entry package for Telegram bots that use handler dispatch with ASP.NET Core webhooks.</Description>
     <RootNamespace>TeleFlow.Telegram.Webhooks</RootNamespace>
   </PropertyGroup>
 

--- a/src/TeleFlow.Framework/TeleFlow.Framework.csproj
+++ b/src/TeleFlow.Framework/TeleFlow.Framework.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Attribute-based Telegram bot framework runtime for TeleFlow, including contexts, dispatcher, filters, callbacks, state integration, and generated handler registration.</Description>
+    <Description>Dependency package with the advanced TeleFlow Telegram handler framework runtime. Most applications should install IWF.TeleFlow.Framework.LongPolling or IWF.TeleFlow.Framework.Webhooks instead.</Description>
     <RootNamespace>TeleFlow.Telegram</RootNamespace>
   </PropertyGroup>
 

--- a/src/TeleFlow.Generators/TeleFlow.Generators.csproj
+++ b/src/TeleFlow.Generators/TeleFlow.Generators.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Build-time source generator and analyzer package for TeleFlow Telegram handler metadata, enabling generated registration without runtime assembly scanning.</Description>
+    <Description>Build-time source generator and analyzer package for TeleFlow Telegram handler metadata. Reference directly with PrivateAssets=all when using generated handler registration.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/TeleFlow.Storage.Memory/TeleFlow.Storage.Memory.csproj
+++ b/src/TeleFlow.Storage.Memory/TeleFlow.Storage.Memory.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>In-memory state, state data, and wizard history storage provider for TeleFlow bots, intended for local development, tests, and single-process applications.</Description>
+    <Description>TeleFlow state storage add-on with in-memory state, state data, and wizard history for local development, tests, and single-process applications.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TeleFlow.Telegram.Client/TeleFlow.Telegram.Client.csproj
+++ b/src/TeleFlow.Telegram.Client/TeleFlow.Telegram.Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Low-level generated Telegram Bot API client for .NET, including ITelegramClient, generated method extensions, transport contracts, JSON options, typed exceptions, and deep links.</Description>
+    <Description>Dependency package with the low-level generated Telegram Bot API client runtime. Most applications should install IWF.TeleFlow.Telegram or a TeleFlow framework entry package instead.</Description>
     <RootNamespace>TeleFlow.Telegram</RootNamespace>
   </PropertyGroup>
 

--- a/src/TeleFlow.Telegram.LongPolling/TeleFlow.Telegram.LongPolling.csproj
+++ b/src/TeleFlow.Telegram.LongPolling/TeleFlow.Telegram.LongPolling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Raw Telegram getUpdates long-polling client for TeleFlow, including safe offset advancement and acknowledged update streaming without the handler framework.</Description>
+    <Description>Advanced TeleFlow raw transport package for Telegram getUpdates, safe offset advancement, and acknowledged update streaming without the handler framework.</Description>
     <RootNamespace>TeleFlow.Telegram</RootNamespace>
   </PropertyGroup>
 

--- a/src/TeleFlow.Telegram.Schema/TeleFlow.Telegram.Schema.csproj
+++ b/src/TeleFlow.Telegram.Schema/TeleFlow.Telegram.Schema.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Generated Telegram Bot API schema DTOs, method models, union wrappers, and shared abstractions used by TeleFlow client and framework packages.</Description>
+    <Description>Dependency package with generated Telegram Bot API schema DTOs, method models, union wrappers, and shared abstractions used by TeleFlow client and framework packages.</Description>
   </PropertyGroup>
 </Project>

--- a/src/TeleFlow.Telegram.Webhooks/TeleFlow.Telegram.Webhooks.csproj
+++ b/src/TeleFlow.Telegram.Webhooks/TeleFlow.Telegram.Webhooks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Raw ASP.NET Core Telegram webhook endpoint helpers for TeleFlow applications that want Telegram Update payloads without the handler framework.</Description>
+    <Description>Advanced TeleFlow raw transport package with ASP.NET Core webhook endpoint helpers for applications that want Telegram Update payloads without the handler framework.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TeleFlow.Telegram/TeleFlow.Telegram.csproj
+++ b/src/TeleFlow.Telegram/TeleFlow.Telegram.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Direct Telegram Bot API client package for TeleFlow, including ITelegramClient, generated Bot API methods, defaults, transport customization, typed exceptions, and deep links.</Description>
+    <Description>Recommended TeleFlow entry package for direct Telegram Bot API access through ITelegramClient, generated Bot API methods, defaults, transport customization, typed exceptions, and deep links.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
@@ -221,6 +221,7 @@ public sealed class PackageSmokeTests
 
             Assert.Equal("IWFTech", package.Authors);
             Assert.False(string.IsNullOrWhiteSpace(package.Description));
+            AssertPackageDescriptionPolicy(package);
             Assert.Contains("teleflow", package.Tags, StringComparison.OrdinalIgnoreCase);
             Assert.Equal("README.md", package.Readme);
 
@@ -234,6 +235,32 @@ public sealed class PackageSmokeTests
                     static entry => entry.FullName == "lib/net10.0/TeleFlow.Annotations.xml");
             }
         }
+    }
+
+    private static void AssertPackageDescriptionPolicy(PackageIdentity package)
+    {
+        var requiredText = package.Id switch
+        {
+            "IWF.TeleFlow.Framework.LongPolling" or
+            "IWF.TeleFlow.Framework.Webhooks" or
+            "IWF.TeleFlow.Telegram" => "Recommended TeleFlow",
+
+            "IWF.TeleFlow.Framework.Core" or
+            "IWF.TeleFlow.Framework" or
+            "IWF.TeleFlow.Telegram.Client" or
+            "IWF.TeleFlow.Telegram.Schema" or
+            "IWF.TeleFlow.Annotations" => "Dependency package",
+
+            "IWF.TeleFlow.Telegram.LongPolling" or
+            "IWF.TeleFlow.Telegram.Webhooks" => "Advanced TeleFlow raw transport package",
+
+            "IWF.TeleFlow.Framework.Hosting" => "Optional TeleFlow",
+            "IWF.TeleFlow.Generators" => "Reference directly with PrivateAssets=all",
+            "IWF.TeleFlow.Storage.Memory" => "TeleFlow state storage add-on",
+            _ => throw new InvalidOperationException($"Unexpected package id '{package.Id}'.")
+        };
+
+        Assert.Contains(requiredText, package.Description, StringComparison.Ordinal);
     }
 
     private static void AssertPackedAnalyzerPackage(string packageSource, string packageId)


### PR DESCRIPTION
## Summary

- clarify the recommended NuGet entry packages in README and package docs
- separate recommended entry packages from advanced/dependency packages in English and Russian docs
- update package descriptions so NuGet search communicates entry-point vs dependency-package intent
- add package smoke coverage that asserts the description policy from packed `.nupkg` metadata

## Validation

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --configuration Release --filter PackageSmokeTests /nodeReuse:false`
- `dotnet build TeleFlow.sln --configuration Release /nodeReuse:false`
- `git diff --check`

## Notes

- `mkdocs build --strict` was not run locally because `mkdocs` is not installed in PATH on this machine.

Closes #111