### PR TITLE
feat(framework): add state key isolation contracts

### DIFF
--- a/docs/en/advanced/custom-storage.md
+++ b/docs/en/advanced/custom-storage.md
@@ -10,7 +10,8 @@ Core contracts:
 - `IStateDataStore`: key-value data for the current state key;
 - `IStateDataSerializer`: serialization for state data values;
 - `IStateHistoryStore`: wizard history;
-- `IStateKeyFactory`: maps an update to a state key.
+- `IStateKeyFactory`: maps an update to a structured state key;
+- `IStateStorageKeyBuilder`: builds stable external storage keys from structured state keys.
 
 ## Memory Storage
 
@@ -47,12 +48,34 @@ Use custom keys for:
 - business connection partitioning;
 - custom worker or gateway topologies.
 
+`IStateKeyFactory` should describe ownership and isolation. It should not contain Redis, SQL, or document-store formatting rules.
+
+## Custom Storage Key Builder
+
+Durable providers often need a string key. Use `IStateStorageKeyBuilder` for that conversion:
+
+```csharp
+builder.Services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
+```
+
+The default builder produces stable escaped keys for each state record family:
+
+```text
+teleflow:state:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:data:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:history:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:lock:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+```
+
+Memory storage does not need this conversion and continues to use `StateKey` directly.
+
 ## Storage Implementation Guidance
 
 Storage implementations should:
 
 - respect `CancellationToken`;
 - use deterministic keys;
+- keep state, data, history, and lock records isolated;
 - avoid swallowing serialization errors;
 - preserve wizard history ordering;
 - be safe under concurrent updates from the same user if your deployment allows it;

--- a/docs/en/features/state-and-wizard.md
+++ b/docs/en/features/state-and-wizard.md
@@ -173,10 +173,30 @@ Scenes are useful when a flow grows and state names need a stable structure.
 
 ## State Key
 
-Telegram state keys are created from Telegram context. For message and callback flows this keeps state scoped to the user and chat. Advanced applications can replace `IStateKeyFactory`.
+Telegram state keys are created from Telegram context. For message and callback flows this keeps state scoped to the user and chat. When TeleFlow can safely read the bot id from the bot token prefix, the default key also isolates state by bot. Message thread id and business connection id are included when Telegram provides them.
+
+The structured key has five parts:
+
+| Part | Meaning |
+| --- | --- |
+| `Namespace` | Application or storage namespace. Defaults to `teleflow`. |
+| `Scope` | Runtime or domain scope. Telegram uses `telegram`. |
+| `Subject` | State owner. Telegram message and callback flows use `user:{id}`. |
+| `Partition` | Additional isolation boundary, such as bot, chat, thread, business connection, or inline callback chat instance. |
+| `Destiny` | Optional state branch. Defaults to `default`. |
+
+Advanced applications can replace `IStateKeyFactory`:
 
 ```csharp
 builder.Services.AddStateKeyFactory<MyStateKeyFactory>();
 ```
 
 Use custom keys when business requirements need tenant-aware, bot-aware, or cross-chat state partitioning.
+
+Durable storage providers can also replace `IStateStorageKeyBuilder` when they need a different Redis, SQL, or document-store key format:
+
+```csharp
+builder.Services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
+```
+
+Memory storage keeps using the structured `StateKey` directly. String key building exists for storage providers that need stable external keys.

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -106,6 +106,7 @@ services.AddStateDataStore<MyStateDataStore>();
 services.AddStateDataSerializer<MySerializer>();
 services.AddStateHistoryStore<MyHistoryStore>();
 services.AddStateKeyFactory<MyStateKeyFactory>();
