### PR TITLE
feat(client): add bounded retry-after policy

### DIFF
--- a/docs/en/features/telegram-client.md
+++ b/docs/en/features/telegram-client.md
@@ -70,6 +70,46 @@ builder.Services.AddTelegramBot(options =>
 
 Defaults are useful for cross-cutting Telegram request settings. Keep handler-specific values in the handler.
 
+## Retry-After Policy
+
+Telegram may return `429 Too Many Requests` with `response_parameters.retry_after` or an HTTP `Retry-After` header. TeleFlow handles this through an explicit bounded policy:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
+});
+```
+
+`TelegramRetryAfterPolicy.Default` retries one short throttled request and waits only when Telegram asks for a delay up to five seconds. If Telegram asks for a longer delay, returns `429` without retry metadata, or the retry count is exhausted, the client throws `TelegramRetryAfterException`.
+
+Disable automatic waiting when the application wants to own all throttling decisions:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Disabled;
+});
+```
+
+Or configure a custom bounded policy:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default with
+    {
+        MaxRetries = 2,
+        MaxDelay = TimeSpan.FromSeconds(3)
+    };
+});
+```
+
+TeleFlow does not automatically retry ordinary Bot API failures or network failures for normal client calls. This avoids hidden duplicate sends for non-idempotent methods. If you need broader retry or outgoing rate limiting, put that policy in application code or replace the request executor intentionally.
+
 ## Custom Transport
 
 Applications can replace the transport:

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -11,6 +11,7 @@ builder.Services.AddTelegramBot(options =>
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
     options.Defaults.ParseMode = TelegramParseMode.Html;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
     options.RoleFilter.CacheEnabled = true;
     options.RoleFilter.CacheTtl = TimeSpan.FromSeconds(30);
 });
@@ -26,10 +27,13 @@ services.AddTelegramClient(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
 });
 ```
 
 Use this for client-only applications.
+
+`RetryAfter` controls bounded automatic handling of Telegram `429` responses. The default policy retries one short retry-after response and throws `TelegramRetryAfterException` when the configured bounds are exceeded.
 
 ## Long Polling Options
 

--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -94,6 +94,7 @@ Status: planned after handler-level rate limiting.
 Current state:
 
 - Telegram `429` responses with `response_parameters.retry_after` or HTTP `Retry-After` are respected by the Telegram request executor.
+- Automatic retry-after waiting is bounded by `TelegramRetryAfterPolicy` and documented in the Telegram client feature page.
 - Ordinary non-429 Telegram API failures are not retried automatically.
 
 Target state:

--- a/docs/en/transports/long-polling.md
+++ b/docs/en/transports/long-polling.md
@@ -43,7 +43,7 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
     TelegramUpdateType.CallbackQuery);
 ```
 
-Long polling retries transient `getUpdates` failures with configurable backoff. Handler failures are not swallowed. The offset advances only after successful update processing.
+Long polling retries transient `getUpdates` failures with configurable backoff. If the Telegram client surfaces `TelegramRetryAfterException`, polling waits for the Telegram-provided retry delay instead of using the generic backoff delay. Handler failures are not swallowed. The offset advances only after successful update processing.
 
 ## When To Use Long Polling
 

--- a/docs/ru/features/telegram-client.md
+++ b/docs/ru/features/telegram-client.md
@@ -70,6 +70,46 @@ builder.Services.AddTelegramBot(options =>
 
 Defaults удобны для cross-cutting Telegram request settings. Handler-specific values держи в handler.
 
+## Retry-After policy
+
+Telegram может вернуть `429 Too Many Requests` с `response_parameters.retry_after` или HTTP header `Retry-After`. TeleFlow обрабатывает это через явную bounded policy:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
+});
+```
+
+`TelegramRetryAfterPolicy.Default` делает один retry короткого throttled request и ждёт только если Telegram попросил задержку до пяти секунд. Если Telegram попросил ждать дольше, вернул `429` без retry metadata или retry count исчерпан, client бросает `TelegramRetryAfterException`.
+
+Отключи automatic waiting, если приложение должно само владеть всеми throttling decisions:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Disabled;
+});
+```
+
+Или задай custom bounded policy:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default with
+    {
+        MaxRetries = 2,
+        MaxDelay = TimeSpan.FromSeconds(3)
+    };
+});
+```
+
+TeleFlow не делает automatic retry обычных Bot API failures или network failures для нормальных client calls. Так мы не создаём hidden duplicate sends для non-idempotent methods. Если нужен более широкий retry или outgoing rate limiting, добавляй эту policy в application code или осознанно заменяй request executor.
+
 ## Собственный transport
 
 Transport можно заменить:

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -11,6 +11,7 @@ builder.Services.AddTelegramBot(options =>
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
     options.Defaults.ParseMode = TelegramParseMode.Html;
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
     options.RoleFilter.CacheEnabled = true;
     options.RoleFilter.CacheTtl = TimeSpan.FromSeconds(30);
 });
