### PR TITLE
ci(release): include hosting package in verification

### DIFF
--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -19,6 +19,7 @@ $strictAnalyzerScriptPath = Join-Path $repositoryRoot "eng\verify-strict-analyze
 $runtimePackages = @(
     @{ Id = "IWF.TeleFlow.Annotations"; Project = "src\TeleFlow.Annotations\TeleFlow.Annotations.csproj" },
     @{ Id = "IWF.TeleFlow.Framework.Core"; Project = "src\TeleFlow.Framework.Core\TeleFlow.Framework.Core.csproj" },
+    @{ Id = "IWF.TeleFlow.Framework.Hosting"; Project = "src\TeleFlow.Framework.Hosting\TeleFlow.Framework.Hosting.csproj" },
     @{ Id = "IWF.TeleFlow.Storage.Memory"; Project = "src\TeleFlow.Storage.Memory\TeleFlow.Storage.Memory.csproj" },
     @{ Id = "IWF.TeleFlow.Telegram.Schema"; Project = "src\TeleFlow.Telegram.Schema\TeleFlow.Telegram.Schema.csproj" },
     @{ Id = "IWF.TeleFlow.Telegram.Client"; Project = "src\TeleFlow.Telegram.Client\TeleFlow.Telegram.Client.csproj" },

--- a/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PackageSmokeTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace TeleFlow.ArchitectureTests;
@@ -113,6 +114,27 @@ public sealed class PackageSmokeTests
         {
             tempDirectory.Delete(recursive: true);
         }
+    }
+
+    [Fact]
+    public void VerifyReleaseScript_UsesTheSamePackageInventory()
+    {
+        var scriptPath = Path.Combine(RepositoryRoot, "eng", "verify-release.ps1");
+        var script = File.ReadAllText(scriptPath);
+
+        var packageIds = Regex
+            .Matches(script, "Id\\s*=\\s*\"(?<id>IWF\\.TeleFlow\\.[^\"]+)\"")
+            .Select(static match => match.Groups["id"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var expectedPackageIds = RuntimePackageProjects
+            .Concat(ReleaseAlignedToolingPackageProjects)
+            .Select(static project => project.PackageId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            expectedPackageIds.Order(StringComparer.Ordinal),
+            packageIds.Order(StringComparer.Ordinal));
     }
 
     private static async Task PackRuntimePackagesAsync(string packageSource)


### PR DESCRIPTION
## Summary

- include `IWF.TeleFlow.Framework.Hosting` in release package verification output
- add package smoke coverage that keeps `eng/verify-release.ps1` aligned with the package inventory used by package smoke tests

## Why

`1.0.0-alpha.6` includes the renamed framework package graph and hosting integration. The package smoke tests knew about `IWF.TeleFlow.Framework.Hosting`, but `eng/verify-release.ps1` did not pack it. Publishing without this fix would miss the hosting package.

## Validation

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --configuration Release --filter PackageSmokeTests /nodeReuse:false`
- `./eng/verify-release.ps1 -PackageVersion 1.0.0-alpha.6 -Configuration Release`
- local Alpha6 smoke bot restore/build against `artifacts/release-packages/1.0.0-alpha.6` using a clean NuGet cache
- manual Telegram smoke flow was checked locally