+services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
 ```
 
 Telegram framework:

--- a/docs/ru/advanced/custom-storage.md
+++ b/docs/ru/advanced/custom-storage.md
@@ -10,7 +10,8 @@ Core contracts:
 - `IStateDataStore`: key-value data для current state key;
 - `IStateDataSerializer`: serialization для state data values;
 - `IStateHistoryStore`: wizard history;
-- `IStateKeyFactory`: mapping update в state key.
+- `IStateKeyFactory`: mapping update в structured state key;
+- `IStateStorageKeyBuilder`: строит stable external storage keys из structured state keys.
 
 ## Memory storage
 
@@ -47,12 +48,34 @@ Custom keys нужны для:
 - business connection partitioning;
 - custom worker или gateway topologies.
 
+`IStateKeyFactory` должна описывать ownership и isolation. В неё не надо прятать Redis, SQL или document-store formatting rules.
+
+## Собственный storage key builder
+
+Durable providers часто нужен string key. Для этого используется `IStateStorageKeyBuilder`:
+
+```csharp
+builder.Services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
+```
+
+Default builder создаёт stable escaped keys для каждой группы state records:
+
+```text
+teleflow:state:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:data:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:history:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+teleflow:lock:scope=telegram:subject=user%3A5:partition=chat%3A100:destiny=default
+```
+
+Memory storage не нуждается в этой conversion и продолжает использовать `StateKey` напрямую.
+
 ## Рекомендации для реализации storage
 
 Storage implementations должны:
 
 - respect `CancellationToken`;
 - использовать deterministic keys;
+- изолировать state, data, history и lock records;
 - не swallow serialization errors;
 - сохранять wizard history ordering;
 - быть safe under concurrent updates от одного user, если deployment это допускает;

--- a/docs/ru/features/state-and-wizard.md
+++ b/docs/ru/features/state-and-wizard.md
@@ -173,10 +173,30 @@ Scenes полезны, когда flow растёт и state names нужна с
 
 ## State key
 
-Telegram state keys создаются из Telegram context. Для message и callback flows state остаётся scoped to user and chat. Advanced applications могут заменить `IStateKeyFactory`.
+Telegram state keys создаются из Telegram context. Для message и callback flows state остаётся scoped to user and chat. Если TeleFlow может безопасно прочитать bot id из prefix bot token, default key также изолирует state по bot. Message thread id и business connection id включаются, когда Telegram их присылает.
+
+Structured key состоит из пяти частей:
+
+| Часть | Значение |
+| --- | --- |
+| `Namespace` | Namespace приложения или storage. По умолчанию `teleflow`. |
+| `Scope` | Runtime или domain scope. Telegram использует `telegram`. |
+| `Subject` | Владелец state. Telegram message и callback flows используют `user:{id}`. |
+| `Partition` | Дополнительная граница изоляции: bot, chat, thread, business connection или inline callback chat instance. |
+| `Destiny` | Опциональная ветка state. По умолчанию `default`. |
+
+Advanced applications могут заменить `IStateKeyFactory`:
 
 ```csharp
 builder.Services.AddStateKeyFactory<MyStateKeyFactory>();
 ```
 
 Custom keys нужны, когда business requirements требуют tenant-aware, bot-aware или cross-chat state partitioning.
+
+Durable storage providers также могут заменить `IStateStorageKeyBuilder`, если им нужен другой формат Redis, SQL или document-store key:
+
+```csharp
+builder.Services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
+```
+
+Memory storage продолжает использовать structured `StateKey` напрямую. String key building существует для storage providers, которым нужны стабильные external keys.

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -106,6 +106,7 @@ services.AddStateDataStore<MyStateDataStore>();
 services.AddStateDataSerializer<MySerializer>();
 services.AddStateHistoryStore<MyHistoryStore>();
 services.AddStateKeyFactory<MyStateKeyFactory>();
+services.AddStateStorageKeyBuilder<MyStateStorageKeyBuilder>();
 ```
 
 Telegram framework:

--- a/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationBuilder.cs
+++ b/src/TeleFlow.Framework.Core/Application/TeleFlowApplicationBuilder.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TeleFlow.Framework.States;
 using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Framework.Application;
@@ -9,6 +11,7 @@ internal sealed class TeleFlowApplicationBuilder : ITeleFlowApplicationBuilder
     {
         Services = new ServiceCollection();
         Services.AddSingleton(new TeleFlowApplicationArguments(args));
+        Services.TryAddSingleton<IStateStorageKeyBuilder, DefaultStateStorageKeyBuilder>();
         Services.AddUpdateContextAccessor();
     }
 