@@ -26,10 +27,13 @@ services.AddTelegramClient(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.RetryAfter = TelegramRetryAfterPolicy.Default;
 });
 ```
 
 Используй это для client-only applications.
+
+`RetryAfter` управляет bounded automatic handling для Telegram `429` responses. Default policy retry-ит один короткий retry-after response и бросает `TelegramRetryAfterException`, когда настроенные границы превышены.
 
 ## Long polling options
 

--- a/docs/ru/roadmap.md
+++ b/docs/ru/roadmap.md
@@ -94,6 +94,7 @@ Non-goals для первой реализации:
 Текущее состояние:
 
 - Telegram `429` responses с `response_parameters.retry_after` или HTTP `Retry-After` уважаются Telegram request executor.
+- Automatic retry-after waiting ограничен `TelegramRetryAfterPolicy` и описан на странице Telegram client feature.
 - Обычные non-429 Telegram API failures не ретраятся автоматически.
 
 Целевое состояние:

--- a/docs/ru/transports/long-polling.md
+++ b/docs/ru/transports/long-polling.md
@@ -43,7 +43,7 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
     TelegramUpdateType.CallbackQuery);
 ```
 
-Long polling retry-ит transient `getUpdates` failures с настраиваемым backoff. Handler failures не swallowing. Offset продвигается только после успешной обработки update.
+Long polling retry-ит transient `getUpdates` failures с настраиваемым backoff. Если Telegram client отдаёт `TelegramRetryAfterException`, polling ждёт Telegram-provided retry delay вместо обычной backoff delay. Handler failures не swallowing. Offset продвигается только после успешной обработки update.
 
 ## Когда использовать long polling
 

--- a/src/TeleFlow.Framework/TelegramBotOptions.cs
+++ b/src/TeleFlow.Framework/TelegramBotOptions.cs
@@ -15,4 +15,9 @@ public sealed class TelegramBotOptions
     public TelegramBotDefaults Defaults { get; set; } = new();
 
     public TelegramRoleFilterOptions RoleFilter { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the bounded retry policy forwarded to the low-level Telegram client.
+    /// </summary>
+    public TelegramRetryAfterPolicy RetryAfter { get; set; } = TelegramRetryAfterPolicy.Default;
 }

--- a/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class TelegramServiceCollectionExtensions
             clientOptions.BotUsername = options.BotUsername;
             clientOptions.BaseUrl = options.BaseUrl;
             clientOptions.Defaults = options.Defaults;
+            clientOptions.RetryAfter = options.RetryAfter;
         });
 
         services.AddSingleton(options);

--- a/src/TeleFlow.Telegram.Client/Internal/Options/TelegramClientOptionsValidator.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/Options/TelegramClientOptionsValidator.cs
@@ -30,5 +30,25 @@ internal static class TelegramClientOptionsValidator
         {
             throw new InvalidOperationException("Telegram bot defaults must be configured.");
         }
+
+        ValidateRetryAfter(options.RetryAfter);
+    }
+
+    private static void ValidateRetryAfter(TelegramRetryAfterPolicy? policy)
+    {
+        if (policy is null)
+        {
+            throw new InvalidOperationException("Telegram retry-after policy must be configured.");
+        }
+
+        if (policy.MaxRetries < 0)
+        {
+            throw new InvalidOperationException("Telegram retry-after maximum retry count must not be negative.");
+        }
+
+        if (policy.MaxDelay <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException("Telegram retry-after maximum retry delay must be greater than zero.");
+        }
     }
 }

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramApiExceptionFactory.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramApiExceptionFactory.cs
@@ -84,24 +84,4 @@ internal static class TelegramApiExceptionFactory
         };
     }
 
