### PR TITLE
feat(callbacks): add callback data diagnostics

### DIFF
--- a/docs/en/features/callbacks-and-keyboards.md
+++ b/docs/en/features/callbacks-and-keyboards.md
@@ -96,7 +96,46 @@ Typed inline keyboard payloads must be marked with `[CallbackData]`. If you need
 
 Custom `ICallbackDataSerializer` implementations remain available for advanced callback payload serialization and route deserialization, but typed inline keyboard buttons use `[CallbackData]` metadata directly.
 
-Invalid typed callback data does not match the typed handler. Serializer failures that are not normal parse/format failures are treated as real failures and remain observable.
+Invalid compact typed callback data does not invoke the typed handler. If the
+callback data matches the typed route prefix and field shape but cannot be
+decoded, TeleFlow logs a warning from `TelegramHandlerSelector` and treats that
+typed route as not matched. This covers stale buttons from an older bot version,
+malformed numeric fields, invalid boolean values, and invalid enum values.
+
+If you want a graceful user-facing answer for old buttons, add a raw callback
+fallback after the typed handler:
+
+```csharp
+[Callback<TicketAction>]
+public Task TicketActionCallback(
+    CallbackQueryContext ctx,
+    TicketAction payload,
+    CancellationToken ct)
+{
+    // Normal typed path.
+    return Task.CompletedTask;
+}
+
+[Callback]
+[CallbackDataPrefix("ticket")]
+public async Task StaleTicketCallback(
+    CallbackQueryContext ctx,
+    CancellationToken ct)
+{
+    await ctx.Callback.AnswerAsync(
+        "This button is outdated. Open the ticket again.",
+        showAlert: true,
+        cancellationToken: ct);
+}
+```
+
+The warning intentionally does not include the raw callback data string, because
+callback data can contain internal keys. Use compact prefixes and short fields
+instead of placing large or sensitive data directly into Telegram callback data.
+
+JSON fallback callback payloads remain supported, but TeleFlow cannot reliably
+distinguish "not my callback" from "my stale JSON payload" without a compact
+prefix. Use `[CallbackData]` for production callback routes.
 
 ## Auto Answer Callback
 

--- a/docs/en/reference/troubleshooting.md
+++ b/docs/en/reference/troubleshooting.md
@@ -118,6 +118,22 @@ public sealed record TicketAction(long Id, string A);
 
 Do not put large JSON payloads in callback data.
 
+## Callback Data Failed To Deserialize
+
+If logs contain `Telegram callback data failed to deserialize`, the callback
+matched a typed `[Callback<TPayload>]` route by compact prefix and field count,
+but the payload could not be decoded. Common causes:
+
+- an old inline button was clicked after you changed the callback payload type;
+- a numeric, boolean, or enum field contains an invalid value;
+- another bot component produced callback data with the same prefix but a
+  different field format.
+
+TeleFlow treats that typed route as not matched, so a raw callback fallback can
+answer the user. Keep callback payloads versionable: use short stable prefixes,
+prefer IDs over large objects, and create a new prefix when a deployed callback
+shape changes incompatibly.
+
 ## Webhook Returns Unauthorized
 
 Check `SecretToken` configuration and Telegram webhook settings. The incoming request must use the expected secret token.