--- a/src/TeleFlow.Framework.Core/DependencyInjection/PolicyServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework.Core/DependencyInjection/PolicyServiceCollectionExtensions.cs
@@ -90,6 +90,16 @@ public static class PolicyServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddStateStorageKeyBuilder<TBuilder>(this IServiceCollection services)
+        where TBuilder : class, IStateStorageKeyBuilder
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.RemoveAll<IStateStorageKeyBuilder>();
+        services.AddSingleton<IStateStorageKeyBuilder, TBuilder>();
+        return services;
+    }
+
     public static IServiceCollection AddUpdateRateLimiter<TLimiter>(this IServiceCollection services)
         where TLimiter : class, IUpdateRateLimiter
     {

--- a/src/TeleFlow.Framework.Core/States/DefaultStateStorageKeyBuilder.cs
+++ b/src/TeleFlow.Framework.Core/States/DefaultStateStorageKeyBuilder.cs
@@ -1,0 +1,39 @@
+namespace TeleFlow.Framework.States;
+
+/// <summary>
+/// Builds deterministic string keys from <see cref="StateKey"/> for durable state providers while
+/// preserving the structured state ownership model used by the runtime pipeline.
+/// </summary>
+public sealed class DefaultStateStorageKeyBuilder : IStateStorageKeyBuilder
+{
+    public string Build(StateKey key, StateStorageKeyPart part)
+    {
+        return string.Join(
+            ":",
+            Escape(key.Namespace),
+            FormatPart(part),
+            $"scope={Escape(key.Scope)}",
+            $"subject={Escape(key.Subject)}",
+            $"partition={Escape(key.Partition)}",
+            $"destiny={Escape(key.Destiny)}");
+    }
+
+    private static string FormatPart(StateStorageKeyPart part)
+    {
+        return part switch
+        {
+            StateStorageKeyPart.State => "state",
+            StateStorageKeyPart.Data => "data",
+            StateStorageKeyPart.History => "history",
+            StateStorageKeyPart.Lock => "lock",
+            _ => throw new ArgumentOutOfRangeException(nameof(part), part, "Unknown state storage key part.")
+        };
+    }
+
+    private static string Escape(string? value)
+    {
+        return value is null
+            ? string.Empty
+            : Uri.EscapeDataString(value);
+    }
+}

--- a/src/TeleFlow.Framework.Core/States/IStateStorageKeyBuilder.cs
+++ b/src/TeleFlow.Framework.Core/States/IStateStorageKeyBuilder.cs
@@ -1,0 +1,10 @@
+namespace TeleFlow.Framework.States;
+
+/// <summary>
+/// Converts structured state keys into deterministic storage keys for providers that address
+/// state records with strings, such as Redis, SQL rows, or document-store partition keys.
+/// </summary>
+public interface IStateStorageKeyBuilder
+{
+    string Build(StateKey key, StateStorageKeyPart part);
+}

--- a/src/TeleFlow.Framework.Core/States/StateKey.cs
+++ b/src/TeleFlow.Framework.Core/States/StateKey.cs
@@ -1,19 +1,104 @@
 namespace TeleFlow.Framework.States;
 
-public readonly record struct StateKey(string Scope, string Subject, string? Partition = null)
+/// <summary>
+/// Identifies the owner and isolation boundary of state records used by state stores, state data,
+/// wizard history, and future storage-backed coordination primitives.
+/// </summary>
+public readonly record struct StateKey(
+    string Namespace,
+    string Scope,
+    string Subject,
+    string? Partition,
+    string Destiny)
 {
+    private readonly string _namespace = ValidateRequired(Namespace, nameof(Namespace));
+    private readonly string _scope = ValidateRequired(Scope, nameof(Scope));
+    private readonly string _subject = ValidateRequired(Subject, nameof(Subject));
+    private readonly string? _partition = ValidateOptional(Partition, nameof(Partition));
+    private readonly string _destiny = ValidateRequired(Destiny, nameof(Destiny));
+
+    public StateKey(string scope, string subject)
+        : this(
+            StateKeyDefaults.DefaultNamespace,
+            scope,
+            subject,
+            null,
+            StateKeyDefaults.DefaultDestiny)
+    {
+    }
+
+    public StateKey(string scope, string subject, string? partition)
+        : this(
+            StateKeyDefaults.DefaultNamespace,
+            scope,
+            subject,
+            partition,
+            StateKeyDefaults.DefaultDestiny)
+    {
+    }
+
+    public string Namespace
+    {
+        get => _namespace;
+        init => _namespace = ValidateRequired(value, nameof(Namespace));
+    }
+
+    public string Scope
+    {
+        get => _scope;
+        init => _scope = ValidateRequired(value, nameof(Scope));
+    }
+
+    public string Subject
+    {
+        get => _subject;
+        init => _subject = ValidateRequired(value, nameof(Subject));
+    }
+
+    public string? Partition
+    {
+        get => _partition;
+        init => _partition = ValidateOptional(value, nameof(Partition));
+    }
+
+    public string Destiny
+    {
+        get => _destiny;
+        init => _destiny = ValidateRequired(value, nameof(Destiny));
+    }
+
     public static StateKey Create(string scope, string subject, string? partition = null)
     {
-        if (string.IsNullOrWhiteSpace(scope))
-        {
-            throw new ArgumentException("Scope must be provided.", nameof(scope));
-        }
-
-        if (string.IsNullOrWhiteSpace(subject))
-        {
-            throw new ArgumentException("Subject must be provided.", nameof(subject));
-        }
-
         return new StateKey(scope, subject, partition);
+    }
+
+    public static StateKey Create(
+        string keyNamespace,
+        string scope,
+        string subject,
+        string? partition,
+        string destiny)
+    {
+        return new StateKey(keyNamespace, scope, subject, partition, destiny);
+    }
+
+    private static string ValidateRequired(string? value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{parameterName} must be provided.", parameterName);
+        }
+
+        return value;
+    }
+
+    private static string? ValidateOptional(string? value, string parameterName)
+    {
+        if (value is not null && string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{parameterName} must be null or non-empty.", parameterName);
+        }
+
+        return value;
     }
 }

