### PR TITLE
feat(framework): add command prefix modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- Added `CommandPrefixMode` for `[Command]`, `[CommandTemplate]`, and `[CommandRegex]` routes, allowing command prefixes to be required, optional, or disabled for prefix-less command-shaped text.
+
+### Changed
+
+- Generated handler metadata now carries command prefix mode when a route opts into non-default command prefix behavior.
 
 ## 1.0.0-alpha.7 - 2026-07-01
 

--- a/docs/en/fundamentals/handlers-and-routing.md
+++ b/docs/en/fundamentals/handlers-and-routing.md
@@ -17,6 +17,39 @@ public sealed class StartHandler
 
 `[Command("start")]` matches `/start` by default. The command prefix can be changed through attribute properties.
 
+Command prefix matching is explicit. The default is `CommandPrefixMode.Required`,
+which means the user must send `/start` or another configured prefix:
+
+```csharp
+[Command("start", Prefixes = new[] { "/", "!" })]
+public Task Start(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Welcome.", ct);
+}
+```
+
+Use `CommandPrefixMode.Optional` when the same route should accept both a
+Telegram command and prefix-less command-like text:
+
+```csharp
+[Command("help", PrefixMode = CommandPrefixMode.Optional)]
+public Task Help(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Help.", ct);
+}
+```
+
+Use `CommandPrefixMode.NoPrefix` when you want command routing semantics, but
+only for prefix-less text:
+
+```csharp
+[Command("help", PrefixMode = CommandPrefixMode.NoPrefix)]
+public Task HelpText(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Help.", ct);
+}
+```
+
 ## Text Handler
 
 ```csharp
@@ -51,6 +84,26 @@ public Task ShowTicket(MessageContext ctx, long id, CancellationToken ct)
     return ctx.Message.AnswerAsync($"Ticket #{id}", ct);
 }
 ```
+
+The template describes the command body, not the prefix. Write
+`[CommandTemplate("ticket {id:long}")]`, not
+`[CommandTemplate("/ticket {id:long}")]`.
+
+If you need to support both `/ticket 42` and `ticket 42`, keep one handler and
+make the prefix optional:
+
+```csharp
+[CommandTemplate(
+    "ticket {id:long}",
+    PrefixMode = CommandPrefixMode.Optional)]
+public Task ShowTicket(MessageContext ctx, long id, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync($"Ticket #{id}", ct);
+}
+```
+
+This replaces the old workaround where the same method had both
+`[CommandTemplate]` and `[TextTemplate]`.
 
 Text templates work without a command prefix:
 

--- a/docs/en/reference/attributes.md
+++ b/docs/en/reference/attributes.md
@@ -20,7 +20,7 @@ This page summarizes public handler metadata attributes.
 
 ## Route Options
 
-`[Command]` and `[CommandTemplate]` default to `/` commands and case-insensitive matching:
+`[Command]`, `[CommandTemplate]`, and `[CommandRegex]` default to `/` commands and case-insensitive matching:
 
 ```csharp
 [Command("start")]
@@ -33,6 +33,23 @@ You can configure prefixes when your bot accepts command-like text from another 
 [Command("start", Prefixes = new[] { "/", "!" }, AllowSpaceAfterPrefix = true)]
 public Task Start(MessageContext ctx, CancellationToken ct) { ... }
 ```
+
+Use `PrefixMode` when prefix-less text should be handled as command-shaped input:
+
+```csharp
+[CommandTemplate(
+    "ticket {id:long}",
+    PrefixMode = CommandPrefixMode.Optional)]
+public Task Ticket(MessageContext ctx, long id, CancellationToken ct) { ... }
+```
+
+Available `CommandPrefixMode` values are:
+
+| Value | Behavior |
+| --- | --- |
+| `Required` | Requires one of the configured prefixes. This is the default. |
+| `Optional` | Accepts a configured prefix or no prefix. |
+| `NoPrefix` | Accepts only prefix-less text. Do not combine it with `Prefixes`. |
 
 `[Text]` supports explicit match modes:
 

--- a/docs/ru/fundamentals/handlers-and-routing.md
+++ b/docs/ru/fundamentals/handlers-and-routing.md
@@ -17,6 +17,40 @@ public sealed class StartHandler
 
 `[Command("start")]` по умолчанию матчится на `/start`. Command prefix можно менять через свойства атрибута.
 
+Матчинг command prefix явный. По умолчанию используется
+`CommandPrefixMode.Required`: пользователь должен отправить `/start` или другую
+настроенную prefix-команду:
+
+```csharp
+[Command("start", Prefixes = new[] { "/", "!" })]
+public Task Start(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Welcome.", ct);
+}
+```
+
+Если один route должен принимать и Telegram command, и текст без prefix,
+используй `CommandPrefixMode.Optional`:
+
+```csharp
+[Command("help", PrefixMode = CommandPrefixMode.Optional)]
+public Task Help(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Help.", ct);
+}
+```
+
+Если нужна command route-семантика, но только для текста без prefix, используй
+`CommandPrefixMode.NoPrefix`:
+
+```csharp
+[Command("help", PrefixMode = CommandPrefixMode.NoPrefix)]
+public Task HelpText(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Help.", ct);
+}
+```
+
 ## Text handler
 
 ```csharp
@@ -51,6 +85,26 @@ public Task ShowTicket(MessageContext ctx, long id, CancellationToken ct)
     return ctx.Message.AnswerAsync($"Ticket #{id}", ct);
 }
 ```
