### PR TITLE
docs(readme): stabilize project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![Telegram Bot API](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FIWFTech%2FTeleFlow%2Fmain%2Fdocs%2Fbadges%2Ftelegram-bot-api.json)](https://core.telegram.org/bots/api-changelog)
 [![Telegram Chat](https://img.shields.io/badge/Telegram-chat-26A5E4?logo=telegram&logoColor=white)](https://t.me/teleflow_chat)
-[![NuGet](https://img.shields.io/nuget/vpre/IWF.TeleFlow.Framework.LongPolling?label=NuGet)](https://www.nuget.org/packages/IWF.TeleFlow.Framework.LongPolling/)
+[![Release](https://img.shields.io/github/v/release/IWFTech/TeleFlow?include_prereleases&label=release)](https://github.com/IWFTech/TeleFlow/releases)
 
-[![License](https://img.shields.io/github/license/IWFTech/TeleFlow)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/IWFTech/TeleFlow/actions/workflows/ci.yml/badge.svg)](https://github.com/IWFTech/TeleFlow/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/IWFTech/TeleFlow/actions/workflows/codeql.yml/badge.svg)](https://github.com/IWFTech/TeleFlow/actions/workflows/codeql.yml)
 ![GitHub last commit](https://img.shields.io/github/last-commit/IWFTech/TeleFlow)
-[![Downloads](https://img.shields.io/nuget/dt/IWF.TeleFlow.Framework.LongPolling?label=downloads)](https://www.nuget.org/packages/IWF.TeleFlow.Framework.LongPolling/)
+[![Downloads](https://img.shields.io/nuget/dt/IWF.TeleFlow.Telegram.Schema?label=downloads)](https://www.nuget.org/packages/IWF.TeleFlow.Telegram.Schema/)
 
 
 


### PR DESCRIPTION
## Summary
- replace the repository license detection badge with a stable MIT badge
- show the project release badge instead of tying the version badge to one NuGet entry package
- use `IWF.TeleFlow.Telegram.Schema` for total NuGet downloads because it is the common transitive package across normal Telegram usage

## Validation
- `git diff --check`
- checked the updated Shields endpoints return HTTP 200

## Risk
Docs-only README badge update.