--- a/src/TeleFlow.Framework.Core/States/StateKeyDefaults.cs
+++ b/src/TeleFlow.Framework.Core/States/StateKeyDefaults.cs
@@ -1,0 +1,12 @@
+namespace TeleFlow.Framework.States;
+
+/// <summary>
+/// Defines stable default state-key segments used when an application does not provide
+/// custom namespace or destiny isolation.
+/// </summary>
+public static class StateKeyDefaults
+{
+    public const string DefaultNamespace = "teleflow";
+
+    public const string DefaultDestiny = "default";
+}

--- a/src/TeleFlow.Framework.Core/States/StateStorageKeyPart.cs
+++ b/src/TeleFlow.Framework.Core/States/StateStorageKeyPart.cs
@@ -1,0 +1,13 @@
+namespace TeleFlow.Framework.States;
+
+/// <summary>
+/// Names the logical storage record family derived from a state key so durable providers can
+/// keep current state, state data, wizard history, and future locks isolated consistently.
+/// </summary>
+public enum StateStorageKeyPart
+{
+    State,
+    Data,
+    History,
+    Lock
+}

--- a/src/TeleFlow.Framework/Internal/Options/TelegramStateKeyOptions.cs
+++ b/src/TeleFlow.Framework/Internal/Options/TelegramStateKeyOptions.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace TeleFlow.Telegram.Internal.Options;
+
+/// <summary>
+/// Stores Telegram-specific state-key settings resolved during Telegram framework registration,
+/// before updates reach state middleware and handler dispatch.
+/// </summary>
+internal sealed record class TelegramStateKeyOptions(long? BotId)
+{
+    public static TelegramStateKeyOptions FromToken(string token)
+    {
+        return TryResolveBotId(token, out var botId)
+            ? new TelegramStateKeyOptions(botId)
+            : new TelegramStateKeyOptions(BotId: null);
+    }
+
+    private static bool TryResolveBotId(string token, out long botId)
+    {
+        botId = default;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var separatorIndex = token.IndexOf(':', StringComparison.Ordinal);
+
+        return separatorIndex > 0 &&
+            long.TryParse(
+                token.AsSpan(0, separatorIndex),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out botId);
+    }
+}

--- a/src/TeleFlow.Framework/Internal/TelegramStateKeyFactory.cs
+++ b/src/TeleFlow.Framework/Internal/TelegramStateKeyFactory.cs
@@ -1,11 +1,21 @@
 using TeleFlow.Framework.States;
 using TeleFlow.Framework.Updates;
+using TeleFlow.Telegram.Internal.Options;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal;
 
 internal sealed class TelegramStateKeyFactory : IStateKeyFactory
 {
+    private readonly string? _botPartitionSegment;
+
+    public TelegramStateKeyFactory(TelegramStateKeyOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _botPartitionSegment = options.BotId is { } botId ? $"bot:{botId}" : null;
+    }
+
     public bool TryCreateStateKey(UpdateContext context, out StateKey key)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -26,7 +36,7 @@ internal sealed class TelegramStateKeyFactory : IStateKeyFactory
         return false;
     }
 