+
+Template описывает command body, а не prefix. Пиши
+`[CommandTemplate("ticket {id:long}")]`, а не
+`[CommandTemplate("/ticket {id:long}")]`.
+
+Если нужно поддержать и `/ticket 42`, и `ticket 42`, оставь один handler и
+сделай prefix optional:
+
+```csharp
+[CommandTemplate(
+    "ticket {id:long}",
+    PrefixMode = CommandPrefixMode.Optional)]
+public Task ShowTicket(MessageContext ctx, long id, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync($"Ticket #{id}", ct);
+}
+```
+
+Это заменяет старый workaround, где на один method вешались и
+`[CommandTemplate]`, и `[TextTemplate]`.
 
 Text templates работают без command prefix:
 

--- a/docs/ru/reference/attributes.md
+++ b/docs/ru/reference/attributes.md
@@ -20,7 +20,7 @@
 
 ## Настройки route attributes
 
-`[Command]` и `[CommandTemplate]` по умолчанию работают с `/` commands и case-insensitive matching:
+`[Command]`, `[CommandTemplate]` и `[CommandRegex]` по умолчанию работают с `/` commands и case-insensitive matching:
 
 ```csharp
 [Command("start")]
@@ -33,6 +33,23 @@ Prefixes можно настроить, если бот принимает comma
 [Command("start", Prefixes = new[] { "/", "!" }, AllowSpaceAfterPrefix = true)]
 public Task Start(MessageContext ctx, CancellationToken ct) { ... }
 ```
+
+`PrefixMode` нужен, когда текст без prefix должен обрабатываться как command-shaped input:
+
+```csharp
+[CommandTemplate(
+    "ticket {id:long}",
+    PrefixMode = CommandPrefixMode.Optional)]
+public Task Ticket(MessageContext ctx, long id, CancellationToken ct) { ... }
+```
+
+Доступные значения `CommandPrefixMode`:
+
+| Value | Behavior |
+| --- | --- |
+| `Required` | Требует один из настроенных prefixes. Это значение по умолчанию. |
+| `Optional` | Принимает настроенный prefix или текст без prefix. |
+| `NoPrefix` | Принимает только текст без prefix. Не комбинируй с `Prefixes`. |
 
 `[Text]` поддерживает явный match mode:
 

--- a/src/TeleFlow.Annotations/Routing/CommandAttribute.cs
+++ b/src/TeleFlow.Annotations/Routing/CommandAttribute.cs
@@ -26,6 +26,11 @@ public sealed class CommandAttribute : TeleFlowAttribute
     public string[] Prefixes { get; set; } = ["/"];
 
     /// <summary>
+    /// Defines whether the command prefix is required, optional, or disabled for this route.
+    /// </summary>
+    public CommandPrefixMode PrefixMode { get; set; } = CommandPrefixMode.Required;
+
+    /// <summary>
     /// Allows whitespace between the prefix and command name.
     /// </summary>
     public bool AllowSpaceAfterPrefix { get; set; }

--- a/src/TeleFlow.Annotations/Routing/CommandPrefixMode.cs
+++ b/src/TeleFlow.Annotations/Routing/CommandPrefixMode.cs
@@ -1,0 +1,22 @@
+namespace TeleFlow.Annotations;
+
+/// <summary>
+/// Defines whether a command route requires, accepts, or ignores a command prefix before matching the command body.
+/// </summary>
+public enum CommandPrefixMode
+{
+    /// <summary>
+    /// The incoming message must start with one of the configured command prefixes.
+    /// </summary>
+    Required = 0,
+
+    /// <summary>
+    /// The incoming message may start with one of the configured command prefixes, but prefix-less text is accepted too.
+    /// </summary>
+    Optional = 1,
+
+    /// <summary>
+    /// The incoming message is matched as command body text and configured command prefixes are not accepted.
+    /// </summary>
+    NoPrefix = 2
+}

--- a/src/TeleFlow.Annotations/Routing/CommandRegexAttribute.cs
+++ b/src/TeleFlow.Annotations/Routing/CommandRegexAttribute.cs
@@ -26,6 +26,11 @@ public sealed class CommandRegexAttribute : TeleFlowAttribute
     public string[] Prefixes { get; set; } = ["/"];
 
     /// <summary>
+    /// Defines whether the command prefix is required, optional, or disabled for this route.
+    /// </summary>
+    public CommandPrefixMode PrefixMode { get; set; } = CommandPrefixMode.Required;
+
+    /// <summary>
     /// Allows whitespace between the prefix and command body.
     /// </summary>
     public bool AllowSpaceAfterPrefix { get; set; }

--- a/src/TeleFlow.Annotations/Routing/CommandTemplateAttribute.cs
+++ b/src/TeleFlow.Annotations/Routing/CommandTemplateAttribute.cs
@@ -26,6 +26,11 @@ public sealed class CommandTemplateAttribute : TeleFlowAttribute
     public string[] Prefixes { get; set; } = ["/"];
 
     /// <summary>
+    /// Defines whether the command prefix is required, optional, or disabled for this route.
+    /// </summary>
+    public CommandPrefixMode PrefixMode { get; set; } = CommandPrefixMode.Required;
+
+    /// <summary>
     /// Allows whitespace between the prefix and command body.
     /// </summary>
     public bool AllowSpaceAfterPrefix { get; set; }

--- a/src/TeleFlow.Framework/Generated/TelegramGeneratedHandlerDescriptor.cs
+++ b/src/TeleFlow.Framework/Generated/TelegramGeneratedHandlerDescriptor.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using TeleFlow.Annotations;
 
 namespace TeleFlow.Telegram;
 
@@ -189,7 +190,8 @@ public sealed class TelegramGeneratedHandlerDescriptor
         TelegramGeneratedHandlerInvoker invoker,
         string? sceneName = null,
         IReadOnlyList<TelegramGeneratedRouteValueDescriptor>? routeValues = null,