-    public static TelegramRetryAfterException CreateRetryAfterException(
-        string methodName,
-        int statusCode,
-        TelegramTransportEnvelope envelope,
-        string fallbackDescription)
-    {
-        var description = envelope.Description ?? fallbackDescription;
-        var message = $"Telegram request '{methodName}' failed: {description}";
-        int? retryAfterSeconds = envelope.ResponseParameters?.RetryAfter is long retryAfter
-            ? checked((int)retryAfter)
-            : null;
-
-        return new TelegramRetryAfterException(
-            message,
-            methodName,
-            httpStatusCode: statusCode,
-            telegramErrorCode: envelope.ErrorCode,
-            description: description,
-            retryAfterSeconds: retryAfterSeconds);
-    }
 }

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
@@ -8,6 +8,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
     private readonly JsonSerializerOptions _serializerOptions;
     private readonly TelegramRequestSender _sender;
     private readonly TelegramTransportEnvelopeParser _envelopeParser;
+    private readonly TelegramRetryAfterPolicy _retryAfterPolicy;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<TelegramRequestExecutor> _logger;
 
@@ -30,6 +31,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
             options,
             new TelegramRequestContentBuilder(_serializerOptions));
         _envelopeParser = new TelegramTransportEnvelopeParser(_serializerOptions);
+        _retryAfterPolicy = options.RetryAfter;
         _timeProvider = timeProvider;
         _logger = loggerFactory.CreateLogger<TelegramRequestExecutor>();
     }