-    private static bool TryCreateFromMessage(Message? message, out StateKey key)
+    private bool TryCreateFromMessage(Message? message, out StateKey key)
     {
         if (message?.From is null)
         {
@@ -37,11 +47,11 @@ internal sealed class TelegramStateKeyFactory : IStateKeyFactory
         key = StateKey.Create(
             scope: "telegram",
             subject: CreateUserSubject(message.From.Id),
-            partition: CreateChatPartition(message.Chat.Id));
+            partition: CreateMessagePartition(message));
         return true;
     }
 
-    private static bool TryCreateFromCallback(CallbackQuery? callbackQuery, out StateKey key)
+    private bool TryCreateFromCallback(CallbackQuery? callbackQuery, out StateKey key)
     {
         if (callbackQuery is null)
         {
@@ -56,13 +66,13 @@ internal sealed class TelegramStateKeyFactory : IStateKeyFactory
         return true;
     }
 
-    private static string ResolveCallbackPartition(CallbackQuery callbackQuery)
+    private string ResolveCallbackPartition(CallbackQuery callbackQuery)
     {
         if (callbackQuery.Message is not null)
         {
             if (callbackQuery.Message.TryGetMessage(out var message) && message is not null)
             {
-                return CreateChatPartition(message.Chat.Id);
+                return CreateMessagePartition(message);
             }
 
             if (callbackQuery.Message.TryGetInaccessibleMessage(out var inaccessibleMessage) &&
@@ -73,8 +83,8 @@ internal sealed class TelegramStateKeyFactory : IStateKeyFactory
         }
 
         return string.IsNullOrWhiteSpace(callbackQuery.ChatInstance)
-            ? "inline:unknown"
-            : $"inline:{callbackQuery.ChatInstance}";
+            ? CreateInlinePartition("unknown")
+            : CreateInlinePartition(callbackQuery.ChatInstance);
     }
 
     private static string CreateUserSubject(long userId)
@@ -82,8 +92,52 @@ internal sealed class TelegramStateKeyFactory : IStateKeyFactory
         return $"user:{userId}";
     }
 
-    private static string CreateChatPartition(long chatId)
+    private string CreateMessagePartition(Message message)
     {
-        return $"chat:{chatId}";
+        var segments = CreatePartitionSegments(capacity: 4);
+
+        if (!string.IsNullOrWhiteSpace(message.BusinessConnectionId))
+        {
+            segments.Add($"business:{message.BusinessConnectionId}");
+        }
+
+        segments.Add($"chat:{message.Chat.Id}");
+
+        if (message.MessageThreadId is not null)
+        {
+            segments.Add($"thread:{message.MessageThreadId.Value}");
+        }
+
+        return string.Join(':', segments);
+    }
+
+    private string CreateChatPartition(long chatId)
+    {
+        var segments = CreatePartitionSegments(capacity: 2);
+
+        segments.Add($"chat:{chatId}");
+
+        return string.Join(':', segments);
+    }
+
+    private string CreateInlinePartition(string chatInstance)
+    {
+        var segments = CreatePartitionSegments(capacity: 2);
+
+        segments.Add($"inline:{chatInstance}");
+
+        return string.Join(':', segments);
+    }
+
+    private List<string> CreatePartitionSegments(int capacity)
+    {
+        var segments = new List<string>(capacity);
+
+        if (_botPartitionSegment is not null)
+        {
+            segments.Add(_botPartitionSegment);
+        }
+
+        return segments;
     }
 }

--- a/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class TelegramServiceCollectionExtensions
         var options = new TelegramBotOptions();
         configure(options);
         TelegramBotOptionsValidator.Validate(options);
+        var stateKeyOptions = TelegramStateKeyOptions.FromToken(options.Token);
 
         services.AddTelegramClient(clientOptions =>
         {
@@ -46,10 +47,12 @@ public static class TelegramServiceCollectionExtensions
         });
 
         services.AddSingleton(options);
+        services.AddSingleton(stateKeyOptions);
         services.AddUpdateContextAccessor();
         services.TryAddSingleton(options.RoleFilter);
         services.AddSingleton<TelegramContextFactory>();
         services.TryAddScoped<ITelegramCurrentUpdateAccessor, TelegramCurrentUpdateAccessor>();