-        TelegramGeneratedAutoAnswerCallbackDescriptor? autoAnswerCallback = null)
+        TelegramGeneratedAutoAnswerCallbackDescriptor? autoAnswerCallback = null,
+        CommandPrefixMode prefixMode = CommandPrefixMode.Required)
     {
         ArgumentNullException.ThrowIfNull(handlerType);
         ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
@@ -201,6 +203,11 @@ public sealed class TelegramGeneratedHandlerDescriptor
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(invoker);
 
+        if (!Enum.IsDefined(prefixMode))
+        {
+            throw new ArgumentOutOfRangeException(nameof(prefixMode), prefixMode, "Unsupported command prefix mode.");
+        }
+
         HandlerType = handlerType;
         MethodName = methodName;
         Kind = kind;
@@ -208,6 +215,7 @@ public sealed class TelegramGeneratedHandlerDescriptor
         RoutePattern = routePattern;
         CommandPrefixes = CopyValues(commandPrefixes ?? ["/"]);
         AllowSpaceAfterPrefix = allowSpaceAfterPrefix;
+        PrefixMode = prefixMode;
         IgnoreCase = ignoreCase;
         RegistrationOrder = registrationOrder;
         ModuleName = moduleName;
@@ -250,6 +258,8 @@ public sealed class TelegramGeneratedHandlerDescriptor
     public IReadOnlyList<string> CommandPrefixes { get; }
 
     public bool AllowSpaceAfterPrefix { get; }
+
+    public CommandPrefixMode PrefixMode { get; }
 
     public bool IgnoreCase { get; }
 

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramCommandPolicy.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramCommandPolicy.cs
@@ -1,3 +1,5 @@
+using TeleFlow.Annotations;
+
 namespace TeleFlow.Telegram.Internal.Handlers;
 
 internal sealed class TelegramCommandPolicy
@@ -7,9 +9,15 @@ internal sealed class TelegramCommandPolicy
     public TelegramCommandPolicy(
         IReadOnlyList<string> prefixes,
         bool allowSpaceAfterPrefix,
-        bool ignoreCase)
+        bool ignoreCase,
+        CommandPrefixMode prefixMode = CommandPrefixMode.Required)
     {
         ArgumentNullException.ThrowIfNull(prefixes);
+
+        if (!Enum.IsDefined(prefixMode))
+        {
+            throw new InvalidOperationException($"Telegram command prefix mode '{prefixMode}' is not supported.");
+        }
 
         if (prefixes.Count == 0 || prefixes.Any(string.IsNullOrWhiteSpace))
         {
@@ -19,6 +27,7 @@ internal sealed class TelegramCommandPolicy
         Prefixes = prefixes.Select(static prefix => prefix.Trim()).Distinct(StringComparer.Ordinal).ToArray();
         AllowSpaceAfterPrefix = allowSpaceAfterPrefix;
         IgnoreCase = ignoreCase;
+        PrefixMode = prefixMode;
     }
 
     public IReadOnlyList<string> Prefixes { get; }
@@ -26,4 +35,6 @@ internal sealed class TelegramCommandPolicy
     public bool AllowSpaceAfterPrefix { get; }
 
     public bool IgnoreCase { get; }
+
+    public CommandPrefixMode PrefixMode { get; }
 }

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramGeneratedHandlerRegistry.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramGeneratedHandlerRegistry.cs
@@ -77,7 +77,8 @@ internal sealed class TelegramGeneratedHandlerRegistry : ITelegramGeneratedHandl
             new TelegramCommandPolicy(
                 descriptor.CommandPrefixes,
                 descriptor.AllowSpaceAfterPrefix,
-                descriptor.IgnoreCase),
+                descriptor.IgnoreCase,
+                descriptor.PrefixMode),
             descriptor.TextFilters
                 .Select(static filter => new TelegramTextFilter(filter.Value, filter.Mode, filter.IgnoreCase))
                 .ToArray(),

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDescriptorBuilder.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDescriptorBuilder.cs
@@ -745,7 +745,7 @@ internal static class TelegramHandlerDescriptorBuilder
 
         foreach (var command in commandAttributes)
         {
-            var policy = CreateCommandPolicy(command.Prefixes, command.AllowSpaceAfterPrefix, command.IgnoreCase);
+            var policy = CreateCommandPolicy(command.Prefixes, command.AllowSpaceAfterPrefix, command.IgnoreCase, command.PrefixMode);
             definitions.Add(new RouteDefinition(
                 TelegramRouteKind.CommandExact,
                 NormalizeCommand(method, command.Command),
@@ -757,7 +757,7 @@ internal static class TelegramHandlerDescriptorBuilder
 
         foreach (var template in commandTemplates)
         {
-            var policy = CreateCommandPolicy(template.Prefixes, template.AllowSpaceAfterPrefix, template.IgnoreCase);
+            var policy = CreateCommandPolicy(template.Prefixes, template.AllowSpaceAfterPrefix, template.IgnoreCase, template.PrefixMode);
             definitions.Add(new RouteDefinition(
                 TelegramRouteKind.CommandTemplate,
                 NormalizeCommandPattern(method, template.Template, policy),
@@ -773,7 +773,7 @@ internal static class TelegramHandlerDescriptorBuilder
 
         foreach (var regex in commandRegexes)
         {
-            var policy = CreateCommandPolicy(regex.Prefixes, regex.AllowSpaceAfterPrefix, regex.IgnoreCase);
+            var policy = CreateCommandPolicy(regex.Prefixes, regex.AllowSpaceAfterPrefix, regex.IgnoreCase, regex.PrefixMode);
             var routeValues = GetRegexRouteValueNames(method, regex.Pattern, regex.IgnoreCase)
                 .ToDictionary(
                     static name => name,
@@ -1177,9 +1177,10 @@ internal static class TelegramHandlerDescriptorBuilder
     private static TelegramCommandPolicy CreateCommandPolicy(
         IReadOnlyList<string> prefixes,
         bool allowSpaceAfterPrefix,
-        bool ignoreCase)
+        bool ignoreCase,
+        CommandPrefixMode prefixMode)
     {
-        return new TelegramCommandPolicy(prefixes, allowSpaceAfterPrefix, ignoreCase);
+        return new TelegramCommandPolicy(prefixes, allowSpaceAfterPrefix, ignoreCase, prefixMode);
     }
 
     private static Dictionary<string, RouteValueDefinition> CreateEmptyRouteValues()

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerRegistrationValidator.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerRegistrationValidator.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using TeleFlow.Annotations;
 
 namespace TeleFlow.Telegram.Internal.Handlers;
 
@@ -105,11 +106,21 @@ internal static class TelegramHandlerRegistrationValidator
             yield break;
         }
 
-        foreach (var prefix in descriptor.Route.CommandPolicy.Prefixes)
+        if (descriptor.Route.CommandPolicy.PrefixMode is CommandPrefixMode.Required or CommandPrefixMode.Optional)
+        {
+            foreach (var prefix in descriptor.Route.CommandPolicy.Prefixes)
+            {
+                yield return new DuplicateCommandCandidate(
+                    $"{prefix.ToUpperInvariant()}\u001F{descriptor.Route.CommandPolicy.AllowSpaceAfterPrefix}\u001FPREFIXED\u001F{descriptor.Command.ToUpperInvariant()}",
+                    $"{prefix}{descriptor.Command}");
+            }
+        }
+
+        if (descriptor.Route.CommandPolicy.PrefixMode is CommandPrefixMode.Optional or CommandPrefixMode.NoPrefix)
         {
             yield return new DuplicateCommandCandidate(
-                $"{prefix.ToUpperInvariant()}\u001F{descriptor.Route.CommandPolicy.AllowSpaceAfterPrefix}\u001F{descriptor.Command.ToUpperInvariant()}",
-                $"{prefix}{descriptor.Command}");
+                $"NO_PREFIX\u001F{descriptor.Command.ToUpperInvariant()}",
+                descriptor.Command);
         }
     }
 

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using TeleFlow.Annotations;
 using TeleFlow.Framework.Callbacks;
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Types;
@@ -390,6 +391,23 @@ internal sealed partial class TelegramHandlerSelector
             return false;
         }
 
+        return route.CommandPolicy.PrefixMode switch
+        {
+            CommandPrefixMode.Required => TryGetPrefixedCommandBody(text, route, out commandBody),
+            CommandPrefixMode.Optional => TryGetPrefixedCommandBody(text, route, out commandBody) ||
+                                          TryGetPrefixLessCommandBody(text, out commandBody),
+            CommandPrefixMode.NoPrefix => TryGetPrefixLessCommandBody(text, out commandBody),
+            _ => false
+        };
+    }
+
+    private static bool TryGetPrefixedCommandBody(
+        string text,
+        TelegramRouteDescriptor route,
+        out string commandBody)
+    {
+        commandBody = string.Empty;
+
         foreach (var prefix in route.CommandPolicy.Prefixes)
         {
             if (!text.StartsWith(prefix, route.CommandPolicy.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
@@ -413,6 +431,15 @@ internal sealed partial class TelegramHandlerSelector
         }
 
         return false;
+    }
+
+    private static bool TryGetPrefixLessCommandBody(
+        string text,
+        out string commandBody)
+    {
+        commandBody = text;
+
+        return !string.IsNullOrWhiteSpace(commandBody);
     }
 
     private static string TrimSlashCommandBotMention(string commandBody)

--- a/src/TeleFlow.Generators/TelegramHandlerAnalyzer.RouteValidation.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerAnalyzer.RouteValidation.cs
@@ -7,6 +7,10 @@ namespace TeleFlow.Generators;
 
 public sealed partial class TelegramHandlerAnalyzer
 {
+    private const int CommandPrefixModeRequired = 0;
+    private const int CommandPrefixModeOptional = 1;
+    private const int CommandPrefixModeNoPrefix = 2;
+
     private static HandlerKind? GetRouteKind(
         IMethodSymbol method,
         bool includeClassRouteAttributes,
@@ -119,12 +123,35 @@ public sealed partial class TelegramHandlerAnalyzer
                 continue;
             }
 
-            foreach (string prefix in prefixes)
+            int prefixMode = GetCommandPrefixMode(attribute);
+
+            if (!TryValidateCommandPrefixMode(attribute, prefixMode, out string prefixModeReason))
             {
-                bool allowSpace = GetNamedBool(attribute, "AllowSpaceAfterPrefix", defaultValue: false);
+                context.ReportDiagnostic(Diagnostic.Create(
+                    InvalidCommandPrefix,
+                    location,
+                    prefixModeReason));
+                continue;
+            }
+
+            bool allowSpace = GetNamedBool(attribute, "AllowSpaceAfterPrefix", defaultValue: false);
+
+            if (prefixMode is CommandPrefixModeRequired or CommandPrefixModeOptional)
+            {
+                foreach (string prefix in prefixes)
+                {
+                    commands.Add(new CommandRegistration(
+                        $"{prefix.ToUpperInvariant()}\u001F{allowSpace}\u001FPREFIXED\u001F{command!.ToUpperInvariant()}",
+                        $"{prefix}{command}",
+                        location));
+                }
+            }
+
+            if (prefixMode is CommandPrefixModeOptional or CommandPrefixModeNoPrefix)
+            {
                 commands.Add(new CommandRegistration(
-                    $"{prefix.ToUpperInvariant()}\u001F{allowSpace}\u001F{command!.ToUpperInvariant()}",
-                    $"{prefix}{command}",
+                    $"NO_PREFIX\u001F{command!.ToUpperInvariant()}",
+                    command,
                     location));
             }
         }
@@ -188,6 +215,17 @@ public sealed partial class TelegramHandlerAnalyzer
                 continue;
             }
 
+            int prefixMode = GetCommandPrefixMode(attribute);
+
+            if (!TryValidateCommandPrefixMode(attribute, prefixMode, out string prefixModeReason))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    InvalidCommandPrefix,
+                    location,
+                    prefixModeReason));
+                continue;
+            }
+
             if (CommandPatternStartsWithPrefix(template!, prefixes))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
