### PR TITLE
feat(framework): harden DI and current update access

### DIFF
--- a/docs/en/advanced/middleware-and-rate-limiting.md
+++ b/docs/en/advanced/middleware-and-rate-limiting.md
@@ -113,6 +113,8 @@ builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 
 `AddUpdateMiddleware<T>()` registers middleware in the update pipeline and creates the middleware from the current update scope. This means middleware can use scoped constructor dependencies such as repositories, unit-of-work services, database contexts, and request/update-scoped application services.
 
+Middleware receives `UpdateContext` directly because middleware is part of the framework pipeline. Normal application services usually should not accept `UpdateContext` or `MessageContext`. If a scoped service needs the current Telegram user or chat, inject `ITelegramCurrentUpdateAccessor` into that service instead.
+
 Use the normal .NET options pattern when middleware needs application configuration. In a minimal console project, add the options package explicitly:
 
 ```bash
@@ -166,6 +168,8 @@ builder.Services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 ```
 
 Singleton middleware must not depend on scoped services in its constructor.
+
+Singleton middleware also must not depend on `ITelegramCurrentUpdateAccessor` or `IUpdateContextAccessor`. Current-update accessors are scoped to one update.
 
 Do not register middleware directly as `IUpdateMiddleware` in `IServiceCollection`. TeleFlow builds the middleware pipeline from middleware registrations, not from arbitrary `IUpdateMiddleware` services, and application startup fails clearly when direct registrations are found.
 