+        services.TryAddSingleton<IStateStorageKeyBuilder, DefaultStateStorageKeyBuilder>();
         services.TryAddSingleton<IStateKeyFactory, TelegramStateKeyFactory>();
         services.TryAddSingleton<ICallbackDataSerializer, JsonCallbackDataSerializer>();
         services.TryAddSingleton<ITelegramChatMemberStatusResolver, TelegramChatMemberStatusResolver>();

--- a/src/TeleFlow.Storage.Memory/MemoryStateServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Storage.Memory/MemoryStateServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class MemoryStateServiceCollectionExtensions
         services.TryAddSingleton<IStateDataStore, MemoryStateDataStore>();
         services.TryAddSingleton<IStateDataSerializer, JsonStateDataSerializer>();
         services.TryAddSingleton<IStateHistoryStore, MemoryStateHistoryStore>();
+        services.TryAddSingleton<IStateStorageKeyBuilder, DefaultStateStorageKeyBuilder>();
         services.AddUpdateMiddleware<UpdateStateMiddleware>();
 
         return services;

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -495,11 +495,13 @@ public sealed class StageSixStateAndMiddlewareTests
         var customDataStore = new RecordingStateDataStore();
         var customSerializer = new RecordingStateDataSerializer();
         var customHistoryStore = new RecordingStateHistoryStore();
+        var customKeyBuilder = new RecordingStateStorageKeyBuilder();
 
         services.AddSingleton<IStateStore>(customStore);
         services.AddSingleton<IStateDataStore>(customDataStore);
         services.AddSingleton<IStateDataSerializer>(customSerializer);
         services.AddSingleton<IStateHistoryStore>(customHistoryStore);
+        services.AddSingleton<IStateStorageKeyBuilder>(customKeyBuilder);
         services.AddSingleton<IStateKeyFactory>(new StaticStateKeyFactory(StateKey.Create("scope", "subject")));
         services.AddMemoryStateStorage();
 
@@ -513,6 +515,7 @@ public sealed class StageSixStateAndMiddlewareTests
         Assert.Same(customDataStore, serviceProvider.GetRequiredService<IStateDataStore>());
         Assert.Same(customSerializer, serviceProvider.GetRequiredService<IStateDataSerializer>());
         Assert.Same(customHistoryStore, serviceProvider.GetRequiredService<IStateHistoryStore>());
+        Assert.Same(customKeyBuilder, serviceProvider.GetRequiredService<IStateStorageKeyBuilder>());
         Assert.Contains(
             serviceProvider.GetServices<UpdateMiddlewareRegistration>(),
             registration => registration.MiddlewareType == typeof(UpdateStateMiddleware));
@@ -653,6 +656,59 @@ public sealed class StageSixStateAndMiddlewareTests
         Assert.NotEqual(first, sameUserDifferentChat);
         Assert.NotEqual(first, sameChatDifferentUser);
         Assert.Equal(StateKey.Create("telegram", "user:5", "inline:inline-chat"), inlineCallback);
+    }
+
+    [Fact]
+    public void TelegramStateKeyFactory_IncludesBotThreadAndBusinessIsolationWhenAvailable()
+    {
+        using var serviceProvider = CreateTelegramServiceProvider(
+            static _ => { },
+            token: "777:secret");
+        using var scope = serviceProvider.CreateScope();
+        var factory = serviceProvider.GetRequiredService<IStateKeyFactory>();
+
+        var key = CreateStateKey(
+            factory,
+            scope.ServiceProvider,
+            CreateMessageUpdate(
+                "business",
+                userId: 5,
+                chatId: 100,
+                messageThreadId: 45,
+                businessConnectionId: "bc-1"));
+
+        Assert.Equal(
+            new StateKey(
+                StateKeyDefaults.DefaultNamespace,
+                "telegram",
+                "user:5",
+                "bot:777:business:bc-1:chat:100:thread:45",
+                StateKeyDefaults.DefaultDestiny),
+            key);
+    }
+
+    [Fact]
+    public void TelegramStateKeyFactory_IsolatesInlineCallbacksByBotAndChatInstance()
+    {
+        using var serviceProvider = CreateTelegramServiceProvider(
+            static _ => { },
+            token: "777:secret");
+        using var scope = serviceProvider.CreateScope();
+        var factory = serviceProvider.GetRequiredService<IStateKeyFactory>();
+
+        var key = CreateStateKey(
+            factory,
+            scope.ServiceProvider,
+            CreateCallbackUpdate("data", userId: 5, chatId: null, chatInstance: "inline-chat"));
+
+        Assert.Equal(
+            new StateKey(
+                StateKeyDefaults.DefaultNamespace,
+                "telegram",
+                "user:5",
+                "bot:777:inline:inline-chat",
+                StateKeyDefaults.DefaultDestiny),
+            key);
     }
 
     [Fact]