@@ -241,6 +279,17 @@ public sealed partial class TelegramHandlerAnalyzer
                     InvalidCommandPrefix,
                     location,
                     prefixReason));
+                continue;
+            }
+
+            int prefixMode = GetCommandPrefixMode(attribute);
+
+            if (!TryValidateCommandPrefixMode(attribute, prefixMode, out string prefixModeReason))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    InvalidCommandPrefix,
+                    location,
+                    prefixModeReason));
                 continue;
             }
 
@@ -868,6 +917,56 @@ public sealed partial class TelegramHandlerAnalyzer
         }
 
         return true;
+    }
+
+    private static int GetCommandPrefixMode(AttributeData attribute)
+    {
+        foreach (KeyValuePair<string, TypedConstant> argument in attribute.NamedArguments)
+        {
+            if (string.Equals(argument.Key, "PrefixMode", StringComparison.Ordinal) &&
+                argument.Value.Value is int value)
+            {
+                return value;
+            }
+        }
+
+        return CommandPrefixModeRequired;
+    }
+
+    private static bool TryValidateCommandPrefixMode(
+        AttributeData attribute,
+        int prefixMode,
+        out string reason)
+    {
+        reason = string.Empty;
+
+        if (!IsSupportedCommandPrefixMode(prefixMode))
+        {
+            reason = "Command route prefix mode must be Required, Optional, or NoPrefix.";
+            return false;
+        }
+
+        if (prefixMode == CommandPrefixModeNoPrefix && HasNamedArgument(attribute, "Prefixes"))
+        {
+            reason = "Command route prefixes must not be configured when PrefixMode is NoPrefix.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsSupportedCommandPrefixMode(int value)
+    {
+        return value is CommandPrefixModeRequired or
+            CommandPrefixModeOptional or
+            CommandPrefixModeNoPrefix;
+    }
+
+    private static bool HasNamedArgument(
+        AttributeData attribute,
+        string name)
+    {
+        return attribute.NamedArguments.Any(argument => string.Equals(argument.Key, name, StringComparison.Ordinal));
     }
 
     private static bool CommandPatternStartsWithPrefix(

--- a/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Emission.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Emission.cs
@@ -287,7 +287,16 @@ public sealed partial class TelegramHandlerSourceGenerator
 
         builder.AppendLine("            },");
         AppendAutoAnswerCallback(builder, handler.AutoAnswerCallback);
-        builder.AppendLine("            ));");
+
+        if (route.PrefixMode == CommandPrefixModeRequired)
+        {
+            builder.AppendLine("            ));");
+        }
+        else
+        {
+            builder.AppendLine(",");
+            builder.AppendLine($"            prefixMode: {ToCommandPrefixModeLiteral(route.PrefixMode)}));");
+        }
     }
 
     private static void AppendAutoAnswerCallback(
@@ -672,6 +681,17 @@ public sealed partial class TelegramHandlerSourceGenerator
     private static string ToBoolLiteral(bool value)
     {
         return value ? "true" : "false";
+    }
+
+    private static string ToCommandPrefixModeLiteral(int value)
+    {
+        return value switch
+        {
+            CommandPrefixModeRequired => "global::TeleFlow.Annotations.CommandPrefixMode.Required",
+            CommandPrefixModeOptional => "global::TeleFlow.Annotations.CommandPrefixMode.Optional",
+            CommandPrefixModeNoPrefix => "global::TeleFlow.Annotations.CommandPrefixMode.NoPrefix",
+            _ => $"(global::TeleFlow.Annotations.CommandPrefixMode){value}"
+        };
     }
 
     private static string ToAttributeCreationExpression(AttributeData attribute)

--- a/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Models.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.Models.cs
@@ -4,6 +4,10 @@ namespace TeleFlow.Generators;
 
 public sealed partial class TelegramHandlerSourceGenerator
 {
+    private const int CommandPrefixModeRequired = 0;
+    private const int CommandPrefixModeOptional = 1;
+    private const int CommandPrefixModeNoPrefix = 2;
+
     private enum GeneratedHandlerKind
     {
         Command,
@@ -105,6 +109,7 @@ public sealed partial class TelegramHandlerSourceGenerator
         string? Pattern,
         ImmutableArray<string> CommandPrefixes,
         bool AllowSpaceAfterPrefix,
+        int PrefixMode,
         bool IgnoreCase,
         ImmutableArray<GeneratedTextFilter> TextFilters,
         ImmutableArray<GeneratedFilter> Filters,

--- a/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.cs
+++ b/src/TeleFlow.Generators/TelegramHandlerSourceGenerator.cs
@@ -542,6 +542,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                     Pattern: null,
                     CommandPrefixes: ["/"],
                     AllowSpaceAfterPrefix: false,
+                    PrefixMode: CommandPrefixModeRequired,
                     IgnoreCase: true,
                     TextFilters: [],
                     filters,
@@ -559,6 +560,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                     Pattern: null,
                     CommandPrefixes: ["/"],
                     AllowSpaceAfterPrefix: false,
+                    PrefixMode: CommandPrefixModeRequired,
                     IgnoreCase: true,
                     TextFilters: [],
                     filters,
@@ -589,6 +591,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                     Pattern: null,
                     CommandPrefixes: ["/"],
                     AllowSpaceAfterPrefix: false,
+                    PrefixMode: CommandPrefixModeRequired,
                     IgnoreCase: true,
                     TextFilters: [],
                     filters,
@@ -614,9 +617,12 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                      includeClassRouteAttributes))
         {
             string? command = GetConstructorString(attribute);
+            int prefixMode = GetCommandPrefixMode(attribute);
 
             if (!IsValidCommand(command) ||
-                !TryGetPrefixes(attribute, out ImmutableArray<string> prefixes))
+                !TryGetPrefixes(attribute, out ImmutableArray<string> prefixes) ||
+                !IsSupportedCommandPrefixMode(prefixMode) ||
+                HasInvalidNoPrefixConfiguration(attribute, prefixMode))
             {
                 return [];
             }
@@ -628,6 +634,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 command,
                 prefixes,
                 GetNamedBool(attribute, "AllowSpaceAfterPrefix", defaultValue: false),
+                prefixMode,
                 GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
                 TextFilters: [],
                 filters,
@@ -642,11 +649,14 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                      includeClassRouteAttributes))
         {
             string? template = GetConstructorString(attribute);
+            int prefixMode = GetCommandPrefixMode(attribute);
 
             if (template is null ||
                 string.IsNullOrWhiteSpace(template) ||
                 !TryParseTemplateRouteValues(template, out ImmutableDictionary<string, GeneratedRouteValue> routeValues) ||
                 !TryGetPrefixes(attribute, out ImmutableArray<string> prefixes) ||
+                !IsSupportedCommandPrefixMode(prefixMode) ||
+                HasInvalidNoPrefixConfiguration(attribute, prefixMode) ||
                 CommandPatternStartsWithPrefix(template, prefixes))
             {
                 return [];
@@ -659,6 +669,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 Pattern: template.Trim(),
                 prefixes,
                 GetNamedBool(attribute, "AllowSpaceAfterPrefix", defaultValue: false),
+                prefixMode,
                 GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
                 TextFilters: [],
                 filters,
@@ -673,10 +684,13 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                      includeClassRouteAttributes))
         {
             string? pattern = GetConstructorString(attribute);
+            int prefixMode = GetCommandPrefixMode(attribute);
 
             if (string.IsNullOrWhiteSpace(pattern) ||
                 !TryParseRegexRouteValues(pattern, out ImmutableDictionary<string, GeneratedRouteValue> routeValues) ||
-                !TryGetPrefixes(attribute, out ImmutableArray<string> prefixes))
+                !TryGetPrefixes(attribute, out ImmutableArray<string> prefixes) ||
+                !IsSupportedCommandPrefixMode(prefixMode) ||
+                HasInvalidNoPrefixConfiguration(attribute, prefixMode))
             {
                 return [];
             }
@@ -688,6 +702,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 Pattern: pattern,
                 prefixes,
                 GetNamedBool(attribute, "AllowSpaceAfterPrefix", defaultValue: false),
+                prefixMode,
                 GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
                 TextFilters: [],
                 filters,
@@ -711,6 +726,7 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 Pattern: null,
                 CommandPrefixes: ["/"],
                 AllowSpaceAfterPrefix: false,
+                PrefixMode: CommandPrefixModeRequired,
                 IgnoreCase: true,
                 textFilters,
                 filters,
@@ -729,7 +745,8 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                     Pattern: filter.Value,
                     CommandPrefixes: ["/"],
                     AllowSpaceAfterPrefix: false,
-                    filter.IgnoreCase,
+                    PrefixMode: CommandPrefixModeRequired,
+                    IgnoreCase: filter.IgnoreCase,
                     TextFilters: [filter],
                     filters,
                     ChatMemberTransitions: [],
@@ -757,10 +774,11 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 GeneratedRouteKind.TextTemplate,
                 Command: null,
                 Pattern: template.Trim(),
-                CommandPrefixes: ["/"],
-                AllowSpaceAfterPrefix: false,
-                GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
-                TextFilters: [],
+                    CommandPrefixes: ["/"],
+                    AllowSpaceAfterPrefix: false,
+                    PrefixMode: CommandPrefixModeRequired,
+                    IgnoreCase: GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
+                    TextFilters: [],
                 filters,
                 ChatMemberTransitions: [],
                 RoleRequirements: roleRequirements,
@@ -785,10 +803,11 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
                 GeneratedRouteKind.TextRegex,
                 Command: null,
                 Pattern: pattern,
-                CommandPrefixes: ["/"],
-                AllowSpaceAfterPrefix: false,
-                GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
-                TextFilters: [],
+                    CommandPrefixes: ["/"],
+                    AllowSpaceAfterPrefix: false,
+                    PrefixMode: CommandPrefixModeRequired,
+                    IgnoreCase: GetNamedBool(attribute, "IgnoreCase", defaultValue: true),
+                    TextFilters: [],
                 filters,
                 ChatMemberTransitions: [],
                 RoleRequirements: roleRequirements,
@@ -1541,6 +1560,41 @@ public sealed partial class TelegramHandlerSourceGenerator : IIncrementalGenerat
         }
 
         return true;