@@ -132,28 +134,30 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
 
             if (envelope is null)
             {
-                var retryAfterHeaderDelay = TelegramRetryAfterPolicy.ResolveDelay(response, envelope, _timeProvider);
+                var retryAfterHeaderDelay = TelegramRetryAfterDelayResolver.ResolveDelay(response, envelope, _timeProvider);
                 if (response.StatusCode == 429)
                 {
-                    if (retryAfterHeaderDelay is not null)
+                    if (retryAfterHeaderDelay is not null &&
+                        CanRetryAfter(attempt, retryAfterHeaderDelay.Value))
                     {
                         if (!isPollingRequest && _logger.IsEnabled(LogLevel.Warning))
                         {
                             LogRequestThrottled(executableRequest.MethodName, attempt, retryAfterHeaderDelay.Value);
                         }
 
-                        await TelegramRetryAfterPolicy.DelayAsync(
+                        await TelegramRetryAfterDelayResolver.DelayAsync(
                             retryAfterHeaderDelay.Value,
                             _timeProvider,
                             cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
-                    var exception = new TelegramRetryAfterException(
-                        $"Telegram request '{executableRequest.MethodName}' was throttled, but the response did not provide retry timing metadata.",
+                    var exception = CreateRetryAfterException(
                         executableRequest.MethodName,
-                        httpStatusCode: response.StatusCode,
-                        description: "Telegram throttling response did not provide retry timing metadata.");
+                        response.StatusCode,
+                        envelope: null,
+                        retryAfterHeaderDelay,
+                        GetRetryAfterFailureDescription(retryAfterHeaderDelay));
                     if (requestErrorEnabled)
                     {
                         LogRequestFailure(
@@ -240,28 +244,31 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                 }
             }
 
-            var retryAfterDelay = TelegramRetryAfterPolicy.ResolveDelay(response, envelope, _timeProvider);
-            if (TelegramApiExceptionFactory.IsThrottling(response.StatusCode, envelope) && retryAfterDelay is not null)
+            var retryAfterDelay = TelegramRetryAfterDelayResolver.ResolveDelay(response, envelope, _timeProvider);
+            if (TelegramApiExceptionFactory.IsThrottling(response.StatusCode, envelope) &&
+                retryAfterDelay is not null &&
+                CanRetryAfter(attempt, retryAfterDelay.Value))
             {
                 if (!isPollingRequest && _logger.IsEnabled(LogLevel.Warning))
                 {
                     LogRequestThrottled(executableRequest.MethodName, attempt, retryAfterDelay.Value);
                 }
 
-                await TelegramRetryAfterPolicy.DelayAsync(
+                await TelegramRetryAfterDelayResolver.DelayAsync(
                     retryAfterDelay.Value,
                     _timeProvider,
                     cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
-            if (TelegramApiExceptionFactory.IsThrottling(response.StatusCode, envelope) && retryAfterDelay is null)
+            if (TelegramApiExceptionFactory.IsThrottling(response.StatusCode, envelope))
             {
-                var retryAfterException = TelegramApiExceptionFactory.CreateRetryAfterException(
+                var retryAfterException = CreateRetryAfterException(
                     executableRequest.MethodName,
                     response.StatusCode,
                     envelope,
-                    "Telegram throttling response did not provide retry timing metadata.");
+                    retryAfterDelay,
+                    GetRetryAfterFailureDescription(retryAfterDelay));
                 if (requestErrorEnabled)
                 {
                     LogRequestFailure(
@@ -298,6 +305,39 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
     private static bool IsPollingRequest(string methodName)
     {
         return string.Equals(methodName, "getUpdates", StringComparison.Ordinal);
+    }
+
+    private bool CanRetryAfter(int attempt, TelegramRetryAfterDelay retryAfter)
+    {
+        return _retryAfterPolicy.Enabled &&
+            attempt <= _retryAfterPolicy.MaxRetries &&
+            retryAfter.Value <= _retryAfterPolicy.MaxDelay;
+    }
+
+    private static TelegramRetryAfterException CreateRetryAfterException(
+        string methodName,
+        int httpStatusCode,
+        TelegramTransportEnvelope? envelope,
+        TelegramRetryAfterDelay? retryAfter,
+        string fallbackDescription)
+    {
+        var description = envelope?.Description ?? fallbackDescription;
+        var message = $"Telegram request '{methodName}' failed: {description}";
+
+        return new TelegramRetryAfterException(
+            message,
+            methodName,
+            httpStatusCode: httpStatusCode,
+            telegramErrorCode: envelope?.ErrorCode,
+            description: description,
+            retryAfterSeconds: retryAfter?.Seconds);
+    }
+
+    private static string GetRetryAfterFailureDescription(TelegramRetryAfterDelay? retryAfter)
+    {
+        return retryAfter is null
+            ? "Telegram throttling response did not provide retry timing metadata."
+            : "Telegram request was throttled and automatic retry-after handling was not applied by the configured policy.";
     }
 
     private static string GetContentKind(TelegramTransportContent content)

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRetryAfterDelayResolver.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRetryAfterDelayResolver.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 
 namespace TeleFlow.Telegram.Internal;
 
-internal static class TelegramRetryAfterPolicy
+internal static class TelegramRetryAfterDelayResolver
 {
     public static TelegramRetryAfterDelay? ResolveDelay(
         TelegramTransportResponse response,

--- a/src/TeleFlow.Telegram.Client/TelegramClientOptions.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramClientOptions.cs
@@ -15,4 +15,9 @@ public sealed class TelegramClientOptions
     public string BaseUrl { get; set; } = "https://api.telegram.org";
 
     public TelegramBotDefaults Defaults { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the bounded retry policy used when Telegram returns Bot API throttling metadata.
+    /// </summary>
+    public TelegramRetryAfterPolicy RetryAfter { get; set; } = TelegramRetryAfterPolicy.Default;
 }

--- a/src/TeleFlow.Telegram.Client/TelegramRetryAfterPolicy.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramRetryAfterPolicy.cs
@@ -1,0 +1,43 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Controls how the Telegram client reacts to Bot API throttling responses that include retry timing metadata.
+/// This policy is used by the request executor for outgoing Bot API calls such as generated ctx.Bot.*Async methods.
+/// </summary>
+public sealed record class TelegramRetryAfterPolicy
+{
+    /// <summary>
+    /// Production-safe default that retries one short Telegram throttling response before surfacing the error.
+    /// </summary>
+    public static TelegramRetryAfterPolicy Default { get; } = new()
+    {
+        Enabled = true,
+        MaxRetries = 1,
+        MaxDelay = TimeSpan.FromSeconds(5)
+    };
+
+    /// <summary>
+    /// Disables automatic retry-after waiting and surfaces Telegram throttling responses immediately.
+    /// </summary>
+    public static TelegramRetryAfterPolicy Disabled { get; } = new()
+    {
+        Enabled = false,
+        MaxRetries = 0,
+        MaxDelay = TimeSpan.FromSeconds(5)
+    };
+
+    /// <summary>
+    /// Gets whether automatic retry-after waiting is enabled.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the maximum number of automatic retry attempts after the first throttled response.
+    /// </summary>
+    public int MaxRetries { get; init; } = 1;
+
+    /// <summary>
+    /// Gets the maximum Telegram-requested delay that the executor may wait automatically.
+    /// </summary>
+    public TimeSpan MaxDelay { get; init; } = TimeSpan.FromSeconds(5);
+}

--- a/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
+++ b/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
@@ -208,7 +208,7 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
             }
             catch (Exception exception) when (IsPollingTransient(exception) && !cancellationToken.IsCancellationRequested)
             {
-                var delay = backoff.NextDelay();
+                var delay = GetPollingRetryDelay(exception, backoff);
                 onTransientFailure();
 
                 LogGetUpdatesFailed(
@@ -260,6 +260,13 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
             TelegramServerException or
             TelegramDecodeException or
             TelegramRetryAfterException;
+    }
+
+    private static TimeSpan GetPollingRetryDelay(Exception exception, TelegramRawLongPollingBackoff backoff)
+    {
+        return exception is TelegramRetryAfterException { RetryAfter: { } retryAfter }
+            ? retryAfter
+            : backoff.NextDelay();
     }
 
     [LoggerMessage(

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -31,6 +31,7 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.TelegramNotFoundException",
         "TeleFlow.Telegram.TelegramConflictException",
         "TeleFlow.Telegram.TelegramEntityTooLargeException",
+        "TeleFlow.Telegram.TelegramRetryAfterPolicy",
         "TeleFlow.Telegram.TelegramRetryAfterException",
         "TeleFlow.Telegram.TelegramMigrateToChatException",
         "TeleFlow.Telegram.TelegramServerException",

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -82,6 +82,33 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Equal(TelegramParseMode.Html, client.Defaults.ParseMode);
         Assert.True(client.Defaults.DisableNotification);
         Assert.True(client.Defaults.ProtectContent);
+        Assert.Same(TelegramRetryAfterPolicy.Default, serviceProvider.GetRequiredService<TelegramClientOptions>().RetryAfter);
+    }
+
+    [Fact]
+    public void AddTelegramBot_ValidatesRetryAfterPolicy()
+    {
+        var invalidCases = new (Action<TelegramBotOptions> Configure, string ExpectedMessage)[]
+        {
+            (options => options.RetryAfter = null!, "retry-after policy must be configured"),
+            (options => options.RetryAfter = TelegramRetryAfterPolicy.Default with { MaxRetries = -1 }, "maximum retry count must not be negative"),
+            (options => options.RetryAfter = TelegramRetryAfterPolicy.Default with { MaxDelay = TimeSpan.Zero }, "maximum retry delay must be greater than zero"),
+            (options => options.RetryAfter = TelegramRetryAfterPolicy.Default with { MaxDelay = TimeSpan.FromSeconds(-1) }, "maximum retry delay must be greater than zero")
+        };
+
+        foreach (var (configure, expectedMessage) in invalidCases)
+        {
+            var services = new ServiceCollection();
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                services.AddTelegramBot(options =>
+                {
+                    options.Token = "test-token";
+                    configure(options);
+                }));
+
+            Assert.Contains(expectedMessage, exception.Message, StringComparison.Ordinal);
+        }
     }
 
     [Fact]
@@ -1217,6 +1244,76 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task Executor_StopsRetrying429AfterConfiguredMaximum()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":false,"error_code":429,"description":"Too Many Requests","response_parameters":{"retry_after":0}}""",
+                HttpStatusCode.TooManyRequests),
+            CreateJsonResponse(
+                """{"ok":false,"error_code":429,"description":"Too Many Requests","response_parameters":{"retry_after":0}}""",
+                HttpStatusCode.TooManyRequests));
+
+        using var serviceProvider = CreateTelegramServiceProvider(handler);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var exception = await Assert.ThrowsAsync<TelegramRetryAfterException>(() => client.SendAsync(new GetMe()));
+
+        Assert.Equal(429, exception.HttpStatusCode);
+        Assert.Equal(0, exception.RetryAfterSeconds);
+        Assert.Equal("getMe", exception.MethodName);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task Executor_DoesNotRetry429_WhenRetryAfterPolicyIsDisabled()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":false,"error_code":429,"description":"Too Many Requests","response_parameters":{"retry_after":0}}""",
+                HttpStatusCode.TooManyRequests));
+
+        using var serviceProvider = CreateTelegramServiceProvider(
+            handler,
+            configureBot: options => options.RetryAfter = TelegramRetryAfterPolicy.Disabled);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var exception = await Assert.ThrowsAsync<TelegramRetryAfterException>(() => client.SendAsync(new GetMe()));
+
+        Assert.Equal(429, exception.HttpStatusCode);
+        Assert.Equal(0, exception.RetryAfterSeconds);
+        Assert.Equal("getMe", exception.MethodName);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task Executor_DoesNotRetry429_WhenRetryAfterExceedsConfiguredMaximumDelay()
+    {
+        var timeProvider = new RecordingTimeProvider();
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":false,"error_code":429,"description":"Too Many Requests","response_parameters":{"retry_after":6}}""",
+                HttpStatusCode.TooManyRequests));
+
+        using var serviceProvider = CreateTelegramServiceProvider(
+            handler,
+            configureBot: options => options.RetryAfter = TelegramRetryAfterPolicy.Default with
+            {
+                MaxDelay = TimeSpan.FromSeconds(5)
+            },
+            timeProvider: timeProvider);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var exception = await Assert.ThrowsAsync<TelegramRetryAfterException>(() => client.SendAsync(new GetMe()));
+
+        Assert.Equal(429, exception.HttpStatusCode);
+        Assert.Equal(6, exception.RetryAfterSeconds);
+        Assert.Equal("getMe", exception.MethodName);
+        Assert.Empty(timeProvider.Delays);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
     public async Task Executor_UsesRetryAfterHeaderFallback()
     {
         var throttledResponse = CreateJsonResponse(
@@ -1592,6 +1689,42 @@ public sealed class TelegramRuntimeIntegrationTests
             timeProvider.Delays);
         Assert.Equal([1L], dispatcher.UpdateIds);
         Assert.Equal(5, telegramClient.GetUpdatesRequests.Count);
+    }
+
+    [Fact]
+    public async Task LongPolling_UsesRetryAfterDelayForThrottledGetUpdates()
+    {
+        var timeProvider = new RecordingTimeProvider();
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":false,"error_code":429,"description":"Too Many Requests","response_parameters":{"retry_after":3}}""",
+                HttpStatusCode.TooManyRequests),
+            CreateJsonResponse(
+                """{"ok":true,"result":[{"update_id":1,"message":{"message_id":10,"date":0,"chat":{"id":100,"type":"private"},"text":"first"}}]}"""));
+        var dispatcher = new RecordingDispatcher(cancelAfter: 1);
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateTelegramApplication(
+            services =>
+            {
+                services.AddSingleton<TimeProvider>(timeProvider);
+                services.AddTelegramHttpTransport(_ => new HttpClient(handler));
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+            },
+            services => services.AddLongPolling(options =>
+            {
+                options.Backoff.MinDelay = TimeSpan.FromSeconds(1);
+                options.Backoff.MaxDelay = TimeSpan.FromSeconds(1);
+                options.Backoff.Jitter = 0;
+            }),
+            cancellation,
+            configureBot: options => options.RetryAfter = TelegramRetryAfterPolicy.Disabled);
+
+        await application.RunAsync(cancellation.Token);
+
+        Assert.Equal([TimeSpan.FromSeconds(3)], timeProvider.Delays);
+        Assert.Equal([1L], dispatcher.UpdateIds);
+        Assert.Equal(2, handler.Requests.Count);
     }
 
     [Fact]
@@ -3049,10 +3182,15 @@ public sealed class TelegramRuntimeIntegrationTests
     private static ITeleFlowApplication CreateTelegramApplication(
         Action<IServiceCollection> configureServices,
         Action<IServiceCollection> configureTelegram,
-        CancellationTokenSource? cancellation = null)
+        CancellationTokenSource? cancellation = null,
+        Action<TelegramBotOptions>? configureBot = null)
     {
         var builder = TeleFlowApplication.CreateBuilder();
-        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            configureBot?.Invoke(options);
+        });
         configureTelegram(builder.Services);
         configureServices(builder.Services);
 


### PR DESCRIPTION
## Summary
- add an explicit bounded `TelegramRetryAfterPolicy` for Telegram `429` / `Retry-After` handling
- wire the policy through low-level client options and framework bot options
- preserve retry metadata in `TelegramRetryAfterException` when automatic waiting is disabled or policy bounds are exceeded
- make long polling use Telegram-provided retry-after delays for throttled `getUpdates`
- document the behavior in English and Russian docs

## Touched hot paths
- `TelegramRequestExecutor` now checks the configured retry-after policy only in throttling branches; the successful response path remains unchanged apart from storing the policy reference.
- `TelegramLongPollingClient` changes only the transient `getUpdates` failure delay selection, preferring `TelegramRetryAfterException.RetryAfter` over generic backoff.

## Validation
- `dotnet build TeleFlow.sln -c Debug --no-restore`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj -c Debug --filter "FullyQualifiedName~TelegramRuntimeIntegrationTests"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj -c Debug --filter "FullyQualifiedName~PublicSurfaceTests"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj -c Debug`
- `git diff --check`

Closes #25