@@ -868,10 +924,12 @@ public sealed class StageSixStateAndMiddlewareTests
         Assert.Equal(["rate-limit", "dispatch"], trace);
     }
 
-    private static ServiceProvider CreateTelegramServiceProvider(Action<IServiceCollection> configureServices)
+    private static ServiceProvider CreateTelegramServiceProvider(
+        Action<IServiceCollection> configureServices,
+        string token = "test-token")
     {
         var services = new ServiceCollection();
-        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddTelegramBot(options => options.Token = token);
         configureServices(services);
 
         return services.BuildServiceProvider(new ServiceProviderOptions
@@ -958,7 +1016,12 @@ public sealed class StageSixStateAndMiddlewareTests
         return key;
     }
 
-    private static Update CreateMessageUpdate(string text, long userId, long chatId)
+    private static Update CreateMessageUpdate(
+        string text,
+        long userId,
+        long chatId,
+        long? messageThreadId = null,
+        string? businessConnectionId = null)
     {
         return new Update
         {
@@ -967,6 +1030,8 @@ public sealed class StageSixStateAndMiddlewareTests
             {
                 MessageId = 10,
                 Date = 0,
+                MessageThreadId = messageThreadId,
+                BusinessConnectionId = businessConnectionId,
                 From = new User
                 {
                     Id = userId,
@@ -1428,6 +1493,14 @@ public sealed class StageSixStateAndMiddlewareTests
             CancellationToken cancellationToken = default)
         {
             return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingStateStorageKeyBuilder : IStateStorageKeyBuilder
+    {
+        public string Build(StateKey key, StateStorageKeyPart part)
+        {
+            return $"{key.Namespace}:{part}";
         }
     }
 

--- a/tests/TeleFlow.ArchitectureTests/StateKeyContractTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StateKeyContractTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Framework.DependencyInjection;
+using TeleFlow.Framework.States;
+
+namespace TeleFlow.ArchitectureTests;
+
+public sealed class StateKeyContractTests
+{
+    [Fact]
+    public void Create_UsesDefaultNamespaceAndDestinyForExistingThreePartShape()
+    {
+        var key = StateKey.Create("telegram", "user:5", "chat:100");
+
+        Assert.Equal(StateKeyDefaults.DefaultNamespace, key.Namespace);
+        Assert.Equal("telegram", key.Scope);
+        Assert.Equal("user:5", key.Subject);
+        Assert.Equal("chat:100", key.Partition);
+        Assert.Equal(StateKeyDefaults.DefaultDestiny, key.Destiny);
+    }
+
+    [Fact]
+    public void Constructor_StoresExplicitIsolationDimensions()
+    {
+        var key = new StateKey(
+            "support-desk",
+            "telegram",
+            "user:5",
+            "bot:777:chat:100",
+            "quiz");
+
+        Assert.Equal("support-desk", key.Namespace);
+        Assert.Equal("telegram", key.Scope);
+        Assert.Equal("user:5", key.Subject);
+        Assert.Equal("bot:777:chat:100", key.Partition);
+        Assert.Equal("quiz", key.Destiny);
+    }
+
+    [Theory]
+    [InlineData("", "telegram", "user:5", "chat:100", "default")]
+    [InlineData(" ", "telegram", "user:5", "chat:100", "default")]
+    [InlineData("teleflow", "", "user:5", "chat:100", "default")]
+    [InlineData("teleflow", " ", "user:5", "chat:100", "default")]
+    [InlineData("teleflow", "telegram", "", "chat:100", "default")]
+    [InlineData("teleflow", "telegram", " ", "chat:100", "default")]
+    [InlineData("teleflow", "telegram", "user:5", " ", "default")]
+    [InlineData("teleflow", "telegram", "user:5", "chat:100", "")]
+    [InlineData("teleflow", "telegram", "user:5", "chat:100", " ")]
+    public void Constructor_RejectsInvalidIsolationDimensions(
+        string keyNamespace,
+        string scope,
+        string subject,
+        string? partition,
+        string destiny)
+    {
+        Assert.Throws<ArgumentException>(() => new StateKey(
+            keyNamespace,
+            scope,
+            subject,
+            partition,
+            destiny));
+    }
+
+    [Fact]
+    public void WithExpression_RejectsInvalidIsolationDimensions()
+    {
+        var key = StateKey.Create("telegram", "user:5", "chat:100");
+
+        Assert.Throws<ArgumentException>(() => key with { Namespace = " " });
+        Assert.Throws<ArgumentException>(() => key with { Scope = " " });
+        Assert.Throws<ArgumentException>(() => key with { Subject = " " });
+        Assert.Throws<ArgumentException>(() => key with { Partition = " " });
+        Assert.Throws<ArgumentException>(() => key with { Destiny = " " });
+    }
+
+    [Theory]
+    [InlineData(StateStorageKeyPart.State, "support-desk:state:scope=telegram:subject=user%3A5:partition=bot%3A777%3Achat%3A100:destiny=quiz")]
+    [InlineData(StateStorageKeyPart.Data, "support-desk:data:scope=telegram:subject=user%3A5:partition=bot%3A777%3Achat%3A100:destiny=quiz")]
+    [InlineData(StateStorageKeyPart.History, "support-desk:history:scope=telegram:subject=user%3A5:partition=bot%3A777%3Achat%3A100:destiny=quiz")]
+    [InlineData(StateStorageKeyPart.Lock, "support-desk:lock:scope=telegram:subject=user%3A5:partition=bot%3A777%3Achat%3A100:destiny=quiz")]
+    public void DefaultStateStorageKeyBuilder_BuildsStableEscapedKeys(
+        StateStorageKeyPart part,
+        string expected)
+    {
+        var key = new StateKey(
+            "support-desk",
+            "telegram",
+            "user:5",
+            "bot:777:chat:100",
+            "quiz");
+        var builder = new DefaultStateStorageKeyBuilder();
+
+        Assert.Equal(expected, builder.Build(key, part));
+    }
+
+    [Fact]
+    public void DefaultStateStorageKeyBuilder_PreservesNullPartitionAsCanonicalEmptySegment()
+    {
+        var key = new StateKey(
+            "support-desk",
+            "telegram",
+            "user:5",
+            null,
+            StateKeyDefaults.DefaultDestiny);
+        var builder = new DefaultStateStorageKeyBuilder();
+
+        Assert.Equal(
+            "support-desk:state:scope=telegram:subject=user%3A5:partition=:destiny=default",
+            builder.Build(key, StateStorageKeyPart.State));
+    }
+
+    [Fact]
+    public void StateStorageKeyBuilderPolicy_ReplacesExistingBuilder()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IStateStorageKeyBuilder, DefaultStateStorageKeyBuilder>();
+        services.AddStateStorageKeyBuilder<CustomStateStorageKeyBuilder>();
+
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.IsType<CustomStateStorageKeyBuilder>(
+            serviceProvider.GetRequiredService<IStateStorageKeyBuilder>());
+    }
+
+    private sealed class CustomStateStorageKeyBuilder : IStateStorageKeyBuilder
+    {
+        public string Build(StateKey key, StateStorageKeyPart part)
+        {
+            return $"{key.Namespace}:{part}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand `StateKey` into a structured isolation model with namespace, scope, subject, partition, and destiny
- add `IStateStorageKeyBuilder` and the default stable string key builder for durable storage providers
- keep memory storage on structured `StateKey` while registering the default builder for provider implementations
- resolve Telegram bot id once during `AddTelegramBot(...)` and use it in default Telegram state partitioning when available
- include Telegram business connection, message thread, chat, and inline callback isolation in the default state key factory
- document state key isolation and storage key customization in EN/RU docs

## Touched hot paths
- `UpdateStateMiddleware` still receives a `StateKey` from `IStateKeyFactory`; state middleware flow is unchanged.
- `TelegramStateKeyFactory` now builds richer partitions, but token parsing is done once during Telegram service registration through internal `TelegramStateKeyOptions`.
- Memory stores continue using `StateKey` directly as dictionary keys and do not format string keys on normal state operations.

## Validation
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "StateKeyContractTests|StageSixStateAndMiddlewareTests|StateStorageContracts" --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "PublicSurfaceTests|PackageSmokeTests" --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "StateKeyContractTests|TelegramStateKeyFactory|StageSixStateAndMiddlewareTests" --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-restore`
- `dotnet build .\TeleFlow.sln --no-restore`
- `git diff --check`

Closes #30