+    }
+
+    private static int GetCommandPrefixMode(AttributeData attribute)
+    {
+        foreach (KeyValuePair<string, TypedConstant> argument in attribute.NamedArguments)
+        {
+            if (string.Equals(argument.Key, "PrefixMode", StringComparison.Ordinal) &&
+                argument.Value.Value is int value)
+            {
+                return value;
+            }
+        }
+
+        return CommandPrefixModeRequired;
+    }
+
+    private static bool HasInvalidNoPrefixConfiguration(
+        AttributeData attribute,
+        int prefixMode)
+    {
+        return prefixMode == CommandPrefixModeNoPrefix && HasNamedArgument(attribute, "Prefixes");
+    }
+
+    private static bool IsSupportedCommandPrefixMode(int value)
+    {
+        return value is CommandPrefixModeRequired or
+            CommandPrefixModeOptional or
+            CommandPrefixModeNoPrefix;
+    }
+
+    private static bool HasNamedArgument(
+        AttributeData attribute,
+        string name)
+    {
+        return attribute.NamedArguments.Any(argument => string.Equals(argument.Key, name, StringComparison.Ordinal));
     }
 
     private static bool CommandPatternStartsWithPrefix(

--- a/tests/TeleFlow.ArchitectureTests/AnnotationContractTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/AnnotationContractTests.cs
@@ -129,7 +129,8 @@ public sealed class AnnotationContractTests
             states,
             parameters,
             static (_, _, _) => ValueTask.CompletedTask,
-            routeValues: routeValues);
+            routeValues: routeValues,
+            prefixMode: CommandPrefixMode.Optional);
 
         commandPrefixes[0] = "/";
         textFilters[0] = new TelegramGeneratedTextFilterDescriptor("mutated", TextMatchMode.Equals, ignoreCase: true);