--- a/docs/en/fundamentals/dependency-injection.md
+++ b/docs/en/fundamentals/dependency-injection.md
@@ -41,15 +41,55 @@ public async Task Stats(
 
 Both styles are useful. Constructor injection is better for stable dependencies. Parameter injection is convenient for narrow handler methods.
 
+## Current Update In Application Services
+
+Handlers should stay close to Telegram: they receive `MessageContext`, `CallbackQueryContext`, route values, callback payloads, and cancellation tokens. Application services should not need to accept handler contexts just to know who is calling the bot.
+
+Use `ITelegramCurrentUpdateAccessor` when a scoped application service needs the current Telegram identity:
+
+```csharp
+public sealed class UserActivityService(
+    ITelegramCurrentUpdateAccessor current,
+    IUserRepository users)
+{
+    public async Task TouchAsync(CancellationToken ct)
+    {
+        var user = current.User
+            ?? throw new InvalidOperationException("This operation requires a Telegram user.");
+
+        await users.TouchAsync(user.Id, ct);
+    }
+}
+```
+
+Then keep the handler small:
+
+```csharp
+public sealed class StartHandler(UserActivityService activity)
+{
+    [Command("start")]
+    public async Task Start(MessageContext ctx, CancellationToken ct)
+    {
+        await activity.TouchAsync(ct);
+        await ctx.Message.AnswerAsync("Ready.", ct);
+    }
+}
+```
+
+The accessor is scoped to one update. It is available while TeleFlow processes an update and fails clearly outside update processing. Do not inject it into singleton services.
+
 ## Register Application Services
 
 ```csharp
-builder.Services.AddSingleton<ITicketRepository, InMemoryTicketRepository>();
-builder.Services.AddSingleton<IStatsService, StatsService>();
+builder.Services.AddScoped<ITicketRepository, EfTicketRepository>();
+builder.Services.AddScoped<IStatsService, StatsService>();
+builder.Services.AddScoped<UserActivityService>();
 builder.Services.AddSingleton<BusinessHoursFilter>();
 ```
 
 Register application services before `Build()`.
+
+TeleFlow validates handler method dependencies, error handler dependencies, and custom filter registrations before normal update processing starts. If a handler asks for `ITicketRepository` and the service is missing, the application fails with a TeleFlow configuration error instead of failing later on a random user update.
 
 ## Avoid Service Locator Handlers
 
@@ -90,7 +130,11 @@ Use these intentionally. A replacement point is not a reason to customize everyt
 
 - Use singleton for stateless services and thread-safe repositories.
 - Use singleton for in-memory demo repositories only when process-local data is acceptable.
-- Use scoped services for update-scoped application work. TeleFlow creates one DI scope per update when the update goes through the framework pipeline, and scoped middleware plus handlers share that scope.
+- Use scoped services for repositories, database contexts, units of work, and application services that belong to one update.
+- Handlers are transient by default. They are resolved from the current update scope, so they can safely use scoped constructor dependencies.
+- Middleware registered through `AddUpdateMiddleware<T>()` is scoped by default and can safely use scoped repositories and services.
+- `ITelegramCurrentUpdateAccessor` and `IUpdateContextAccessor` are scoped current-update accessors. Use them from scoped services, not from singleton services.
+- TeleFlow creates one DI scope per update when the update goes through the framework pipeline, and scoped middleware plus handlers share that scope.
 - Avoid mutable singleton state for production workflows unless it is explicitly synchronized and process-local by design.
 
 TeleFlow itself does not turn DI into an application architecture. Keep your own boundaries clear.

--- a/docs/en/reference/troubleshooting.md
+++ b/docs/en/reference/troubleshooting.md
@@ -67,6 +67,53 @@ public Task Name(MessageContext ctx, CancellationToken ct)
 
 Use `[Message]`, `[Command]`, `[Callback]`, `[ChatMemberUpdated]`, or another explicit route attribute before adding state and filter constraints.
 
+## `Handler dependency was not registered`
+
+TeleFlow validates handler method parameters before normal update processing starts. If a handler asks for a service, that service must be registered in DI:
+
+```csharp
+public sealed class TicketHandler
+{
+    [CommandTemplate("ticket {id:long}")]
+    public Task Ticket(
+        MessageContext ctx,
+        ITicketRepository tickets,
+        CancellationToken ct)
+    {
+        // ...
+    }
+}
+```
+
+Register the dependency before building the app:
+
+```csharp
+builder.Services.AddScoped<ITicketRepository, EfTicketRepository>();
+```
+
+The same rule applies to Telegram error handlers and custom filters.
+
+## Current Update Accessor Fails Outside Update Processing
+
+`ITelegramCurrentUpdateAccessor` is scoped to one incoming Telegram update. It works inside handlers, middleware, and scoped services reached from the update pipeline.
+
+It does not work from application startup, background jobs, singleton services, or code that runs before an update exists.
+
+Use it from scoped services:
+
+```csharp
+public sealed class UserService(ITelegramCurrentUpdateAccessor current)
+{
+    public long RequireUserId()
+    {
+        return current.User?.Id
+            ?? throw new InvalidOperationException("This operation requires a Telegram user.");
+    }
+}
+```
+
+Do not inject it into singleton services.
+
 ## Can I Read The Token From `appsettings.json`?
 
 Yes. TeleFlow does not care where the token comes from. Read it through normal .NET configuration and pass the resolved value explicitly:

--- a/docs/ru/advanced/middleware-and-rate-limiting.md
+++ b/docs/ru/advanced/middleware-and-rate-limiting.md
@@ -113,6 +113,8 @@ builder.Services.AddUpdateMiddleware<UserGateMiddleware>();
 
 `AddUpdateMiddleware<T>()` добавляет middleware в update pipeline и создаёт его из текущего update scope. Поэтому middleware может принимать scoped-зависимости в конструкторе: repositories, unit-of-work services, database contexts и другие update-scoped application services.
 
+Middleware получает `UpdateContext` напрямую, потому что middleware является частью framework pipeline. Обычным application services обычно не нужно принимать `UpdateContext` или `MessageContext`. Если scoped service нужен текущий Telegram user или chat, внедри в этот service `ITelegramCurrentUpdateAccessor`.
+
 Если middleware нужна application configuration, используй обычный .NET options pattern. В минимальном console-проекте пакет с options лучше добавить явно:
 
 ```bash
@@ -166,6 +168,8 @@ builder.Services.AddSingletonUpdateMiddleware<MyStatelessMiddleware>();
 ```
 
 Singleton middleware не должен принимать scoped services в конструкторе.
+
+Singleton middleware также не должен принимать `ITelegramCurrentUpdateAccessor` или `IUpdateContextAccessor`. Current-update accessors scoped на один update.
 
 Не регистрируй middleware напрямую как `IUpdateMiddleware` в `IServiceCollection`. TeleFlow строит middleware pipeline из middleware-регистраций, а не из произвольных `IUpdateMiddleware` services, и startup приложения намеренно падает с понятной ошибкой, если находит прямые регистрации.
 

--- a/docs/ru/fundamentals/dependency-injection.md
+++ b/docs/ru/fundamentals/dependency-injection.md
@@ -1,8 +1,8 @@
 # Dependency Injection
 
-TeleFlow использует `Microsoft.Extensions.DependencyInjection`. Handlers, filters, middleware, repositories, services, storage implementations, serializers и Telegram client replacements регистрируются в обычном .NET service collection.
+TeleFlow использует `Microsoft.Extensions.DependencyInjection`. Хэндлеры, фильтры, middleware, репозитории, сервисы, storage-реализации, сериализаторы и замены Telegram client регистрируются в обычном .NET service collection.
 
-## Внедрение сервисов в handlers
+## Внедрение сервисов в хэндлеры
 
 Constructor injection:
 
@@ -39,17 +39,57 @@ public async Task Stats(
 }
 ```
 
-Оба стиля полезны. Constructor injection лучше для стабильных dependencies. Parameter injection удобен для узких handler methods.
+Оба стиля полезны. Constructor injection лучше для стабильных зависимостей. Parameter injection удобен для узких handler methods.
+
+## Текущий update в application service
+
+Хэндлер должен оставаться рядом с Telegram: он принимает `MessageContext`, `CallbackQueryContext`, route values, callback payloads и cancellation token. Но application service не должен принимать handler context только ради того, чтобы узнать текущего пользователя или чат.
+
+Если scoped application service нужен текущий Telegram user/chat/message, используй `ITelegramCurrentUpdateAccessor`:
+
+```csharp
+public sealed class UserActivityService(
+    ITelegramCurrentUpdateAccessor current,
+    IUserRepository users)
+{
+    public async Task TouchAsync(CancellationToken ct)
+    {
+        var user = current.User
+            ?? throw new InvalidOperationException("Для этой операции нужен Telegram user.");
+
+        await users.TouchAsync(user.Id, ct);
+    }
+}
+```
+
+Хэндлер при этом остаётся тонким:
+
+```csharp
+public sealed class StartHandler(UserActivityService activity)
+{
+    [Command("start")]
+    public async Task Start(MessageContext ctx, CancellationToken ct)
+    {
+        await activity.TouchAsync(ct);
+        await ctx.Message.AnswerAsync("Ready.", ct);
+    }
+}
+```
+
+Accessor живёт в scope одного update. Он доступен только пока TeleFlow обрабатывает update, а вне обработки падает с понятной ошибкой. Не внедряй его в singleton services.
 
 ## Регистрация application services
 
 ```csharp
-builder.Services.AddSingleton<ITicketRepository, InMemoryTicketRepository>();
-builder.Services.AddSingleton<IStatsService, StatsService>();
+builder.Services.AddScoped<ITicketRepository, EfTicketRepository>();
+builder.Services.AddScoped<IStatsService, StatsService>();
+builder.Services.AddScoped<UserActivityService>();
 builder.Services.AddSingleton<BusinessHoursFilter>();
 ```
 
 Application services регистрируются до `Build()`.
+
+TeleFlow валидирует зависимости handler methods, error handlers и custom filters до нормальной обработки updates. Если handler просит `ITicketRepository`, а сервис не зарегистрирован, приложение упадёт с понятной TeleFlow configuration error, а не позже на случайном update от пользователя.
 
 ## Не превращай handler в service locator
 
@@ -90,7 +130,11 @@ builder.Services.AddUpdateRateLimiter<TenantUpdateRateLimiter>();
 
 - Singleton подходит для stateless services и thread-safe repositories.
 - Singleton подходит для in-memory demo repositories только когда process-local data acceptable.
-- Scoped services используй для update-scoped application work. TeleFlow создаёт один DI scope на update, когда update проходит через framework pipeline, и scoped middleware вместе с handlers разделяют этот scope.
+- Scoped services используй для repositories, database contexts, units of work и application services, которые относятся к одному update.
+- Хэндлеры по умолчанию transient. Они создаются из текущего update scope, поэтому могут безопасно принимать scoped dependencies в constructor.
+- Middleware, зарегистрированное через `AddUpdateMiddleware<T>()`, по умолчанию scoped и может безопасно принимать scoped repositories и services.
+- `ITelegramCurrentUpdateAccessor` и `IUpdateContextAccessor` - scoped current-update accessors. Используй их из scoped services, а не из singleton services.
+- TeleFlow создаёт один DI scope на update, когда update проходит через framework pipeline, и scoped middleware вместе с handlers разделяют этот scope.
 - Избегай mutable singleton state в production workflows, если он явно не синхронизирован и не process-local by design.
 
 TeleFlow сам по себе не превращает DI в application architecture. Границы своего приложения нужно держать отдельно.

--- a/docs/ru/reference/troubleshooting.md
+++ b/docs/ru/reference/troubleshooting.md
@@ -67,6 +67,53 @@ public Task Name(MessageContext ctx, CancellationToken ct)
 
 Используй `[Message]`, `[Command]`, `[Callback]`, `[ChatMemberUpdated]` или другой явный route attribute перед state и filter constraints.
 
+## `Handler dependency was not registered`
+
+TeleFlow валидирует параметры handler methods до нормальной обработки updates. Если handler просит сервис, этот сервис должен быть зарегистрирован в DI:
+
+```csharp
+public sealed class TicketHandler
+{
+    [CommandTemplate("ticket {id:long}")]
+    public Task Ticket(
+        MessageContext ctx,
+        ITicketRepository tickets,
+        CancellationToken ct)
+    {
+        // ...
+    }
+}
+```
+
+Зарегистрируй dependency до сборки приложения:
+
+```csharp
+builder.Services.AddScoped<ITicketRepository, EfTicketRepository>();
+```
+
+То же правило действует для Telegram error handlers и custom filters.
+
+## Current update accessor падает вне обработки update
+
+`ITelegramCurrentUpdateAccessor` scoped на один входящий Telegram update. Он работает внутри handlers, middleware и scoped services, до которых дошёл update pipeline.
+
+Он не работает из application startup, background jobs, singleton services или кода, который выполняется до появления update.
+
+Используй его из scoped services:
+
+```csharp
+public sealed class UserService(ITelegramCurrentUpdateAccessor current)
+{
+    public long RequireUserId()
+    {
+        return current.User?.Id
+            ?? throw new InvalidOperationException("Для этой операции нужен Telegram user.");
+    }
+}
+```
+
+Не внедряй его в singleton services.
+
 ## Можно ли читать token из `appsettings.json`?
 
 Да. TeleFlow не важно, откуда пришёл token. Прочитай его через обычную .NET configuration и явно передай resolved value:

--- a/src/TeleFlow.Framework.Core/Application/ITeleFlowRuntimeValidator.cs
+++ b/src/TeleFlow.Framework.Core/Application/ITeleFlowRuntimeValidator.cs
@@ -1,0 +1,14 @@
+namespace TeleFlow.Framework.Application;
+
+/// <summary>
+/// Validates framework runtime configuration against the final service provider before updates are processed.
+/// Framework layers register validators for metadata that cannot be checked by the DI container alone.
+/// </summary>
+public interface ITeleFlowRuntimeValidator
+{
+    /// <summary>
+    /// Validates the final runtime service provider and throws <see cref="TeleFlowConfigurationException"/>
+    /// when the application setup is invalid.
+    /// </summary>
+    void Validate(IServiceProvider services);
+}

--- a/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationBuilder.cs
+++ b/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Framework.Application;
 
@@ -8,6 +9,7 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
     {
         Services = new ServiceCollection();
         Services.AddSingleton(new TeleFlowApplicationArguments(args));
+        Services.AddUpdateContextAccessor();
     }
 
     public IServiceCollection Services { get; }

--- a/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationRuntimeFactory.cs
+++ b/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationRuntimeFactory.cs
@@ -51,6 +51,8 @@ internal static class TeleFlowApplicationRuntimeFactory
 
     private static ITeleFlowApplication Create(IServiceProvider serviceProvider, bool ownsServices)
     {
+        TeleFlowRuntimeValidatorRunner.Validate(serviceProvider);
+
         var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
         var updateSource = ResolveSingleRequiredService<IUpdateSource>(serviceProvider);
         var dispatcher = ResolveSingleRequiredService<IUpdateDispatcher>(serviceProvider);

--- a/src/TeleFlow.Framework.Core/Application/TeleFlowConfigurationException.cs
+++ b/src/TeleFlow.Framework.Core/Application/TeleFlowConfigurationException.cs
@@ -1,0 +1,18 @@
+namespace TeleFlow.Framework.Application;
+
+/// <summary>
+/// Represents an invalid TeleFlow application setup detected before an update should be processed.
+/// The runtime uses this exception for configuration and DI validation failures that users can fix in startup code.
+/// </summary>
+public sealed class TeleFlowConfigurationException : InvalidOperationException
+{
+    public TeleFlowConfigurationException(string message)
+        : base(message)
+    {
+    }
+
+    public TeleFlowConfigurationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/TeleFlow.Framework.Core/Application/TeleFlowRuntimeValidatorRunner.cs
+++ b/src/TeleFlow.Framework.Core/Application/TeleFlowRuntimeValidatorRunner.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeleFlow.Framework.Application;
+
+/// <summary>
+/// Runs framework runtime validators from application and transport entrypoints before update processing starts.
+/// This keeps validation centralized while individual validators remain owned by their framework layer.
+/// </summary>
+internal static class TeleFlowRuntimeValidatorRunner
+{
+    public static void Validate(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        List<Exception>? exceptions = null;
+
+        foreach (var validator in services.GetServices<ITeleFlowRuntimeValidator>())
+        {
+            try
+            {
+                validator.Validate(services);
+            }
+            catch (TeleFlowConfigurationException exception)
+            {
+                exceptions ??= [];
+                exceptions.Add(exception);
+            }
+        }
+
+        if (exceptions is null)
+        {
+            return;
+        }
+
+        if (exceptions.Count == 1)
+        {
+            throw exceptions[0];
+        }
+
+        throw new TeleFlowConfigurationException(
+            "TeleFlow configuration is invalid." +
+            Environment.NewLine +
+            Environment.NewLine +
+            string.Join(
+                Environment.NewLine + Environment.NewLine,
+                exceptions.Select(static exception => exception.Message)),
+            new AggregateException(exceptions));
+    }
+}

--- a/src/TeleFlow.Framework.Core/Updates/DefaultUpdateContextAccessor.cs
+++ b/src/TeleFlow.Framework.Core/Updates/DefaultUpdateContextAccessor.cs
@@ -1,0 +1,49 @@
+namespace TeleFlow.Framework.Updates;
+
+/// <summary>
+/// Stores the current update context for one DI update scope so middleware, dispatchers, and scoped
+/// application services observe the same update identity during processing.
+/// </summary>
+internal sealed class DefaultUpdateContextAccessor : IUpdateContextAccessor, IUpdateContextAccessorInitializer
+{
+    private UpdateContext? _current;
+
+    public bool IsAvailable => _current is not null;
+
+    public UpdateContext Current => _current ?? throw new InvalidOperationException(
+        "No current update is available. IUpdateContextAccessor can only be used inside TeleFlow update processing, not outside an update scope.");
+
+    public bool TryGetCurrent(out UpdateContext context)
+    {
+        if (_current is null)
+        {
+            context = null!;
+            return false;
+        }
+
+        context = _current;
+        return true;
+    }
+
+    public void Initialize(UpdateContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (_current is not null)
+        {
+            throw new InvalidOperationException("The current update accessor has already been initialized for this update scope.");
+        }
+
+        _current = context;
+    }
+
+    public void Clear(UpdateContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (ReferenceEquals(_current, context))
+        {
+            _current = null;
+        }
+    }
+}

--- a/src/TeleFlow.Framework.Core/Updates/DefaultUpdateProcessor.cs
+++ b/src/TeleFlow.Framework.Core/Updates/DefaultUpdateProcessor.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Framework.Application;
 using TeleFlow.Framework.Dispatching;
 using TeleFlow.Framework.Middleware;
 
@@ -9,6 +10,8 @@ internal sealed class DefaultUpdateProcessor : IUpdateProcessor
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IUpdateDispatcher _dispatcher;
     private readonly IReadOnlyList<UpdateMiddlewareRegistration> _middleware;
+    private readonly object _validationLock = new();
+    private bool _runtimeValidated;
 
     public DefaultUpdateProcessor(
         IServiceScopeFactory scopeFactory,
@@ -29,10 +32,41 @@ internal sealed class DefaultUpdateProcessor : IUpdateProcessor
         var scope = _scopeFactory.CreateAsyncScope();
         await using (scope.ConfigureAwait(false))
         {
+            EnsureRuntimeValidated(scope.ServiceProvider);
+
             var context = new UpdateContext(scope.ServiceProvider, payload, cancellationToken);
+            var currentUpdate = scope.ServiceProvider.GetService<IUpdateContextAccessorInitializer>();
             var pipeline = BuildPipeline(scope.ServiceProvider, _dispatcher, _middleware);
 
-            await pipeline(context).ConfigureAwait(false);
+            currentUpdate?.Initialize(context);
+
+            try
+            {
+                await pipeline(context).ConfigureAwait(false);
+            }
+            finally
+            {
+                currentUpdate?.Clear(context);
+            }
+        }
+    }
+
+    private void EnsureRuntimeValidated(IServiceProvider services)
+    {
+        if (_runtimeValidated)
+        {
+            return;
+        }
+
+        lock (_validationLock)
+        {
+            if (_runtimeValidated)
+            {
+                return;
+            }
+
+            TeleFlowRuntimeValidatorRunner.Validate(services);
+            _runtimeValidated = true;
         }
     }
 

--- a/src/TeleFlow.Framework.Core/Updates/IUpdateContextAccessor.cs
+++ b/src/TeleFlow.Framework.Core/Updates/IUpdateContextAccessor.cs
@@ -1,0 +1,24 @@
+namespace TeleFlow.Framework.Updates;
+
+/// <summary>
+/// Provides scoped read-only access to the update currently being processed by the TeleFlow runtime pipeline.
+/// Application services can use this accessor when they need update identity without accepting framework
+/// handler contexts directly.
+/// </summary>
+public interface IUpdateContextAccessor
+{
+    /// <summary>
+    /// Gets whether a current update is available in the active DI scope.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets the current update context or throws when called outside update processing.
+    /// </summary>
+    UpdateContext Current { get; }
+
+    /// <summary>
+    /// Attempts to get the current update context without throwing outside update processing.
+    /// </summary>
+    bool TryGetCurrent(out UpdateContext context);
+}

--- a/src/TeleFlow.Framework.Core/Updates/IUpdateContextAccessorInitializer.cs
+++ b/src/TeleFlow.Framework.Core/Updates/IUpdateContextAccessorInitializer.cs
@@ -1,0 +1,12 @@
+namespace TeleFlow.Framework.Updates;
+
+/// <summary>
+/// Initializes the scoped current-update accessor from the runtime pipeline before middleware and
+/// handler dispatch execute for an incoming update.
+/// </summary>
+internal interface IUpdateContextAccessorInitializer
+{
+    void Initialize(UpdateContext context);
+
+    void Clear(UpdateContext context);
+}

--- a/src/TeleFlow.Framework.Core/Updates/UpdateContextAccessorServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework.Core/Updates/UpdateContextAccessorServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace TeleFlow.Framework.Updates;
+
+/// <summary>
+/// Registers the scoped current-update accessor used by the TeleFlow runtime pipeline.
+/// Framework entry packages call this automatically; custom Core-only applications can call it explicitly.
+/// </summary>
+public static class UpdateContextAccessorServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers scoped services that expose the current update during TeleFlow update processing.
+    /// </summary>
+    public static IServiceCollection AddUpdateContextAccessor(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<DefaultUpdateContextAccessor>();
+        services.TryAddScoped<IUpdateContextAccessor>(
+            static provider => provider.GetRequiredService<DefaultUpdateContextAccessor>());
+        services.TryAddScoped<IUpdateContextAccessorInitializer>(
+            static provider => provider.GetRequiredService<DefaultUpdateContextAccessor>());
+
+        return services;
+    }
+}

--- a/src/TeleFlow.Framework.Webhooks/TelegramWebhookEndpointRouteBuilderExtensions.cs
+++ b/src/TeleFlow.Framework.Webhooks/TelegramWebhookEndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Framework.Application;
 using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Telegram.Webhooks;
@@ -14,6 +15,8 @@ public static class TelegramWebhookEndpointRouteBuilderExtensions
 
         var options = endpoints.ServiceProvider.GetRequiredService<TelegramWebhookOptions>();
         var processor = endpoints.ServiceProvider.GetRequiredService<IUpdateProcessor>();
+
+        TeleFlowRuntimeValidatorRunner.Validate(endpoints.ServiceProvider);
 
         return endpoints.MapTelegramWebhook(
             options.Path,

--- a/src/TeleFlow.Framework/ITelegramCurrentUpdateAccessor.cs
+++ b/src/TeleFlow.Framework/ITelegramCurrentUpdateAccessor.cs
@@ -1,0 +1,77 @@
+using TeleFlow.Framework.States;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Provides scoped read-only access to the Telegram update currently being processed by TeleFlow.
+/// Application services can use it to read current user, chat, message, callback, and state identity
+/// without accepting handler contexts directly.
+/// </summary>
+public interface ITelegramCurrentUpdateAccessor
+{
+    /// <summary>
+    /// Gets whether the active DI scope is currently processing a Telegram update.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets the current Telegram update context or throws outside Telegram update processing.
+    /// </summary>
+    TelegramUpdateContext Current { get; }
+
+    /// <summary>
+    /// Gets the current raw Telegram update or throws outside Telegram update processing.
+    /// </summary>
+    Update Update { get; }
+
+    /// <summary>
+    /// Gets the user who caused the current update when Telegram provides one.
+    /// </summary>
+    User? User { get; }
+
+    /// <summary>
+    /// Gets the chat associated with the current update when Telegram provides one.
+    /// </summary>
+    Chat? Chat { get; }
+
+    /// <summary>
+    /// Gets the current message when the update is a message update.
+    /// </summary>
+    Message? Message { get; }
+
+    /// <summary>
+    /// Gets the current callback query when the update is a callback query update.
+    /// </summary>
+    CallbackQuery? CallbackQuery { get; }
+
+    /// <summary>
+    /// Gets the current chat member update when the update changed a member status.
+    /// </summary>
+    ChatMemberUpdated? ChatMemberUpdated { get; }
+
+    /// <summary>
+    /// Gets the state key produced by state middleware for the current update when available.
+    /// </summary>
+    StateKey? StateKey { get; }
+
+    /// <summary>
+    /// Attempts to get the current Telegram update context without throwing outside update processing.
+    /// </summary>
+    bool TryGetCurrent(out TelegramUpdateContext context);
+
+    /// <summary>
+    /// Attempts to get the current message context when the update is a message update.
+    /// </summary>
+    bool TryGetMessageContext(out MessageContext context);
+
+    /// <summary>
+    /// Attempts to get the current callback query context when the update is a callback query update.
+    /// </summary>
+    bool TryGetCallbackQueryContext(out CallbackQueryContext context);
+
+    /// <summary>
+    /// Attempts to get the current chat member context when the update changed a member status.
+    /// </summary>
+    bool TryGetChatMemberUpdatedContext(out ChatMemberUpdatedContext context);
+}

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramRuntimeDependencyValidator.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramRuntimeDependencyValidator.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Framework.Application;
+
+namespace TeleFlow.Telegram.Internal.Handlers;
+
+/// <summary>
+/// Validates Telegram handler metadata against the final DI service provider so missing method-parameter
+/// services and custom filters fail before an update reaches the dispatcher hot path.
+/// </summary>
+internal sealed class TelegramRuntimeDependencyValidator : ITeleFlowRuntimeValidator
+{
+    public void Validate(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var serviceAvailability = services.GetService<IServiceProviderIsService>();
+
+        if (serviceAvailability is null)
+        {
+            throw new TeleFlowConfigurationException(
+                "TeleFlow runtime validation requires a Microsoft.Extensions.DependencyInjection service provider.");
+        }
+
+        var errors = new List<string>();
+
+        ValidateHandlers(services, serviceAvailability, errors);
+        ValidateErrorHandlers(services, serviceAvailability, errors);
+
+        if (errors.Count == 0)
+        {
+            return;
+        }
+
+        throw new TeleFlowConfigurationException(
+            "TeleFlow configuration is invalid." +
+            Environment.NewLine +
+            Environment.NewLine +
+            string.Join(Environment.NewLine + Environment.NewLine, errors));
+    }
+
+    private static void ValidateHandlers(
+        IServiceProvider services,
+        IServiceProviderIsService serviceAvailability,
+        List<string> errors)
+    {
+        foreach (var handler in services.GetServices<TelegramHandlerDescriptor>())
+        {
+            foreach (var parameter in handler.Parameters.Where(static parameter =>
+                         parameter.Kind == TelegramHandlerParameterKind.Service))
+            {
+                if (!serviceAvailability.IsService(parameter.ParameterType))
+                {
+                    errors.Add(
+                        "Handler dependency was not registered." +
+                        Environment.NewLine +
+                        $"Handler: {TelegramHandlerDescriptorFormatter.GetDisplayName(handler)}" +
+                        Environment.NewLine +
+                        $"Parameter: {parameter.Name ?? "<unnamed>"}" +
+                        Environment.NewLine +
+                        $"Service type: {FormatType(parameter.ParameterType)}" +
+                        Environment.NewLine +
+                        $"Register {FormatType(parameter.ParameterType)} in IServiceCollection before building the TeleFlow application.");
+                }
+            }
+
+            foreach (var filterType in GetCustomFilterTypes(handler))
+            {
+                if (!serviceAvailability.IsService(filterType))
+                {
+                    errors.Add(
+                        "Custom filter was not registered." +
+                        Environment.NewLine +
+                        $"Handler: {TelegramHandlerDescriptorFormatter.GetDisplayName(handler)}" +
+                        Environment.NewLine +
+                        $"Filter type: {FormatType(filterType)}" +
+                        Environment.NewLine +
+                        $"Register {FormatType(filterType)} in IServiceCollection before building the TeleFlow application.");
+                }
+            }
+        }
+    }
+
+    private static void ValidateErrorHandlers(
+        IServiceProvider services,
+        IServiceProviderIsService serviceAvailability,
+        List<string> errors)
+    {
+        foreach (var handler in services.GetServices<TelegramErrorHandlerDescriptor>())
+        {
+            foreach (var parameter in handler.Parameters.Where(static parameter =>
+                         parameter.Kind == TelegramErrorHandlerParameterKind.Service))
+            {
+                if (!serviceAvailability.IsService(parameter.ParameterType))
+                {
+                    errors.Add(
+                        "Error handler dependency was not registered." +
+                        Environment.NewLine +
+                        $"Error handler: {FormatErrorHandler(handler)}" +
+                        Environment.NewLine +
+                        $"Parameter: {parameter.Name ?? "<unnamed>"}" +
+                        Environment.NewLine +
+                        $"Service type: {FormatType(parameter.ParameterType)}" +
+                        Environment.NewLine +
+                        $"Register {FormatType(parameter.ParameterType)} in IServiceCollection before building the TeleFlow application.");
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<Type> GetCustomFilterTypes(TelegramHandlerDescriptor handler)
+    {
+        return handler.Route.Filters
+            .Select(static filter => filter.CustomFilterType)
+            .OfType<Type>()
+            .Distinct();
+    }
+
+    private static string FormatErrorHandler(TelegramErrorHandlerDescriptor handler)
+    {
+        return $"{handler.HandlerType.FullName}.{handler.MethodName}";
+    }
+
+    private static string FormatType(Type type)
+    {
+        return type.FullName ?? type.Name;
+    }
+}

--- a/src/TeleFlow.Framework/Internal/TelegramCurrentUpdateAccessor.cs
+++ b/src/TeleFlow.Framework/Internal/TelegramCurrentUpdateAccessor.cs
@@ -1,0 +1,179 @@
+using TeleFlow.Framework.States;
+using TeleFlow.Framework.Updates;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Adapts the Core current-update accessor to Telegram-specific contexts and identity properties for scoped
+/// application services reached while a Telegram update is being dispatched.
+/// </summary>
+internal sealed class TelegramCurrentUpdateAccessor(
+    IUpdateContextAccessor currentUpdate,
+    TelegramContextFactory contextFactory) : ITelegramCurrentUpdateAccessor
+{
+    public bool IsAvailable => TryGetCurrent(out _);
+
+    public TelegramUpdateContext Current => TryGetCurrent(out var context)
+        ? context
+        : throw new InvalidOperationException(
+            "No current Telegram update is available. ITelegramCurrentUpdateAccessor can only be used inside TeleFlow Telegram update processing.");
+
+    public Update Update => Current.Update;
+
+    public User? User
+    {
+        get
+        {
+            if (!TryGetUpdate(out var update))
+            {
+                return null;
+            }
+
+            return update.Message?.From ??
+                   update.CallbackQuery?.From ??
+                   update.ChatMember?.From ??
+                   update.MyChatMember?.From;
+        }
+    }
+
+    public Chat? Chat
+    {
+        get
+        {
+            if (!TryGetUpdate(out var update))
+            {
+                return null;
+            }
+
+            return update.Message?.Chat ??
+                   GetCallbackChat(update.CallbackQuery) ??
+                   update.ChatMember?.Chat ??
+                   update.MyChatMember?.Chat;
+        }
+    }
+
+    public Message? Message => TryGetUpdate(out var update) ? update.Message : null;
+
+    public CallbackQuery? CallbackQuery => TryGetUpdate(out var update) ? update.CallbackQuery : null;
+
+    public ChatMemberUpdated? ChatMemberUpdated
+    {
+        get
+        {
+            if (!TryGetUpdate(out var update))
+            {
+                return null;
+            }
+
+            return update.ChatMember ?? update.MyChatMember;
+        }
+    }
+
+    public StateKey? StateKey
+    {
+        get
+        {
+            if (!currentUpdate.TryGetCurrent(out var context) ||
+                !context.TryGetState(out var state))
+            {
+                return null;
+            }
+
+            return state.Key;
+        }
+    }
+
+    public bool TryGetCurrent(out TelegramUpdateContext context)
+    {
+        if (!currentUpdate.TryGetCurrent(out var updateContext) ||
+            updateContext.Payload is not TelegramUpdatePayload payload)
+        {
+            context = null!;
+            return false;
+        }
+
+        if (payload.Update.Message is not null)
+        {
+            context = contextFactory.CreateMessageContext(updateContext);
+            return true;
+        }
+
+        if (payload.Update.CallbackQuery is not null)
+        {
+            context = contextFactory.CreateCallbackQueryContext(updateContext);
+            return true;
+        }
+
+        if (payload.Update.ChatMember is not null ||
+            payload.Update.MyChatMember is not null)
+        {
+            context = contextFactory.CreateChatMemberUpdatedContext(updateContext);
+            return true;
+        }
+
+        context = contextFactory.CreateTelegramContext(updateContext);
+        return true;
+    }
+
+    public bool TryGetMessageContext(out MessageContext context)
+    {
+        if (!currentUpdate.TryGetCurrent(out var updateContext) ||
+            updateContext.Payload is not TelegramUpdatePayload payload ||
+            payload.Update.Message is null)
+        {
+            context = null!;
+            return false;
+        }
+
+        context = contextFactory.CreateMessageContext(updateContext);
+        return true;
+    }
+
+    public bool TryGetCallbackQueryContext(out CallbackQueryContext context)
+    {
+        if (!currentUpdate.TryGetCurrent(out var updateContext) ||
+            updateContext.Payload is not TelegramUpdatePayload payload ||
+            payload.Update.CallbackQuery is null)
+        {
+            context = null!;
+            return false;
+        }
+
+        context = contextFactory.CreateCallbackQueryContext(updateContext);
+        return true;
+    }
+
+    public bool TryGetChatMemberUpdatedContext(out ChatMemberUpdatedContext context)
+    {
+        if (!currentUpdate.TryGetCurrent(out var updateContext) ||
+            updateContext.Payload is not TelegramUpdatePayload payload ||
+            payload.Update.ChatMember is null && payload.Update.MyChatMember is null)
+        {
+            context = null!;
+            return false;
+        }
+
+        context = contextFactory.CreateChatMemberUpdatedContext(updateContext);
+        return true;
+    }
+
+    private bool TryGetUpdate(out Update update)
+    {
+        if (!currentUpdate.TryGetCurrent(out var context) ||
+            context.Payload is not TelegramUpdatePayload payload)
+        {
+            update = null!;
+            return false;
+        }
+
+        update = payload.Update;
+        return true;
+    }
+
+    private static Chat? GetCallbackChat(CallbackQuery? callbackQuery)
+    {
+        return callbackQuery?.Message?.Message?.Chat ??
+               callbackQuery?.Message?.InaccessibleMessage?.Chat;
+    }
+}

--- a/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using TeleFlow.Framework.Application;
 using TeleFlow.Framework.Callbacks;
 using TeleFlow.Framework.Dispatching;
 using TeleFlow.Framework.States;
+using TeleFlow.Framework.Updates;
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Internal.Handlers;
 using TeleFlow.Telegram.Internal.Options;
@@ -44,12 +46,15 @@ public static class TelegramServiceCollectionExtensions
         });
 
         services.AddSingleton(options);
+        services.AddUpdateContextAccessor();
         services.TryAddSingleton(options.RoleFilter);
         services.AddSingleton<TelegramContextFactory>();
+        services.TryAddScoped<ITelegramCurrentUpdateAccessor, TelegramCurrentUpdateAccessor>();
         services.TryAddSingleton<IStateKeyFactory, TelegramStateKeyFactory>();
         services.TryAddSingleton<ICallbackDataSerializer, JsonCallbackDataSerializer>();
         services.TryAddSingleton<ITelegramChatMemberStatusResolver, TelegramChatMemberStatusResolver>();
         services.TryAddSingleton<ITelegramChatMemberStatusCache, MemoryTelegramChatMemberStatusCache>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITeleFlowRuntimeValidator, TelegramRuntimeDependencyValidator>());
 
         return services;
     }

--- a/tests/TeleFlow.ArchitectureTests/CurrentUpdateAccessorTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/CurrentUpdateAccessorTests.cs
@@ -1,0 +1,414 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Annotations;
+using TeleFlow.Framework.Dispatching;
+using TeleFlow.Framework.Middleware;
+using TeleFlow.Framework.States;
+using TeleFlow.Framework.Updates;
+using TeleFlow.Storage.Memory;
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.ArchitectureTests;
+
+public sealed class CurrentUpdateAccessorTests
+{
+    [Fact]
+    public void UpdateContextAccessor_FailsClearlyOutsideUpdateProcessing()
+    {
+        var services = new ServiceCollection();
+        services.AddUpdateContextAccessor();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+        using var scope = provider.CreateScope();
+
+        var accessor = scope.ServiceProvider.GetRequiredService<IUpdateContextAccessor>();
+
+        Assert.False(accessor.IsAvailable);
+        Assert.False(accessor.TryGetCurrent(out _));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => accessor.Current);
+
+        Assert.Contains("current update", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("outside", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateContextAccessor_IsAvailableToScopedMiddlewareAndDispatcher()
+    {
+        var recorder = new CoreAccessorRecorder();
+        var services = new ServiceCollection();
+
+        services.AddUpdateContextAccessor();
+        services.AddSingleton(recorder);
+        services.AddSingleton<IUpdateDispatcher, CoreAccessorDispatcher>();
+        services.AddUpdateMiddleware<CoreAccessorMiddleware>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        await ProcessCoreAsync(provider, new TestUpdatePayload("first"));
+
+        Assert.Equal(["middleware:before:first", "dispatcher:first", "middleware:after:first"], recorder.Events);
+    }
+
+    [Fact]
+    public async Task UpdateContextAccessor_IsScopedPerUpdate()
+    {
+        var recorder = new CoreAccessorRecorder();
+        var services = new ServiceCollection();
+
+        services.AddUpdateContextAccessor();
+        services.AddSingleton(recorder);
+        services.AddSingleton<IUpdateDispatcher, CoreAccessorDispatcher>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        await ProcessCoreAsync(provider, new TestUpdatePayload("first"));
+        await ProcessCoreAsync(provider, new TestUpdatePayload("second"));
+
+        Assert.Equal(2, recorder.Accessors.Count);
+        Assert.NotSame(recorder.Accessors[0], recorder.Accessors[1]);
+    }
+
+    [Fact]
+    public void TelegramCurrentUpdateAccessor_FailsClearlyOutsideTelegramUpdateProcessing()
+    {
+        var services = CreateTelegramServices();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+        using var scope = provider.CreateScope();
+
+        var accessor = scope.ServiceProvider.GetRequiredService<ITelegramCurrentUpdateAccessor>();
+
+        Assert.False(accessor.IsAvailable);
+        Assert.False(accessor.TryGetCurrent(out _));
+        Assert.Null(accessor.User);
+        Assert.Null(accessor.Chat);
+        Assert.Null(accessor.Message);
+        Assert.Null(accessor.CallbackQuery);
+        Assert.Null(accessor.ChatMemberUpdated);
+        Assert.Null(accessor.StateKey);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => accessor.Current);
+
+        Assert.Contains("current Telegram update", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TelegramCurrentUpdateAccessor_ExposesMessageIdentityToApplicationServices()
+    {
+        var probe = new TelegramAccessorProbe();
+        var services = CreateTelegramServices();
+
+        services.AddSingleton(probe);
+        services.AddTelegramHandler<MessageAccessorHandler>();
+
+        using var provider = BuildProvider(services);
+
+        await ProcessTelegramAsync(provider, CreateMessageUpdate("/start"));
+
+        Assert.Equal(
+        [
+            "message:True:1:5:100:/start:False:False:False"
+        ], probe.Events);
+    }
+
+    [Fact]
+    public async Task TelegramCurrentUpdateAccessor_ExposesCallbackIdentityToApplicationServices()
+    {
+        var probe = new TelegramAccessorProbe();
+        var services = CreateTelegramServices();
+
+        services.AddSingleton(probe);
+        services.AddTelegramHandler<CallbackAccessorHandler>();
+
+        using var provider = BuildProvider(services);
+
+        await ProcessTelegramAsync(provider, CreateCallbackUpdate("open", includeMessage: true));
+
+        Assert.Equal(
+        [
+            "callback:True:1:5:100:open:False:False:False"
+        ], probe.Events);
+    }
+
+    [Fact]
+    public async Task TelegramCurrentUpdateAccessor_ExposesChatMemberIdentityToApplicationServices()
+    {
+        var probe = new TelegramAccessorProbe();
+        var services = CreateTelegramServices();
+
+        services.AddSingleton(probe);
+        services.AddTelegramHandler<ChatMemberAccessorHandler>();
+
+        using var provider = BuildProvider(services);
+
+        await ProcessTelegramAsync(
+            provider,
+            CreateChatMemberUpdate(
+                isOwnUpdate: false,
+                oldChatMember: LeftChatMember(),
+                newChatMember: MemberChatMember()));
+
+        Assert.Equal(
+        [
+            "chat-member:True:1:42:100:5:False:False:True"
+        ], probe.Events);
+    }
+
+    [Fact]
+    public async Task TelegramCurrentUpdateAccessor_ExposesStateKeyAfterStateMiddleware()
+    {
+        var probe = new TelegramAccessorProbe();
+        var services = CreateTelegramServices();
+
+        services.AddMemoryStateStorage();
+        services.AddSingleton(probe);
+        services.AddTelegramHandler<StateKeyAccessorHandler>();
+
+        using var provider = BuildProvider(services);
+
+        await ProcessTelegramAsync(provider, CreateMessageUpdate("state"));
+
+        Assert.Equal(["state-key:telegram:user:5:chat:100"], probe.Events);
+    }
+
+    private static ServiceCollection CreateTelegramServices()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options => options.Token = "test-token");
+        return services;
+    }
+
+    private static ServiceProvider BuildProvider(IServiceCollection services)
+    {
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+    }
+
+    private static Task ProcessCoreAsync(ServiceProvider provider, IUpdatePayload payload)
+    {
+        var processor = new DefaultUpdateProcessor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<IUpdateDispatcher>(),
+            provider.GetServices<UpdateMiddlewareRegistration>());
+
+        return processor.ProcessAsync(payload);
+    }
+
+    private static Task ProcessTelegramAsync(ServiceProvider provider, Update update)
+    {
+        var processor = new DefaultUpdateProcessor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<IUpdateDispatcher>(),
+            provider.GetServices<UpdateMiddlewareRegistration>());
+
+        return processor.ProcessAsync(new TelegramUpdatePayload(update));
+    }
+
+    private static Update CreateMessageUpdate(string? text)
+    {
+        return new Update
+        {
+            UpdateId = 1,
+            Message = new Message
+            {
+                MessageId = 10,
+                Date = 0,
+                From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                Chat = new Chat { Id = 100, Type = "private" },
+                Text = text
+            }
+        };
+    }
+
+    private static Update CreateCallbackUpdate(string? data, bool includeMessage)
+    {
+        return new Update
+        {
+            UpdateId = 1,
+            CallbackQuery = new CallbackQuery
+            {
+                Id = "cb",
+                From = new User
+                {
+                    Id = 5,
+                    IsBot = false,
+                    FirstName = "User"
+                },
+                ChatInstance = "chat-instance",
+                Data = data,
+                Message = includeMessage
+                    ? MaybeInaccessibleMessage.From(new Message
+                    {
+                        MessageId = 10,
+                        Date = 0,
+                        Chat = new Chat { Id = 100, Type = "private" },
+                        From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                        Text = "callback source"
+                    })
+                    : null
+            }
+        };
+    }
+
+    private static Update CreateChatMemberUpdate(
+        bool isOwnUpdate,
+        ChatMember oldChatMember,
+        ChatMember newChatMember)
+    {
+        var chatMemberUpdated = new ChatMemberUpdated
+        {
+            Chat = new Chat { Id = 100, Type = "supergroup" },
+            From = new User { Id = 42, IsBot = false, FirstName = "Actor" },
+            Date = 0,
+            OldChatMember = oldChatMember,
+            NewChatMember = newChatMember
+        };
+
+        return new Update
+        {
+            UpdateId = 1,
+            ChatMember = isOwnUpdate ? null : chatMemberUpdated,
+            MyChatMember = isOwnUpdate ? chatMemberUpdated : null
+        };
+    }
+
+    private static ChatMember MemberChatMember()
+    {
+        return ChatMember.From(new ChatMemberMember
+        {
+            User = new User { Id = 5, IsBot = false, FirstName = "Member" }
+        });
+    }
+
+    private static ChatMember LeftChatMember()
+    {
+        return ChatMember.From(new ChatMemberLeft
+        {
+            User = new User { Id = 5, IsBot = false, FirstName = "Member" }
+        });
+    }
+
+    private sealed record TestUpdatePayload(string Name) : IUpdatePayload;
+
+    private sealed class CoreAccessorRecorder
+    {
+        public List<string> Events { get; } = [];
+
+        public List<IUpdateContextAccessor> Accessors { get; } = [];
+    }
+
+    private sealed class CoreAccessorMiddleware(
+        IUpdateContextAccessor accessor,
+        CoreAccessorRecorder recorder) : IUpdateMiddleware
+    {
+        public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
+        {
+            recorder.Events.Add($"middleware:before:{((TestUpdatePayload)accessor.Current.Payload).Name}");
+            await next(context);
+            recorder.Events.Add($"middleware:after:{((TestUpdatePayload)accessor.Current.Payload).Name}");
+        }
+    }
+
+    private sealed class CoreAccessorDispatcher(
+        CoreAccessorRecorder recorder) : IUpdateDispatcher
+    {
+        public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        {
+            var accessor = context.Services.GetRequiredService<IUpdateContextAccessor>();
+
+            recorder.Accessors.Add(accessor);
+            recorder.Events.Add($"dispatcher:{((TestUpdatePayload)accessor.Current.Payload).Name}");
+            Assert.Same(context, accessor.Current);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TelegramAccessorProbe
+    {
+        public List<string> Events { get; } = [];
+    }
+
+    private sealed class MessageAccessorHandler(
+        ITelegramCurrentUpdateAccessor current,
+        TelegramAccessorProbe probe)
+    {
+        [Message]
+        public Task Handle(MessageContext context)
+        {
+            probe.Events.Add(
+                $"message:{current.IsAvailable}:{current.Update.UpdateId}:{current.User?.Id}:{current.Chat?.Id}:{current.Message?.Text}:{current.CallbackQuery is not null}:{current.ChatMemberUpdated is not null}:{current.TryGetCallbackQueryContext(out _)}");
+            Assert.True(current.TryGetCurrent(out var currentContext));
+            Assert.True(current.TryGetMessageContext(out var messageContext));
+            Assert.Same(context, currentContext);
+            Assert.Same(context, messageContext);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CallbackAccessorHandler(
+        ITelegramCurrentUpdateAccessor current,
+        TelegramAccessorProbe probe)
+    {
+        [Callback]
+        public Task Handle(CallbackQueryContext context)
+        {
+            probe.Events.Add(
+                $"callback:{current.IsAvailable}:{current.Update.UpdateId}:{current.User?.Id}:{current.Chat?.Id}:{current.CallbackQuery?.Data}:{current.Message is not null}:{current.ChatMemberUpdated is not null}:{current.TryGetMessageContext(out _)}");
+            Assert.True(current.TryGetCurrent(out var currentContext));
+            Assert.True(current.TryGetCallbackQueryContext(out var callbackContext));
+            Assert.Same(context, currentContext);
+            Assert.Same(context, callbackContext);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ChatMemberAccessorHandler(
+        ITelegramCurrentUpdateAccessor current,
+        TelegramAccessorProbe probe)
+    {
+        [ChatMemberUpdated]
+        public Task Handle(ChatMemberUpdatedContext context)
+        {
+            probe.Events.Add(
+                $"chat-member:{current.IsAvailable}:{current.Update.UpdateId}:{current.User?.Id}:{current.Chat?.Id}:{context.Member.Id}:{current.Message is not null}:{current.CallbackQuery is not null}:{current.TryGetChatMemberUpdatedContext(out _)}");
+            Assert.True(current.TryGetCurrent(out var currentContext));
+            Assert.True(current.TryGetChatMemberUpdatedContext(out var chatMemberContext));
+            Assert.Same(context, currentContext);
+            Assert.Same(context, chatMemberContext);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StateKeyAccessorHandler(
+        ITelegramCurrentUpdateAccessor current,
+        TelegramAccessorProbe probe)
+    {
+        [Message]
+        public Task Handle(MessageContext context)
+        {
+            var key = current.StateKey;
+            probe.Events.Add($"state-key:{key?.Scope}:{key?.Subject}:{key?.Partition}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -74,6 +74,7 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.ChatMemberUpdateHandler",
         "TeleFlow.Telegram.ITelegramFilter`1",
         "TeleFlow.Telegram.ITelegramFilter`2",
+        "TeleFlow.Telegram.ITelegramCurrentUpdateAccessor",
         "TeleFlow.Telegram.TelegramUpdatePayload",
         "TeleFlow.Telegram.TelegramServiceCollectionExtensions",
         "TeleFlow.Telegram.TelegramBotOptions",

--- a/tests/TeleFlow.ArchitectureTests/RuntimeDependencyValidationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/RuntimeDependencyValidationTests.cs
@@ -1,0 +1,213 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Annotations;
+using TeleFlow.Framework.Application;
+using TeleFlow.Framework.Dispatching;
+using TeleFlow.Framework.Updates;
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Schema.Types;
+using TeleFlow.Telegram.Webhooks;
+
+namespace TeleFlow.ArchitectureTests;
+
+public sealed class RuntimeDependencyValidationTests
+{
+    [Fact]
+    public void Build_FailsClearlyForMissingHandlerServiceParameter()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddSingleton<IUpdateSource, NoOpUpdateSource>();
+        builder.Services.AddTelegramHandler<HandlerWithMissingServiceParameter>();
+
+        var exception = Assert.Throws<TeleFlowConfigurationException>(() => builder.Build());
+
+        Assert.Contains("Handler dependency was not registered", exception.Message);
+        Assert.Contains(nameof(HandlerWithMissingServiceParameter), exception.Message);
+        Assert.Contains(nameof(IMissingHandlerService), exception.Message);
+    }
+
+    [Fact]
+    public void Build_FailsClearlyForMissingErrorHandlerServiceParameter()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddSingleton<IUpdateSource, NoOpUpdateSource>();
+        builder.Services.AddTelegramHandler<ThrowingMessageHandler>();
+        builder.Services.AddTelegramHandler<ErrorHandlerWithMissingServiceParameter>();
+
+        var exception = Assert.Throws<TeleFlowConfigurationException>(() => builder.Build());
+
+        Assert.Contains("Error handler dependency was not registered", exception.Message);
+        Assert.Contains(nameof(ErrorHandlerWithMissingServiceParameter), exception.Message);
+        Assert.Contains(nameof(IMissingErrorHandlerService), exception.Message);
+    }
+
+    [Fact]
+    public void Build_FailsClearlyForMissingCustomFilterRegistration()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddSingleton<IUpdateSource, NoOpUpdateSource>();
+        builder.Services.AddTelegramHandler<HandlerWithMissingCustomFilter>();
+
+        var exception = Assert.Throws<TeleFlowConfigurationException>(() => builder.Build());
+
+        Assert.Contains("Custom filter was not registered", exception.Message);
+        Assert.Contains(nameof(HandlerWithMissingCustomFilter), exception.Message);
+        Assert.Contains(nameof(MissingCustomFilter), exception.Message);
+    }
+
+    [Fact]
+    public void Build_ReportsMultipleMissingDependenciesTogether()
+    {
+        var builder = TeleFlowApplication.CreateBuilder();
+
+        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddSingleton<IUpdateSource, NoOpUpdateSource>();
+        builder.Services.AddTelegramHandler<HandlerWithMissingServiceParameter>();
+        builder.Services.AddTelegramHandler<HandlerWithMissingCustomFilter>();
+
+        var exception = Assert.Throws<TeleFlowConfigurationException>(() => builder.Build());
+
+        Assert.Contains(nameof(IMissingHandlerService), exception.Message);
+        Assert.Contains(nameof(MissingCustomFilter), exception.Message);
+    }
+
+    [Fact]
+    public async Task DefaultUpdateProcessor_FallbackValidationFailsBeforeDispatch()
+    {
+        var dispatcher = new RecordingDispatcher();
+        var services = new ServiceCollection();
+
+        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddSingleton<IUpdateDispatcher>(dispatcher);
+        services.AddTelegramHandler<HandlerWithMissingServiceParameter>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        var processor = new DefaultUpdateProcessor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<IUpdateDispatcher>(),
+            provider.GetServices<TeleFlow.Framework.Middleware.UpdateMiddlewareRegistration>());
+
+        var exception = await Assert.ThrowsAsync<TeleFlowConfigurationException>(() =>
+            processor.ProcessAsync(new TelegramUpdatePayload(CreateMessageUpdate("/start"))));
+
+        Assert.Contains(nameof(IMissingHandlerService), exception.Message);
+        Assert.Equal(0, dispatcher.DispatchCount);
+    }
+
+    [Fact]
+    public async Task WebhookEndpoint_FailsValidationBeforeProcessingUpdate()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddTelegramBot(options => options.Token = "test-token");
+        builder.Services.AddTelegramHandler<HandlerWithMissingServiceParameter>();
+        builder.Services.AddWebhook();
+
+        await using var app = builder.Build();
+
+        var exception = Assert.Throws<TeleFlowConfigurationException>(() => app.MapTelegramWebhook());
+
+        Assert.Contains(nameof(IMissingHandlerService), exception.Message);
+    }
+
+    private static Update CreateMessageUpdate(string? text)
+    {
+        return new Update
+        {
+            UpdateId = 1,
+            Message = new Message
+            {
+                MessageId = 10,
+                Date = 0,
+                From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                Chat = new Chat { Id = 100, Type = "private" },
+                Text = text
+            }
+        };
+    }
+
+    private sealed class NoOpUpdateSource : IUpdateSource
+    {
+        public Task StartAsync(
+            Func<IUpdatePayload, CancellationToken, Task> updateHandler,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingDispatcher : IUpdateDispatcher
+    {
+        public int DispatchCount { get; private set; }
+
+        public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        {
+            DispatchCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private interface IMissingHandlerService;
+
+    private interface IMissingErrorHandlerService;
+
+    private sealed class HandlerWithMissingServiceParameter
+    {
+        [Command("start")]
+        public Task Handle(MessageContext context, IMissingHandlerService missing)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingMessageHandler
+    {
+        [Message]
+        public Task Handle(MessageContext context)
+        {
+            return Task.FromException(new InvalidOperationException("handler failed"));
+        }
+    }
+
+    private sealed class ErrorHandlerWithMissingServiceParameter
+    {
+        [Error<InvalidOperationException>]
+        public TelegramErrorHandlingResult Handle(
+            InvalidOperationException exception,
+            IMissingErrorHandlerService missing)
+        {
+            return TelegramErrorHandlingResult.Handled;
+        }
+    }
+
+    private sealed class HandlerWithMissingCustomFilter
+    {
+        [Message]
+        [UseFilter<MissingCustomFilter>]
+        public Task Handle(MessageContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MissingCustomFilter : ITelegramFilter<MessageContext>
+    {
+        public ValueTask<bool> MatchesAsync(
+            MessageContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(true);
+        }
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
@@ -111,6 +111,8 @@ public sealed class StageEightGeneratedRegistrationTests
         builder.Services.AddMemoryStateStorage();
         builder.Services.AddUpdateSource<GeneratedStateUpdateSource>();
         builder.Services.AddSingleton(probe);
+        builder.Services.AddSingleton<GeneratedAllowMessageFilter>();
+        builder.Services.AddSingleton<GeneratedRequireTextFilter>();
         builder.Services.AddTelegramHandlersFromAssembly(typeof(StageEightGeneratedRegistrationTests).Assembly);
 
         await using var application = builder.Build();
@@ -136,6 +138,8 @@ public sealed class StageEightGeneratedRegistrationTests
         builder.Services.AddMemoryStateStorage();
         builder.Services.AddUpdateSource<GeneratedStateUpdateSource>();
         builder.Services.AddSingleton(probe);
+        builder.Services.AddSingleton<GeneratedAllowMessageFilter>();
+        builder.Services.AddSingleton<GeneratedRequireTextFilter>();
         builder.Services.AddTelegramHandlersFromAssembly(typeof(StageEightGeneratedRegistrationTests).Assembly);
 
         await using var application = builder.Build();


### PR DESCRIPTION
## Summary
- add scoped Core and Telegram current-update accessors for application services
- validate handler method service parameters, Telegram error handler service parameters, and custom filters before update processing
- invoke runtime validation from normal runtime, borrowed-provider runtime, webhook mapping, and a defensive processor fallback
- document DI lifetimes, current update access, and missing dependency troubleshooting in EN/RU docs

## Touched hot paths
- `DefaultUpdateProcessor` now runs runtime validation once per processor instance and initializes the scoped current-update accessor before middleware dispatch.
- Handler dispatch remains on the existing descriptor/invoker path; dependency validation runs before update processing instead of during handler invocation.
- Webhook mapping invokes the same validation runner before accepting webhook updates.

## Validation
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "CurrentUpdateAccessorTests|RuntimeDependencyValidationTests" --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "PublicSurfaceTests|ProjectGraphTests" --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-restore`
- `dotnet build .\TeleFlow.sln --no-restore`
- `git diff --check`

Closes #37