--- a/docs/ru/features/callbacks-and-keyboards.md
+++ b/docs/ru/features/callbacks-and-keyboards.md
@@ -96,7 +96,46 @@ Typed inline keyboard payloads должны быть помечены `[Callback
 
 Custom `ICallbackDataSerializer` implementations остаются доступны для advanced callback payload serialization и route deserialization, но typed inline keyboard buttons используют `[CallbackData]` metadata напрямую.
 
-Invalid typed callback data не матчится с typed handler. Serializer failures, которые не являются обычными parse/format failures, считаются реальными failures и остаются observable.
+Invalid compact typed callback data не вызывает typed handler. Если callback
+data совпала с prefix и field shape typed route, но не смогла распаковаться,
+TeleFlow пишет warning от `TelegramHandlerSelector` и считает этот typed route
+не сматченным. Это покрывает старые кнопки от предыдущей версии бота,
+сломанные numeric fields, invalid boolean values и invalid enum values.
+
+Если нужен красивый ответ пользователю для старых кнопок, добавь raw callback
+fallback после typed handler:
+
+```csharp
+[Callback<TicketAction>]
+public Task TicketActionCallback(
+    CallbackQueryContext ctx,
+    TicketAction payload,
+    CancellationToken ct)
+{
+    // Нормальный typed path.
+    return Task.CompletedTask;
+}
+
+[Callback]
+[CallbackDataPrefix("ticket")]
+public async Task StaleTicketCallback(
+    CallbackQueryContext ctx,
+    CancellationToken ct)
+{
+    await ctx.Callback.AnswerAsync(
+        "Эта кнопка устарела. Открой заявку заново.",
+        showAlert: true,
+        cancellationToken: ct);
+}
+```
+
+Warning намеренно не содержит raw callback data string, потому что callback data
+может содержать internal keys. Используй compact prefixes и короткие fields,
+а large или sensitive data не клади напрямую в Telegram callback data.
+
+JSON fallback callback payloads остаются поддержанными, но без compact prefix
+TeleFlow не может надёжно отличить "это не мой callback" от "это мой старый JSON
+payload". Для production callback routes используй `[CallbackData]`.
 
 ## Auto answer callback
 

--- a/docs/ru/reference/troubleshooting.md
+++ b/docs/ru/reference/troubleshooting.md
@@ -118,6 +118,23 @@ public sealed record TicketAction(long Id, string A);
 
 Не клади large JSON payloads в callback data.
 
+## Callback data не смогла распаковаться
+
+Если в логах есть `Telegram callback data failed to deserialize`, callback
+совпал с typed `[Callback<TPayload>]` route по compact prefix и количеству
+fields, но payload не удалось декодировать. Частые причины:
+
+- пользователь нажал старую inline-кнопку после изменения callback payload type;
+- numeric, boolean или enum field содержит invalid value;
+- другой компонент бота сгенерировал callback data с тем же prefix, но другим
+  field format.
+
+TeleFlow считает такой typed route не сматченным, поэтому raw callback fallback
+может ответить пользователю. Проектируй callback payloads так, чтобы они
+переживали версии: используй короткие стабильные prefixes, передавай IDs вместо
+больших объектов и заводи новый prefix, когда deployed callback shape меняется
+несовместимо.
+
 ## Webhook возвращает unauthorized
 
 Проверь `SecretToken` configuration и Telegram webhook settings. Incoming request должен использовать expected secret token.

--- a/src/TeleFlow.Framework/Internal/CallbackDataCodec.cs
+++ b/src/TeleFlow.Framework/Internal/CallbackDataCodec.cs
@@ -103,4 +103,9 @@ internal static class CallbackDataCodec
                 $"{subject} must be at most {MaxTelegramCallbackDataBytes} UTF-8 bytes.");
         }
     }
+
+    public static bool IsPayloadDeserializationFailure(Exception exception)
+    {
+        return exception is JsonException or FormatException or OverflowException;
+    }
 }

--- a/src/TeleFlow.Framework/Internal/CallbackDataMetadata.cs
+++ b/src/TeleFlow.Framework/Internal/CallbackDataMetadata.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using TeleFlow.Annotations;
 
 namespace TeleFlow.Telegram.Internal;
@@ -158,6 +159,12 @@ internal sealed class CallbackDataMetadata
             throw new InvalidOperationException(
                 $"Callback data payload type '{payloadType.FullName}' prefix must not contain ':', '%', or whitespace.");
         }
+
+        if (Encoding.UTF8.GetByteCount(prefix) > CallbackDataCodec.MaxTelegramCallbackDataBytes)
+        {
+            throw new InvalidOperationException(
+                $"Callback data payload type '{payloadType.FullName}' prefix must be at most {CallbackDataCodec.MaxTelegramCallbackDataBytes} UTF-8 bytes.");
+        }
     }
 
     private static void ValidateFieldType(Type payloadType, Type fieldType, string fieldName)
@@ -253,7 +260,13 @@ internal sealed class CallbackDataMetadata
 
         if (type.IsEnum)
         {
-            return Enum.Parse(type, text, ignoreCase: false);
+            if (Enum.TryParse(type, text, ignoreCase: false, out var enumValue))
+            {
+                return enumValue;
+            }
+
+            throw new JsonException(
+                $"Telegram callback data field for payload type '{PayloadType.FullName}' is not a valid enum value for '{type.FullName}'.");
         }
 
         throw new InvalidOperationException(

--- a/src/TeleFlow.Framework/Internal/CallbackDataRouteDeserializationException.cs
+++ b/src/TeleFlow.Framework/Internal/CallbackDataRouteDeserializationException.cs
@@ -1,0 +1,36 @@
+using System.Text;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Represents a typed callback route payload that matched the expected callback data
+/// shape but could not be decoded before handler selection.
+/// </summary>
+internal sealed class CallbackDataRouteDeserializationException : Exception
+{
+    public CallbackDataRouteDeserializationException(
+        Type payloadType,
+        string serializedPayload,
+        Exception innerException)
+        : base(
+            CreateMessage(payloadType),
+            innerException ?? throw new ArgumentNullException(nameof(innerException)))
+    {
+        ArgumentNullException.ThrowIfNull(payloadType);
+        ArgumentNullException.ThrowIfNull(serializedPayload);
+
+        PayloadType = payloadType;
+        PayloadByteCount = Encoding.UTF8.GetByteCount(serializedPayload);
+    }
+
+    public Type PayloadType { get; }
+
+    public int PayloadByteCount { get; }
+
+    private static string CreateMessage(Type payloadType)
+    {
+        ArgumentNullException.ThrowIfNull(payloadType);
+
+        return $"Telegram callback data matched payload type '{payloadType.FullName}' but could not be deserialized.";
+    }
+}

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -35,7 +35,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
 
         var table = new TelegramHandlerTable(descriptors);
 
-        _selector = new TelegramHandlerSelector(table);
+        _selector = new TelegramHandlerSelector(table, loggerFactory);
         _errorHandlerIndex = new TelegramErrorHandlerIndex(errorHandlers);
         _timeProvider = timeProvider;
         _globalAutoAnswerCallback = CreateGlobalAutoAnswerDescriptor(autoAnswerCallbackOptions.LastOrDefault());

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.Logging.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.Logging.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+internal sealed partial class TelegramHandlerSelector
+{
+    /// <summary>
+    /// Stable event ids emitted by the Telegram handler selector.
+    /// </summary>
+    private static class LogEventIds
+    {
+        /// <summary>
+        /// A typed callback route matched callback data shape, but payload decoding failed.
+        /// </summary>
+        public const int CallbackDataDeserializationFailed = 1;
+    }
+
+    /// <summary>
+    /// Logs malformed or stale typed callback data without exposing the raw callback payload.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.CallbackDataDeserializationFailed,
+        Level = LogLevel.Warning,
+        Message = "Telegram callback data failed to deserialize. update_id={UpdateId}, payload_type={PayloadType}, handler={Handler}, route={Route}, callback_data_bytes={CallbackDataBytes}. Treating callback route as not matched.")]
+    private static partial void LogCallbackDataDeserializationFailed(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string payloadType,
+        string handler,
+        string route,
+        int callbackDataBytes);
+}

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -4,13 +4,18 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using TeleFlow.Framework.Callbacks;
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal.Handlers;
 
-internal sealed class TelegramHandlerSelector
+/// <summary>
+/// Matches incoming Telegram contexts to registered handler routes and binds route
+/// values or typed callback payloads before the dispatcher invokes a handler.
+/// </summary>
+internal sealed partial class TelegramHandlerSelector
 {
     private static readonly IReadOnlyDictionary<string, object?> EmptyRouteValues =
         new ReadOnlyDictionary<string, object?>(
@@ -18,11 +23,17 @@ internal sealed class TelegramHandlerSelector
     private static readonly ConcurrentDictionary<Type, CallbackPayloadDeserializer> CallbackPayloadDeserializers = new();
 
     private readonly TelegramHandlerTable _table;
+    private readonly ILogger<TelegramHandlerSelector> _logger;
 
-    public TelegramHandlerSelector(TelegramHandlerTable table)
+    public TelegramHandlerSelector(
+        TelegramHandlerTable table,
+        ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
         _table = table;
+        _logger = loggerFactory.CreateLogger<TelegramHandlerSelector>();
     }
 
     public bool HasStatefulHandlers => _table.HasStatefulHandlers;
@@ -178,7 +189,7 @@ internal sealed class TelegramHandlerSelector
         return null;
     }
 
-    private static async ValueTask<TelegramRouteSelection?> SelectCallbackHandlerPassAsync(
+    private async ValueTask<TelegramRouteSelection?> SelectCallbackHandlerPassAsync(
         CallbackQueryContext context,
         IReadOnlyList<TelegramHandlerCandidate> candidates,
         CancellationToken cancellationToken)
@@ -206,11 +217,32 @@ internal sealed class TelegramHandlerSelector
                 continue;
             }
 
-            if (!TryDeserializeCallbackPayload(
-                    context,
-                    route.CallbackPayloadType,
-                    out var callbackPayload))
+            object? callbackPayload;
+
+            try
             {
+                if (!TryDeserializeCallbackPayload(
+                        context,
+                        route.CallbackPayloadType,
+                        out callbackPayload))
+                {
+                    continue;
+                }
+            }
+            catch (CallbackDataRouteDeserializationException exception)
+            {
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    LogCallbackDataDeserializationFailed(
+                        _logger,
+                        exception,
+                        context.Update.UpdateId,
+                        exception.PayloadType.FullName ?? exception.PayloadType.Name,
+                        TelegramUpdateLogFormatter.FormatHandler(candidate.Handler),
+                        TelegramUpdateLogFormatter.FormatRoute(route),
+                        exception.PayloadByteCount);
+                }
+
                 continue;
             }
 

--- a/src/TeleFlow.Framework/JsonCallbackDataSerializer.cs
+++ b/src/TeleFlow.Framework/JsonCallbackDataSerializer.cs
@@ -67,7 +67,10 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
                 return false;
             }
 
-            payload = generatedCodec.Unpack(serializedPayload);
+            payload = UnpackForMatchedRoute(
+                payloadType,
+                serializedPayload,
+                generatedCodec.Unpack);
             return true;
         }
 
@@ -79,7 +82,10 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
                 return false;
             }
 
-            payload = CallbackDataCodec.Unpack(serializedPayload, metadata);
+            payload = UnpackForMatchedRoute(
+                payloadType,
+                serializedPayload,
+                value => CallbackDataCodec.Unpack(value, metadata));
             return true;
         }
 
@@ -91,5 +97,20 @@ public sealed class JsonCallbackDataSerializer : ICallbackDataRouteDeserializer
     {
         return JsonSerializer.Deserialize(serializedPayload, payloadType, _jsonSerializerOptions)
             ?? throw new JsonException("Telegram callback data deserialized to null.");
+    }
+
+    private static object UnpackForMatchedRoute(
+        Type payloadType,
+        string serializedPayload,
+        Func<string, object> unpack)
+    {
+        try
+        {
+            return unpack(serializedPayload);
+        }
+        catch (Exception exception) when (CallbackDataCodec.IsPayloadDeserializationFailure(exception))
+        {
+            throw new CallbackDataRouteDeserializationException(payloadType, serializedPayload, exception);
+        }
     }
 }

--- a/src/TeleFlow.Generators/TelegramHandlerAnalyzer.CallbackData.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerAnalyzer.CallbackData.cs
@@ -30,7 +30,7 @@ public sealed partial class TelegramHandlerAnalyzer
             context.ReportDiagnostic(Diagnostic.Create(
                 InvalidCallbackData,
                 location,
-                $"Callback data payload type '{type.Name}' must declare a non-empty prefix without ':', '%', or whitespace."));
+                $"Callback data payload type '{type.Name}' must declare a non-empty prefix without ':', '%', or whitespace and at most {TelegramCallbackDataFacts.MaxCallbackDataBytes} UTF-8 bytes."));
             return;
         }
 

--- a/src/TeleFlow.Generators/TelegramHandlerMetadataFacts.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerMetadataFacts.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace TeleFlow.Generators;
@@ -160,13 +161,16 @@ internal static class TelegramMemberStatusFacts
 
 internal static class TelegramCallbackDataFacts
 {
+    public const int MaxCallbackDataBytes = 64;
+
     public static bool IsValidPayloadPrefix(string? prefix)
     {
         return prefix is not null &&
                !string.IsNullOrWhiteSpace(prefix) &&
                prefix.IndexOf(':') < 0 &&
                prefix.IndexOf('%') < 0 &&
-               !prefix.Any(char.IsWhiteSpace);
+               !prefix.Any(char.IsWhiteSpace) &&
+               Encoding.UTF8.GetByteCount(prefix) <= MaxCallbackDataBytes;
     }
 
     public static bool IsSupportedFieldType(ITypeSymbol type)

--- a/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Emission.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Emission.cs
@@ -420,7 +420,7 @@ public sealed partial class TelegramHandlerSourceGenerator
                     builder.Append(", ");
                 }
 
-                builder.Append(GetCallbackDataUnpackExpression(payload.Fields[fieldIndex], fieldIndex + 1));
+                builder.Append(GetCallbackDataUnpackExpression(payload, payload.Fields[fieldIndex], fieldIndex + 1));
             }
 
             builder.AppendLine(");");
@@ -433,7 +433,7 @@ public sealed partial class TelegramHandlerSourceGenerator
             for (int fieldIndex = 0; fieldIndex < payload.Fields.Length; fieldIndex++)
             {
                 GeneratedCallbackDataField field = payload.Fields[fieldIndex];
-                builder.AppendLine($"            {field.PropertyName} = {GetCallbackDataUnpackExpression(field, fieldIndex + 1)},");
+                builder.AppendLine($"            {field.PropertyName} = {GetCallbackDataUnpackExpression(payload, field, fieldIndex + 1)},");
             }
 
             builder.AppendLine("        };");
@@ -459,6 +459,7 @@ public sealed partial class TelegramHandlerSourceGenerator
     }
 
     private static string GetCallbackDataUnpackExpression(
+        GeneratedCallbackDataPayload payload,
         GeneratedCallbackDataField field,
         int partIndex)
     {
@@ -470,7 +471,7 @@ public sealed partial class TelegramHandlerSourceGenerator
             GeneratedCallbackDataFieldKind.Int32 => $"global::System.Int32.Parse({value}, global::System.Globalization.CultureInfo.InvariantCulture)",
             GeneratedCallbackDataFieldKind.Int64 => $"global::System.Int64.Parse({value}, global::System.Globalization.CultureInfo.InvariantCulture)",
             GeneratedCallbackDataFieldKind.Boolean => $"global::System.Boolean.Parse({value})",
-            GeneratedCallbackDataFieldKind.Enum => $"global::System.Enum.Parse<{field.TypeName}>({value}, ignoreCase: false)",
+            GeneratedCallbackDataFieldKind.Enum => $"ParseCallbackDataEnum<{field.TypeName}>({value}, {ToLiteral(field.PropertyName)}, {ToLiteral(payload.TypeMetadataName)})",
             _ => throw new InvalidOperationException($"Unsupported generated callback data field kind '{field.Kind}'.")
         };
     }
@@ -537,6 +538,18 @@ public sealed partial class TelegramHandlerSourceGenerator
         builder.AppendLine("        return value");
         builder.AppendLine("            .Replace(\"%3A\", \":\", global::System.StringComparison.Ordinal)");
         builder.AppendLine("            .Replace(\"%25\", \"%\", global::System.StringComparison.Ordinal);");
+        builder.AppendLine("    }");
+        builder.AppendLine();
+
+        builder.AppendLine("    private static TEnum ParseCallbackDataEnum<TEnum>(string value, string fieldName, string payloadTypeName)");
+        builder.AppendLine("        where TEnum : struct, global::System.Enum");
+        builder.AppendLine("    {");
+        builder.AppendLine("        if (global::System.Enum.TryParse<TEnum>(value, ignoreCase: false, out var result))");
+        builder.AppendLine("        {");
+        builder.AppendLine("            return result;");
+        builder.AppendLine("        }");
+        builder.AppendLine();
+        builder.AppendLine("        throw new global::System.Text.Json.JsonException($\"Telegram callback data field '{fieldName}' on payload type '{payloadTypeName}' is not a valid {typeof(TEnum).FullName} value.\");");
         builder.AppendLine("    }");
         builder.AppendLine();
     }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -2226,6 +2226,33 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task MalformedCompactCallbackData_LogsDiagnosticAndFallsBackToRawCallback()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<CompactCallbackHandler>();
+                services.AddTelegramHandler<RawCallbackHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateCallbackUpdate("del:item:not-int"));
+
+        Assert.Equal(["callback:del:item:not-int"], probe.Events);
+        var warning = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.Category == "TeleFlow.Telegram.Internal.Handlers.TelegramHandlerSelector");
+        Assert.Contains("Telegram callback data failed to deserialize", warning.Message);
+        Assert.Contains(nameof(CompactDeleteCallback), warning.Message);
+        Assert.NotNull(warning.Exception);
+    }
+
+    [Fact]
     public async Task BrokenCustomCallbackSerializer_ExceptionBubbles()
     {
         using var serviceProvider = CreateServiceProvider(

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using TeleFlow.Annotations;
 using TeleFlow.Framework.Callbacks;
 using TeleFlow.Framework.Dispatching;
@@ -167,6 +168,15 @@ public sealed class TelegramHandlerGeneratorTests
                         $"callback:{payload.Id}:{payload.Action}:{payload.Confirmed}:{payload.Kind}");
                     return Task.CompletedTask;
                 }
+
+                [Callback]
+                public Task Raw(CallbackQueryContext context)
+                {
+                    GeneratedErrorRuntimeProbe.Record(
+                        "{{runId}}",
+                        $"raw:{context.TelegramCallbackQuery.Data}");
+                    return Task.CompletedTask;
+                }
             }
             """);
         var generatedCompilation = RunGenerator(compilation, out var diagnostics);
@@ -183,7 +193,9 @@ public sealed class TelegramHandlerGeneratorTests
         var takeKind = Enum.Parse(payloadKindType, "Take");
         var payload = Activator.CreateInstance(payloadType, 42L, "a:b%z", true, takeKind)!;
         var services = new ServiceCollection();
+        var loggerFactory = new RecordingLoggerFactory();
         services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddSingleton<ILoggerFactory>(loggerFactory);
         services.AddTelegramHandlersFromAssembly(assembly);
         using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
         {
@@ -209,6 +221,21 @@ public sealed class TelegramHandlerGeneratorTests
         Assert.Equal(
             ["callback:42:a:b%z:True:Take"],
             GeneratedErrorRuntimeProbe.GetEvents(runId));
+
+        await DispatchAsync(
+            serviceProvider,
+            CreateCallbackUpdate("ticket:not-long:stale:true:Take"),
+            cancellation.Token);
+
+        Assert.Equal(
+            ["callback:42:a:b%z:True:Take", "raw:ticket:not-long:stale:true:Take"],
+            GeneratedErrorRuntimeProbe.GetEvents(runId));
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.Category == "TeleFlow.Telegram.Internal.Handlers.TelegramHandlerSelector" &&
+                     entry.Message.Contains("Telegram callback data failed to deserialize", StringComparison.Ordinal) &&
+                     entry.Message.Contains("TicketAction", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -2045,9 +2072,14 @@ public sealed class TelegramHandlerGeneratorTests
 
             [CallbackData("dup")]
             public sealed record SecondPayload(int Id);
+
+            [CallbackData("this_prefix_is_definitely_too_long_for_telegram_callback_data_limit")]
+            public sealed record LongPrefixPayload(int Id);
             """);
 
-        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.InvalidCallbackDataId);
+        Assert.True(
+            diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.InvalidCallbackDataId) >= 2,
+            "Expected callback data diagnostics for unsupported field type and oversized prefix.");
         Assert.Equal(2, diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.DuplicateCallbackDataPrefixId));
     }
 


### PR DESCRIPTION
## Summary
- add warning diagnostics for compact typed callback data that matches a typed route shape but cannot be decoded
- preserve raw callback fallback behavior for stale or malformed typed callback buttons
- validate oversized callback data prefixes in analyzer/runtime paths and harden generated enum decoding
- document stale callback payload handling and callback versioning guidance in EN/RU docs

## Validation
- `dotnet build TeleFlow.sln --no-restore`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-build`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-build --filter "FullyQualifiedName~MalformedCompactCallbackData_LogsDiagnosticAndFallsBackToRawCallback|FullyQualifiedName~Generator_CallbackDataCodecsRunThroughKeyboardSerializerAndDispatcher|FullyQualifiedName~Analyzer_ReportsInvalidCallbackDataAndDuplicatePrefixes"`
- `git diff --check`

Closes #32