@@ -146,6 +147,7 @@ public sealed class AnnotationContractTests
         routeValues[0] = new TelegramGeneratedRouteValueDescriptor("other", typeof(string), isOptional: true);
 
         Assert.Equal(["!"], descriptor.CommandPrefixes);
+        Assert.Equal(CommandPrefixMode.Optional, descriptor.PrefixMode);
         Assert.Equal("help", Assert.Single(descriptor.TextFilters).Value);
         Assert.Equal([100L], Assert.Single(descriptor.Filters).LongValues);
         Assert.Equal(TelegramMemberStatusSet.IsNotMember, Assert.Single(descriptor.ChatMemberTransitions).OldStatus);

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -640,6 +640,20 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task CommandAttribute_OptionalPrefix_MatchesPrefixedAndPrefixLessCommands()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<OptionalPrefixCommandHandler>());
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/help"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("help"));
+
+        Assert.Equal(["optional-prefix-command:/help", "optional-prefix-command:help"], probe.Events);
+    }
+
+    [Fact]
     public async Task TextTemplate_BindsRouteValue()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -732,6 +746,63 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task CommandTemplate_OptionalPrefix_MatchesPrefixedAndPrefixLessCommands()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<OptionalPrefixCommandTemplateRouteHandler>());
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/ban 42"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("ban 43"));
+
+        Assert.Equal(["optional-prefix-command-template:42", "optional-prefix-command-template:43"], probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandTemplate_NoPrefix_MatchesOnlyPrefixLessCommands()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<NoPrefixCommandTemplateRouteHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("ban 42"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/ban 43"));
+
+        Assert.Equal(["no-prefix-command-template:42", "message:/ban 43"], probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandTemplate_OptionalPrefix_RespectsCustomPrefixes()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<OptionalCustomPrefixCommandTemplateRouteHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("!ban 42"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("ban 43"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/ban 44"));
+
+        Assert.Equal(
+            [
+                "optional-custom-prefix-command-template:42",
+                "optional-custom-prefix-command-template:43",
+                "message:/ban 44"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
     public async Task DeepLinkPayload_RoundTripsThroughStartCommandTemplate()
     {
         var deepLinks = new TelegramDeepLinks(
@@ -786,6 +857,20 @@ public sealed class TelegramHandlerDispatcherTests
         await DispatchAsync(serviceProvider, CreateMessageUpdate("/kick 8"));
 
         Assert.Equal(["command-regex:7"], probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandRegex_OptionalPrefix_MatchesPrefixedAndPrefixLessCommands()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<OptionalPrefixCommandRegexRouteHandler>());
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/kick 7"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("kick 8"));
+
+        Assert.Equal(["optional-prefix-command-regex:7", "optional-prefix-command-regex:8"], probe.Events);
     }
 
     [Fact]
@@ -3468,6 +3553,16 @@ public sealed class TelegramHandlerDispatcherTests
         }
     }
 
+    public sealed class OptionalPrefixCommandHandler
+    {
+        [Command("help", PrefixMode = CommandPrefixMode.Optional)]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"optional-prefix-command:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
     public sealed class TextTemplateRouteHandler
     {
         [TextTemplate("order {orderId:long}")]
@@ -3504,6 +3599,36 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(MessageContext context, int userId, HandlerProbe probe)
         {
             probe.Events.Add($"command-template:{userId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class OptionalPrefixCommandTemplateRouteHandler
+    {
+        [CommandTemplate("ban {userId:int}", PrefixMode = CommandPrefixMode.Optional)]
+        public Task Handle(MessageContext context, int userId, HandlerProbe probe)
+        {
+            probe.Events.Add($"optional-prefix-command-template:{userId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class NoPrefixCommandTemplateRouteHandler
+    {
+        [CommandTemplate("ban {userId:int}", PrefixMode = CommandPrefixMode.NoPrefix)]
+        public Task Handle(MessageContext context, int userId, HandlerProbe probe)
+        {
+            probe.Events.Add($"no-prefix-command-template:{userId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class OptionalCustomPrefixCommandTemplateRouteHandler
+    {
+        [CommandTemplate("ban {userId:int}", PrefixMode = CommandPrefixMode.Optional, Prefixes = new[] { "!" })]
+        public Task Handle(MessageContext context, int userId, HandlerProbe probe)
+        {
+            probe.Events.Add($"optional-custom-prefix-command-template:{userId}");
             return Task.CompletedTask;
         }
     }
@@ -3585,6 +3710,16 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(MessageContext context, int userId, HandlerProbe probe)
         {
             probe.Events.Add($"command-regex:{userId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class OptionalPrefixCommandRegexRouteHandler
+    {
+        [CommandRegex(@"^kick (?<userId>\d+)$", PrefixMode = CommandPrefixMode.Optional)]
+        public Task Handle(MessageContext context, int userId, HandlerProbe probe)
+        {
+            probe.Events.Add($"optional-prefix-command-regex:{userId}");
             return Task.CompletedTask;
         }
     }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
@@ -409,6 +409,12 @@ public sealed class TelegramHandlerGeneratorTests
                 {
                     return Task.CompletedTask;
                 }
+
+                [CommandTemplate("ban {userId:int}", PrefixMode = CommandPrefixMode.Optional, Prefixes = new[] { "/", "!" })]
+                public Task Ban(MessageContext context, int userId)
+                {
+                    return Task.CompletedTask;
+                }
             }
             """);
 
@@ -430,11 +436,14 @@ public sealed class TelegramHandlerGeneratorTests
         Assert.Contains("TelegramGeneratedRouteKind.CommandExact", generatedSource);
         Assert.Contains("TelegramGeneratedRouteKind.TextExact", generatedSource);
         Assert.Contains("TelegramGeneratedRouteKind.TextTemplate", generatedSource);
+        Assert.Contains("TelegramGeneratedRouteKind.CommandTemplate", generatedSource);
         Assert.Contains("TelegramGeneratedRouteKind.CommandRegex", generatedSource);
         Assert.Contains("TelegramGeneratedHandlerParameterKind.RouteValue", generatedSource);
+        Assert.Contains("global::TeleFlow.Annotations.CommandPrefixMode.Optional", generatedSource);
         Assert.Contains("Invoke_0", generatedSource);
         Assert.Contains("Invoke_1", generatedSource);
-        Assert.DoesNotContain("Invoke_2", generatedSource);
+        Assert.Contains("Invoke_2", generatedSource);
+        Assert.DoesNotContain("Invoke_3", generatedSource);
     }
 
     [Fact]
@@ -765,6 +774,12 @@ public sealed class TelegramHandlerGeneratorTests
                 {
                     return Task.CompletedTask;
                 }
+
+                [CommandTemplate("mute {id:int}", PrefixMode = CommandPrefixMode.NoPrefix, Prefixes = new[] { "!" })]
+                public Task NoPrefixWithPrefixes(MessageContext context, int id)
+                {
+                    return Task.CompletedTask;
+                }
             }
             """);
 
@@ -786,6 +801,7 @@ public sealed class TelegramHandlerGeneratorTests
         Assert.Contains("Valid", generatedSource);
         Assert.DoesNotContain("BadPrefix", generatedSource);
         Assert.DoesNotContain("PrefixedTemplate", generatedSource);
+        Assert.DoesNotContain("NoPrefixWithPrefixes", generatedSource);
     }
 
     [Fact]
@@ -1971,10 +1987,13 @@ public sealed class TelegramHandlerGeneratorTests
 
                 [CommandRegex(@"^ban (?<id>\d+)$", Prefixes = new[] { "" })]
                 public Task InvalidRegexPrefix(MessageContext context, int id) => Task.CompletedTask;
+
+                [CommandTemplate("mute {id:int}", PrefixMode = CommandPrefixMode.NoPrefix, Prefixes = new[] { "!" })]
+                public Task NoPrefixWithPrefixes(MessageContext context, int id) => Task.CompletedTask;
             }
             """);
 
-        Assert.Equal(2, diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.InvalidCommandPrefixId));
+        Assert.Equal(3, diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.InvalidCommandPrefixId));
         Assert.True(
             diagnostics.Count(diagnostic => diagnostic.Id == TelegramHandlerAnalyzer.InvalidRouteTemplateId) >= 2,
             "Expected route template diagnostics for slash and custom-prefixed command templates.");


### PR DESCRIPTION
## Summary

- add `CommandPrefixMode` for `[Command]`, `[CommandTemplate]`, and `[CommandRegex]`
- support required, optional, and prefix-less command matching through one explicit route policy
- propagate prefix mode through generated handler metadata, analyzer validation, and direct runtime registration
- document EN/RU examples and migration from the `[CommandTemplate]` + `[TextTemplate]` workaround

## Touched hot paths

- `TelegramHandlerSelector.TryGetCommandBody` now applies command prefix policy before existing exact/template/regex matching.
- Default generated registrations keep the old constructor shape and only emit `prefixMode` when a route uses non-default behavior.
- Duplicate exact command detection now models optional-prefix routes as both prefixed and prefix-less candidates.

## Validation

- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~TelegramHandlerDispatcherTests|FullyQualifiedName~TelegramHandlerGeneratorTests|FullyQualifiedName~AnnotationContractTests"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~PackageSmokeTests.ReleaseAlignedToolingPackages_LoadAsAnalyzersFromPackageReference"`
- `dotnet test tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --filter "FullyQualifiedName~PackageSmokeTests.DocumentedPackageReferences_RestoreBuildAndResolveExpectedDependencyClosure"`
- `dotnet test TeleFlow.sln --no-restore /m:1`
- `git diff --check`

Closes #23