### PR TITLE
Improve logging and diagnostics contract

### DIFF
--- a/docs/en/advanced/middleware-and-rate-limiting.md
+++ b/docs/en/advanced/middleware-and-rate-limiting.md
@@ -186,7 +186,33 @@ builder.Services.AddDefaultUpdateRateLimiting();
 builder.Services.AddUpdateRateLimiter<MyRateLimiter>();
 ```
 
-The default limiter is no-op. Custom limiters are application-specific.
+`AddDefaultUpdateRateLimiting()` adds the rate-limit middleware. It does not add a hidden no-op limiter. If no limiters are registered, the middleware simply lets the update continue.
+
+Custom limiters return an explicit decision:
+
+```csharp
+public sealed class MyRateLimiter : IUpdateRateLimiter
+{
+    public ValueTask<UpdateRateLimitDecision> CheckAsync(
+        UpdateContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (ShouldReject(context))
+        {
+            return ValueTask.FromResult(
+                UpdateRateLimitDecision.Rejected(
+                    retryAfter: TimeSpan.FromSeconds(15),
+                    policyName: "per-user-command"));
+        }
+
+        return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
+    }
+}
+```
+
+Use `Rejected` for normal throttling. Do not throw exceptions for expected rate-limit decisions. Exceptions from a limiter are treated as real failures and continue through the normal error path.
+
+The rate-limit warning log includes safe metadata such as payload type, limiter type, retry-after, and developer-controlled policy name. It does not log arbitrary limiter keys, message text, callback data, or user-provided values.
 
 ## Ordering
 

--- a/docs/en/features/errors-and-diagnostics.md
+++ b/docs/en/features/errors-and-diagnostics.md
@@ -87,13 +87,55 @@ builder.Services.AddLogging(logging =>
 });
 ```
 
-For enterprise deployments, route logs to your existing platform and keep update id, chat id, handler, and exception type searchable.
+For enterprise deployments, route logs to your existing platform and keep update id, update type, handler, route, method name, HTTP status, and exception type searchable.
 
-## Handler Timing Logs
+TeleFlow event ids are stable within a logger category. Treat category, event id, event name, and message template as the diagnostic contract. Event ids are not a global numeric registry across every TeleFlow assembly.
+
+## Log Levels
+
+TeleFlow uses log levels deliberately:
+
+| Level | Meaning |
+| --- | --- |
+| `Information` | Runtime lifecycle events such as polling start, connected, stopped, and coarse transport status. |
+| `Debug` | Per-update diagnostics: handler matching, handler completion, route misses, filter rejections, webhook update acceptance, and request timings. |
+| `Warning` | Recoverable or expected runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure, and rate-limit rejection. |
+| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures, and update processing failures. |
+
+Normal successful update processing is not logged at `Information`.
+
+## Handler Timing
 
 Detailed handler timing is collected only when `LogLevel.Debug` is enabled for the Telegram framework logger. In Debug logs TeleFlow can report handler duration, Telegram request count, Telegram request time, and handler logic time.
 
 When Debug logging is disabled, the normal successful handler path does not create handler request timing scopes. Error logs still include update id, update type, handler, route, module, scene, and exception type, but they do not include detailed timing fields that were not collected.
+
+## Security And Privacy
+
+TeleFlow is not a logging engine. It emits diagnostic events through application-owned `Microsoft.Extensions.Logging` providers.
+
+Framework logs use static framework-owned message templates. TeleFlow does not execute, evaluate, or perform lookup operations on log content, and user-controlled strings are not used as logging templates.
+
+By default, framework logs do not include:
+
+- bot tokens;
+- webhook secrets;
+- raw callback data;
+- request bodies;
+- message text;
+- message captions;
+- arbitrary rate-limit keys;
+- arbitrary user-provided values.
+
+Safe metadata can include update id, update type, handler, route, module, scene, exception type, HTTP status code, Telegram method name, retry-after, limiter type, and developer-controlled policy name.
+
+Logging providers remain application infrastructure. If an application configures a provider or sink with its own unsafe processing rules, that is outside TeleFlow's runtime contract.
+
+## Rate-Limit Diagnostics
+
+Update-level rate limiters return `UpdateRateLimitDecision`. A rejected decision stops the pipeline and logs a `Warning`; it is not treated as an exception.
+
+Limiter failures still throw normal exceptions and remain visible through the regular error path.
 
 ## Diagnostics Recommendation
 
@@ -101,6 +143,7 @@ Start with:
 
 - console logging during development;
 - structured logs in production;
+- `Debug` logging only during local debugging or targeted investigations;
 - explicit error handlers for known business exceptions;
 - tests for error handlers that change user-visible behavior.
 

--- a/docs/ru/advanced/middleware-and-rate-limiting.md
+++ b/docs/ru/advanced/middleware-and-rate-limiting.md
@@ -186,7 +186,33 @@ builder.Services.AddDefaultUpdateRateLimiting();
 builder.Services.AddUpdateRateLimiter<MyRateLimiter>();
 ```
 
-Default limiter - no-op. Custom limiters application-specific.
+`AddDefaultUpdateRateLimiting()` добавляет rate-limit middleware. Он не добавляет скрытый no-op limiter. Если limiter-ы не зарегистрированы, middleware просто пропускает update дальше.
+
+Custom limiter возвращает явное решение:
+
+```csharp
+public sealed class MyRateLimiter : IUpdateRateLimiter
+{
+    public ValueTask<UpdateRateLimitDecision> CheckAsync(
+        UpdateContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (ShouldReject(context))
+        {
+            return ValueTask.FromResult(
+                UpdateRateLimitDecision.Rejected(
+                    retryAfter: TimeSpan.FromSeconds(15),
+                    policyName: "per-user-command"));
+        }
+
+        return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
+    }
+}
+```
+
+Используй `Rejected` для обычного throttling. Не кидай exceptions для ожидаемого rate-limit решения. Exceptions из limiter-а считаются настоящими failures и идут через обычный error path.
+
+Rate-limit warning log содержит безопасные metadata: payload type, limiter type, retry-after и developer-controlled policy name. Он не логирует arbitrary limiter keys, message text, callback data или user-provided values.
 
 ## Порядок выполнения
 

--- a/docs/ru/features/errors-and-diagnostics.md
+++ b/docs/ru/features/errors-and-diagnostics.md
@@ -87,13 +87,55 @@ builder.Services.AddLogging(logging =>
 });
 ```
 
-Для enterprise deployments отправляй logs в существующую platform и держи update id, chat id, handler и exception type searchable.
+Для enterprise deployments отправляй logs в существующую platform и держи update id, update type, handler, route, method name, HTTP status и exception type searchable.
 
-## Логи времени выполнения обработчиков
+Event id в TeleFlow стабильны внутри logger category. Диагностический контракт - это category, event id, event name и message template. Event id не являются глобальным числовым registry по всем TeleFlow assemblies.
+
+## Уровни логов
+
+TeleFlow использует log levels осознанно:
+
+| Level | Meaning |
+| --- | --- |
+| `Information` | Runtime lifecycle events: polling start, connected, stopped и coarse transport status. |
+| `Debug` | Per-update diagnostics: handler matching, handler completion, route misses, filter rejections, webhook update acceptance и request timings. |
+| `Warning` | Recoverable или ожидаемые runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure и rate-limit rejection. |
+| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures и update processing failures. |
+
+Обычная успешная обработка update не логируется на `Information`.
+
+## Логи времени выполнения handlers
 
 Подробные замеры времени выполнения обработчиков собираются только когда для логгера Telegram framework включён `LogLevel.Debug`. В логах уровня Debug TeleFlow может показать общее время обработчика, количество Telegram-запросов, время Telegram-запросов и время собственной логики обработчика.
 
 Когда Debug logging выключен, обычный успешный путь обработки не создаёт области замера Telegram-запросов. Логи ошибок по-прежнему содержат update id, update type, handler, route, module, scene и exception type, но не содержат подробные поля времени, которые не собирались.
+
+## Security и privacy
+
+TeleFlow не является logging engine. Он отправляет diagnostic events через application-owned `Microsoft.Extensions.Logging` providers.
+
+Framework logs используют статические framework-owned message templates. TeleFlow не исполняет, не evaluate-ит и не делает lookup operations над log content, а user-controlled strings не используются как logging templates.
+
+По умолчанию framework logs не содержат:
+
+- bot tokens;
+- webhook secrets;
+- raw callback data;
+- request bodies;
+- message text;
+- message captions;
+- arbitrary rate-limit keys;
+- arbitrary user-provided values.
+
+Безопасные metadata: update id, update type, handler, route, module, scene, exception type, HTTP status code, Telegram method name, retry-after, limiter type и developer-controlled policy name.
+
+Logging providers остаются infrastructure приложения. Если приложение подключает provider или sink со своими unsafe processing rules, это находится вне runtime contract TeleFlow.
+
+## Rate-limit diagnostics
+
+Update-level rate limiters возвращают `UpdateRateLimitDecision`. Rejected decision останавливает pipeline и логируется как `Warning`; это не exception.
+
+Failures внутри limiter-а всё ещё выбрасываются как обычные exceptions и видны через regular error path.
 
 ## Рекомендации по диагностике
 
@@ -101,6 +143,7 @@ builder.Services.AddLogging(logging =>
 
 - console logging during development;
 - structured logs in production;
+- `Debug` logging только во время local debugging или targeted investigations;
 - explicit error handlers для known business exceptions;
 - tests для error handlers, которые меняют user-visible behavior.
 

--- a/src/TeleFlow.Framework.Core/Middleware/ServiceCollectionMiddlewareExtensions.cs
+++ b/src/TeleFlow.Framework.Core/Middleware/ServiceCollectionMiddlewareExtensions.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using TeleFlow.Framework.RateLimiting;
 
 namespace TeleFlow.Framework.Middleware;
 
@@ -31,7 +29,6 @@ public static class ServiceCollectionMiddlewareExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddUpdateMiddleware<UpdateRateLimitMiddleware>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IUpdateRateLimiter, NoOpUpdateRateLimiter>());
         return services;
     }
 

--- a/src/TeleFlow.Framework.Core/Middleware/UpdateRateLimitMiddleware.cs
+++ b/src/TeleFlow.Framework.Core/Middleware/UpdateRateLimitMiddleware.cs
@@ -1,16 +1,34 @@
+using Microsoft.Extensions.Logging;
 using TeleFlow.Framework.RateLimiting;
 using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Framework.Middleware;
 
-public sealed class UpdateRateLimitMiddleware : IUpdateMiddleware
+/// <summary>
+/// Runs registered update-level rate limiters before the dispatcher receives the update.
+/// </summary>
+public sealed partial class UpdateRateLimitMiddleware : IUpdateMiddleware
 {
+    private const int UpdateRejectedEventId = 1;
+
     private readonly IReadOnlyList<IUpdateRateLimiter> _rateLimiters;
+    private readonly ILogger<UpdateRateLimitMiddleware>? _logger;
 
     public UpdateRateLimitMiddleware(IEnumerable<IUpdateRateLimiter> rateLimiters)
     {
         ArgumentNullException.ThrowIfNull(rateLimiters);
+
         _rateLimiters = rateLimiters.ToArray();
+    }
+
+    public UpdateRateLimitMiddleware(
+        IEnumerable<IUpdateRateLimiter> rateLimiters,
+        ILogger<UpdateRateLimitMiddleware> logger)
+        : this(rateLimiters)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
     }
 
     public async Task InvokeAsync(UpdateContext context, UpdateDelegate next)
@@ -20,9 +38,37 @@ public sealed class UpdateRateLimitMiddleware : IUpdateMiddleware
 
         foreach (var rateLimiter in _rateLimiters)
         {
-            await rateLimiter.WaitAsync(context, context.CancellationToken).ConfigureAwait(false);
+            var decision = await rateLimiter
+                .CheckAsync(context, context.CancellationToken)
+                .ConfigureAwait(false);
+
+            if (!decision.IsAccepted)
+            {
+                if (_logger is not null)
+                {
+                    LogUpdateRejected(
+                        _logger,
+                        context.Payload.GetType().Name,
+                        rateLimiter.GetType().FullName ?? rateLimiter.GetType().Name,
+                        decision.RetryAfter,
+                        decision.PolicyName ?? string.Empty);
+                }
+
+                return;
+            }
         }
 
         await next(context).ConfigureAwait(false);
     }
+
+    [LoggerMessage(
+        EventId = UpdateRejectedEventId,
+        Level = LogLevel.Warning,
+        Message = "Update rejected by rate limiter. payload_type={PayloadType}, limiter={Limiter}, retry_after={RetryAfter}, policy={PolicyName}.")]
+    private static partial void LogUpdateRejected(
+        ILogger logger,
+        string payloadType,
+        string limiter,
+        TimeSpan? retryAfter,
+        string policyName);
 }

--- a/src/TeleFlow.Framework.Core/RateLimiting/IUpdateRateLimiter.cs
+++ b/src/TeleFlow.Framework.Core/RateLimiting/IUpdateRateLimiter.cs
@@ -2,7 +2,15 @@ using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Framework.RateLimiting;
 
+/// <summary>
+/// Evaluates whether an incoming update may continue through the framework pipeline before dispatch.
+/// </summary>
 public interface IUpdateRateLimiter
 {
-    ValueTask WaitAsync(UpdateContext context, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Checks the current update and returns an explicit decision instead of using exceptions for expected throttling.
+    /// </summary>
+    ValueTask<UpdateRateLimitDecision> CheckAsync(
+        UpdateContext context,
+        CancellationToken cancellationToken = default);
 }

--- a/src/TeleFlow.Framework.Core/RateLimiting/NoOpUpdateRateLimiter.cs
+++ b/src/TeleFlow.Framework.Core/RateLimiting/NoOpUpdateRateLimiter.cs
@@ -2,15 +2,18 @@ using TeleFlow.Framework.Updates;
 
 namespace TeleFlow.Framework.RateLimiting;
 
+/// <summary>
+/// Allows every update through the update-level rate-limiting stage.
+/// </summary>
 public sealed class NoOpUpdateRateLimiter : IUpdateRateLimiter
 {
-    public ValueTask WaitAsync(
+    public ValueTask<UpdateRateLimitDecision> CheckAsync(
         UpdateContext context,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
         cancellationToken.ThrowIfCancellationRequested();
 
-        return ValueTask.CompletedTask;
+        return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
     }
 }

--- a/src/TeleFlow.Framework.Core/RateLimiting/UpdateRateLimitDecision.cs
+++ b/src/TeleFlow.Framework.Core/RateLimiting/UpdateRateLimitDecision.cs
@@ -1,0 +1,66 @@
+namespace TeleFlow.Framework.RateLimiting;
+
+/// <summary>
+/// Describes whether an incoming update can continue through the framework pipeline after
+/// update-level rate limiting has been evaluated.
+/// </summary>
+public readonly record struct UpdateRateLimitDecision
+{
+    private const byte AcceptedKind = 0;
+    private const byte RejectedKind = 1;
+
+    private readonly byte _kind;
+
+    private UpdateRateLimitDecision(
+        byte kind,
+        TimeSpan? retryAfter,
+        string? policyName)
+    {
+        if (retryAfter < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(retryAfter),
+                retryAfter,
+                "Rate-limit retry delay must not be negative.");
+        }
+
+        _kind = kind;
+        RetryAfter = retryAfter;
+        PolicyName = string.IsNullOrWhiteSpace(policyName) ? null : policyName;
+    }
+
+    /// <summary>
+    /// Gets a decision that allows the update to continue through the framework pipeline.
+    /// </summary>
+    public static UpdateRateLimitDecision Accepted => default;
+
+    /// <summary>
+    /// Gets whether the update is allowed to continue through the framework pipeline.
+    /// </summary>
+    public bool IsAccepted => _kind == AcceptedKind;
+
+    /// <summary>
+    /// Gets whether the update was rejected by a rate limiter.
+    /// </summary>
+    public bool IsRejected => _kind == RejectedKind;
+
+    /// <summary>
+    /// Gets the optional delay after which the update sender may retry, when the limiter can provide it.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; }
+
+    /// <summary>
+    /// Gets the optional developer-controlled policy name that rejected the update.
+    /// </summary>
+    public string? PolicyName { get; }
+
+    /// <summary>
+    /// Creates a decision that rejects the update and stops the framework pipeline.
+    /// </summary>
+    public static UpdateRateLimitDecision Rejected(
+        TimeSpan? retryAfter = null,
+        string? policyName = null)
+    {
+        return new UpdateRateLimitDecision(RejectedKind, retryAfter, policyName);
+    }
+}

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.Logging.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.Logging.cs
@@ -13,6 +13,11 @@ internal sealed partial class TelegramHandlerSelector
         /// A typed callback route matched callback data shape, but payload decoding failed.
         /// </summary>
         public const int CallbackDataDeserializationFailed = 1;
+
+        /// <summary>
+        /// A route matched the incoming update, but filters rejected the handler candidate.
+        /// </summary>
+        public const int HandlerRejectedByFilters = 2;
     }
 
     /// <summary>
@@ -30,4 +35,18 @@ internal sealed partial class TelegramHandlerSelector
         string handler,
         string route,
         int callbackDataBytes);
+
+    /// <summary>
+    /// Logs route candidates rejected by filters without exposing user message text or callback data.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.HandlerRejectedByFilters,
+        Level = LogLevel.Debug,
+        Message = "Telegram handler candidate rejected by filters. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}.")]
+    private static partial void LogHandlerRejectedByFilters(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        string handler,
+        string route);
 }

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -135,7 +135,7 @@ internal sealed partial class TelegramHandlerSelector
             cancellationToken).ConfigureAwait(false);
     }
 
-    private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
+    private async ValueTask<TelegramRouteSelection?> SelectMessageHandlerAsync(
         MessageContext context,
         TelegramHandlerCandidateSet candidates,
         string? currentState,
@@ -161,7 +161,7 @@ internal sealed partial class TelegramHandlerSelector
             cancellationToken).ConfigureAwait(false);
     }
 
-    private static async ValueTask<TelegramRouteSelection?> SelectMessageHandlerPassAsync(
+    private async ValueTask<TelegramRouteSelection?> SelectMessageHandlerPassAsync(
         MessageContext context,
         IReadOnlyList<TelegramHandlerCandidate> candidates,
         CancellationToken cancellationToken)
@@ -181,6 +181,7 @@ internal sealed partial class TelegramHandlerSelector
                     candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
+                LogRejectedByFiltersIfEnabled(context, candidate, route);
                 continue;
             }
 
@@ -207,6 +208,7 @@ internal sealed partial class TelegramHandlerSelector
                         candidate.Filters,
                         cancellationToken).ConfigureAwait(false))
                 {
+                    LogRejectedByFiltersIfEnabled(context, candidate, route);
                     continue;
                 }
 
@@ -252,6 +254,7 @@ internal sealed partial class TelegramHandlerSelector
                     candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
+                LogRejectedByFiltersIfEnabled(context, candidate, route);
                 continue;
             }
 
@@ -261,7 +264,7 @@ internal sealed partial class TelegramHandlerSelector
         return null;
     }
 
-    private static async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerPassAsync(
+    private async ValueTask<TelegramRouteSelection?> SelectChatMemberHandlerPassAsync(
         ChatMemberUpdatedContext context,
         IReadOnlyList<TelegramHandlerCandidate> candidates,
         TelegramRouteKind updateRouteKind,
@@ -287,6 +290,7 @@ internal sealed partial class TelegramHandlerSelector
                     candidate.Filters,
                     cancellationToken).ConfigureAwait(false))
             {
+                LogRejectedByFiltersIfEnabled(context, candidate, route);
                 continue;
             }
 
@@ -294,6 +298,24 @@ internal sealed partial class TelegramHandlerSelector
         }
 
         return null;
+    }
+
+    private void LogRejectedByFiltersIfEnabled(
+        TelegramUpdateContext context,
+        TelegramHandlerCandidate candidate,
+        TelegramRouteDescriptor route)
+    {
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        LogHandlerRejectedByFilters(
+            _logger,
+            context.Update.UpdateId,
+            TelegramUpdateLogFormatter.GetUpdateType(context.Update),
+            TelegramUpdateLogFormatter.FormatHandler(candidate.Handler),
+            TelegramUpdateLogFormatter.FormatRoute(route));
     }
 
     private static bool TryMatchRoute(

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
@@ -5,6 +5,11 @@ namespace TeleFlow.Telegram.Internal;
 
 internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
 {
+    private const int RequestStartedEventId = 1;
+    private const int RequestCompletedEventId = 2;
+    private const int RequestThrottledEventId = 3;
+    private const int RequestFailedEventId = 4;
+
     private readonly JsonSerializerOptions _serializerOptions;
     private readonly TelegramRequestSender _sender;
     private readonly TelegramTransportEnvelopeParser _envelopeParser;
@@ -376,7 +381,8 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
             methodName,
             attempt,
             httpStatusCode,
-            GetElapsedMilliseconds(attemptStarted, attemptEnded));
+            GetElapsedMilliseconds(attemptStarted, attemptEnded),
+            exception.GetType().FullName ?? exception.GetType().Name);
     }
 
     private double GetElapsedMilliseconds(long startingTimestamp, long endingTimestamp)
@@ -385,7 +391,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
     }
 
     [LoggerMessage(
-        EventId = 1,
+        EventId = RequestStartedEventId,
         Level = LogLevel.Debug,
         Message = "Telegram request started. method={MethodName}, attempt={Attempt}, content={ContentKind}.")]
     private static partial void LogRequestStarted(
@@ -395,7 +401,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
         string contentKind);
 
     [LoggerMessage(
-        EventId = 2,
+        EventId = RequestCompletedEventId,
         Level = LogLevel.Debug,
         Message = "Telegram request completed. method={MethodName}, attempt={Attempt}, status={HttpStatusCode}, request_ms={RequestElapsedMilliseconds:F2}.")]
     private static partial void LogRequestCompleted(
@@ -406,7 +412,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
         double requestElapsedMilliseconds);
 
     [LoggerMessage(
-        EventId = 3,
+        EventId = RequestThrottledEventId,
         Level = LogLevel.Warning,
         Message = "Telegram request throttled. method={MethodName}, attempt={Attempt}, retry_after={RetryAfter}.")]
     private static partial void LogRequestThrottledCore(
@@ -416,14 +422,15 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
         TimeSpan retryAfter);
 
     [LoggerMessage(
-        EventId = 4,
+        EventId = RequestFailedEventId,
         Level = LogLevel.Error,
-        Message = "Telegram request failed. method={MethodName}, attempt={Attempt}, status={HttpStatusCode}, request_ms={RequestElapsedMilliseconds:F2}.")]
+        Message = "Telegram request failed. method={MethodName}, attempt={Attempt}, status={HttpStatusCode}, request_ms={RequestElapsedMilliseconds:F2}, exception_type={ExceptionType}.")]
     private static partial void LogRequestFailed(
         ILogger logger,
         Exception exception,
         string methodName,
         int attempt,
         int? httpStatusCode,
-        double requestElapsedMilliseconds);
+        double requestElapsedMilliseconds,
+        string exceptionType);
 }

--- a/src/TeleFlow.Telegram.Webhooks/Internal/TelegramRawWebhookEndpoint.cs
+++ b/src/TeleFlow.Telegram.Webhooks/Internal/TelegramRawWebhookEndpoint.cs
@@ -1,25 +1,39 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Webhooks.Internal;
 
-internal sealed class TelegramRawWebhookEndpoint
+/// <summary>
+/// Handles raw ASP.NET Core webhook requests, validates Telegram webhook security metadata,
+/// deserializes updates, and passes accepted updates to the user-provided webhook handler.
+/// </summary>
+internal sealed partial class TelegramRawWebhookEndpoint
 {
     private const string SecretTokenHeaderName = "X-Telegram-Bot-Api-Secret-Token";
+
+    private const int SecretTokenRejectedEventId = 1;
+    private const int InvalidPayloadRejectedEventId = 2;
+    private const int UpdateReceivedEventId = 3;
+    private const int UpdateProcessedEventId = 4;
+    private const int UpdateProcessingFailedEventId = 5;
 
     private static readonly TelegramJsonOptions DefaultJsonOptions = TelegramJsonOptions.CreateDefault();
 
     private readonly TelegramRawWebhookHandler _handler;
     private readonly TelegramRawWebhookOptions _options;
+    private readonly ILogger<TelegramRawWebhookEndpoint>? _logger;
 
     public TelegramRawWebhookEndpoint(
         TelegramRawWebhookHandler handler,
-        TelegramRawWebhookOptions options)
+        TelegramRawWebhookOptions options,
+        ILogger<TelegramRawWebhookEndpoint>? logger = null)
     {
         _handler = handler ?? throw new ArgumentNullException(nameof(handler));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
     }
 
     public async Task<IResult> HandleAsync(HttpContext context)
@@ -28,6 +42,11 @@ internal sealed class TelegramRawWebhookEndpoint
 
         if (!IsSecretTokenAccepted(context))
         {
+            if (_logger is not null)
+            {
+                LogSecretTokenRejected(_logger, _options.SecretTokenFailureStatusCode);
+            }
+
             return Results.StatusCode(_options.SecretTokenFailureStatusCode);
         }
 
@@ -43,16 +62,60 @@ internal sealed class TelegramRawWebhookEndpoint
         }
         catch (JsonException)
         {
+            if (_logger is not null)
+            {
+                LogInvalidPayloadRejected(_logger, _options.InvalidPayloadStatusCode);
+            }
+
             return Results.StatusCode(_options.InvalidPayloadStatusCode);
         }
 
         if (update is null)
         {
+            if (_logger is not null)
+            {
+                LogInvalidPayloadRejected(_logger, _options.InvalidPayloadStatusCode);
+            }
+
             return Results.StatusCode(_options.InvalidPayloadStatusCode);
         }
 
+        string? updateType = null;
+        string GetUpdateType()
+        {
+            return updateType ??= TelegramWebhookUpdateLogFormatter.GetUpdateType(update);
+        }
+
+        if (_logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            LogUpdateReceived(_logger, update.UpdateId, GetUpdateType());
+        }
+
         var bot = context.RequestServices.GetRequiredService<ITelegramClient>();
-        return await _handler(update, bot, context.RequestAborted).ConfigureAwait(false);
+        try
+        {
+            var result = await _handler(update, bot, context.RequestAborted).ConfigureAwait(false);
+
+            if (_logger?.IsEnabled(LogLevel.Debug) == true)
+            {
+                LogUpdateProcessed(_logger, update.UpdateId, GetUpdateType());
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            if (_logger?.IsEnabled(LogLevel.Error) == true)
+            {
+                LogUpdateProcessingFailed(_logger, exception, update.UpdateId, GetUpdateType());
+            }
+
+            throw;
+        }
     }
 
     private bool IsSecretTokenAccepted(HttpContext context)
@@ -66,4 +129,48 @@ internal sealed class TelegramRawWebhookEndpoint
             values.Count == 1 &&
             string.Equals(values[0], _options.SecretToken, StringComparison.Ordinal);
     }
+
+    [LoggerMessage(
+        EventId = SecretTokenRejectedEventId,
+        Level = LogLevel.Warning,
+        Message = "Telegram webhook request rejected because secret token validation failed. status={StatusCode}.")]
+    private static partial void LogSecretTokenRejected(
+        ILogger logger,
+        int statusCode);
+
+    [LoggerMessage(
+        EventId = InvalidPayloadRejectedEventId,
+        Level = LogLevel.Warning,
+        Message = "Telegram webhook request rejected because payload was invalid. status={StatusCode}.")]
+    private static partial void LogInvalidPayloadRejected(
+        ILogger logger,
+        int statusCode);
+
+    [LoggerMessage(
+        EventId = UpdateReceivedEventId,
+        Level = LogLevel.Debug,
+        Message = "Telegram webhook update received. update_id={UpdateId}, type={UpdateType}.")]
+    private static partial void LogUpdateReceived(
+        ILogger logger,
+        long updateId,
+        string updateType);
+
+    [LoggerMessage(
+        EventId = UpdateProcessedEventId,
+        Level = LogLevel.Debug,
+        Message = "Telegram webhook update processed. update_id={UpdateId}, type={UpdateType}.")]
+    private static partial void LogUpdateProcessed(
+        ILogger logger,
+        long updateId,
+        string updateType);
+
+    [LoggerMessage(
+        EventId = UpdateProcessingFailedEventId,
+        Level = LogLevel.Error,
+        Message = "Telegram webhook update processing failed. update_id={UpdateId}, type={UpdateType}.")]
+    private static partial void LogUpdateProcessingFailed(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string updateType);
 }

--- a/src/TeleFlow.Telegram.Webhooks/Internal/TelegramWebhookUpdateLogFormatter.cs
+++ b/src/TeleFlow.Telegram.Webhooks/Internal/TelegramWebhookUpdateLogFormatter.cs
@@ -1,0 +1,42 @@
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Webhooks.Internal;
+
+/// <summary>
+/// Formats safe Telegram update metadata for webhook diagnostics without reading user message content.
+/// </summary>
+internal static class TelegramWebhookUpdateLogFormatter
+{
+    public static string GetUpdateType(Update update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        if (update.Message is not null) return "message";
+        if (update.EditedMessage is not null) return "edited_message";
+        if (update.ChannelPost is not null) return "channel_post";
+        if (update.EditedChannelPost is not null) return "edited_channel_post";
+        if (update.BusinessConnection is not null) return "business_connection";
+        if (update.BusinessMessage is not null) return "business_message";
+        if (update.EditedBusinessMessage is not null) return "edited_business_message";
+        if (update.DeletedBusinessMessages is not null) return "deleted_business_messages";
+        if (update.GuestMessage is not null) return "guest_message";
+        if (update.MessageReaction is not null) return "message_reaction";
+        if (update.MessageReactionCount is not null) return "message_reaction_count";
+        if (update.InlineQuery is not null) return "inline_query";
+        if (update.ChosenInlineResult is not null) return "chosen_inline_result";
+        if (update.CallbackQuery is not null) return "callback_query";
+        if (update.ShippingQuery is not null) return "shipping_query";
+        if (update.PreCheckoutQuery is not null) return "pre_checkout_query";
+        if (update.PurchasedPaidMedia is not null) return "purchased_paid_media";
+        if (update.Poll is not null) return "poll";
+        if (update.PollAnswer is not null) return "poll_answer";
+        if (update.MyChatMember is not null) return "my_chat_member";
+        if (update.ChatMember is not null) return "chat_member";
+        if (update.ChatJoinRequest is not null) return "chat_join_request";
+        if (update.ChatBoost is not null) return "chat_boost";
+        if (update.RemovedChatBoost is not null) return "removed_chat_boost";
+        if (update.ManagedBot is not null) return "managed_bot";
+
+        return "unknown";
+    }
+}

--- a/src/TeleFlow.Telegram.Webhooks/TelegramRawWebhookEndpointRouteBuilderExtensions.cs
+++ b/src/TeleFlow.Telegram.Webhooks/TelegramRawWebhookEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using TeleFlow.Telegram.Webhooks.Internal;
 
 namespace TeleFlow.Telegram.Webhooks;
@@ -27,7 +29,10 @@ public static class TelegramRawWebhookEndpointRouteBuilderExtensions
             throw new InvalidOperationException("Telegram webhook path must start with '/'.");
         }
 
-        var endpoint = new TelegramRawWebhookEndpoint(handler, options);
+        var logger = endpoints.ServiceProvider
+            .GetService<ILoggerFactory>()
+            ?.CreateLogger<TelegramRawWebhookEndpoint>();
+        var endpoint = new TelegramRawWebhookEndpoint(handler, options, logger);
         return endpoints.MapPost(
             normalizedPattern,
             (Func<HttpContext, Task<IResult>>)endpoint.HandleAsync);

--- a/tests/TeleFlow.ArchitectureTests/RecordingLoggerFactory.cs
+++ b/tests/TeleFlow.ArchitectureTests/RecordingLoggerFactory.cs
@@ -42,13 +42,14 @@ internal sealed class RecordingLoggerFactory(LogLevel minimumLevel = LogLevel.Tr
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            entries.Add(new TestLogEntry(categoryName, logLevel, formatter(state, exception), exception));
+            entries.Add(new TestLogEntry(categoryName, eventId, logLevel, formatter(state, exception), exception));
         }
     }
 }
 
 internal sealed record TestLogEntry(
     string Category,
+    EventId EventId,
     LogLevel Level,
     string Message,
     Exception? Exception);

--- a/tests/TeleFlow.ArchitectureTests/StageSevenPolicyOverrideTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSevenPolicyOverrideTests.cs
@@ -142,7 +142,7 @@ public sealed class StageSevenPolicyOverrideTests
     }
 
     [Fact]
-    public async Task AddDefaultUpdateRateLimiting_RegistersNoOpLimiterMiddleware_AndAdditiveLimitersRunInOrder()
+    public async Task AddDefaultUpdateRateLimiting_RegistersMiddleware_AndAdditiveLimitersRunInOrder()
     {
         var trace = new List<string>();
         using var serviceProvider = new ServiceCollection()
@@ -160,7 +160,6 @@ public sealed class StageSevenPolicyOverrideTests
 
         Assert.Collection(
             limiters,
-            limiter => Assert.IsType<NoOpUpdateRateLimiter>(limiter),
             limiter => Assert.IsType<FirstRecordingRateLimiter>(limiter),
             limiter => Assert.IsType<SecondRecordingRateLimiter>(limiter));
         Assert.Contains(
@@ -397,19 +396,23 @@ public sealed class StageSevenPolicyOverrideTests
 
     private sealed class FirstRecordingRateLimiter(List<string> trace) : IUpdateRateLimiter
     {
-        public ValueTask WaitAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        public ValueTask<UpdateRateLimitDecision> CheckAsync(
+            UpdateContext context,
+            CancellationToken cancellationToken = default)
         {
             trace.Add("first");
-            return ValueTask.CompletedTask;
+            return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
         }
     }
 
     private sealed class SecondRecordingRateLimiter(List<string> trace) : IUpdateRateLimiter
     {
-        public ValueTask WaitAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        public ValueTask<UpdateRateLimitDecision> CheckAsync(
+            UpdateContext context,
+            CancellationToken cancellationToken = default)
         {
             trace.Add("second");
-            return ValueTask.CompletedTask;
+            return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
         }
     }
 }

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -924,6 +924,52 @@ public sealed class StageSixStateAndMiddlewareTests
         Assert.Equal(["rate-limit", "dispatch"], trace);
     }
 
+    [Fact]
+    public async Task UpdateRateLimitMiddleware_StopsPipelineAndLogsWarningWhenLimiterRejects()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var logger = new RecordingLogger<UpdateRateLimitMiddleware>();
+        var middleware = new UpdateRateLimitMiddleware(
+            [new RejectingRateLimiter()],
+            logger);
+        var context = new UpdateContext(serviceProvider, new TestUpdatePayload("secret-user-input"));
+        var called = false;
+
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            });
+
+        Assert.False(called);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(1, entry.EventId.Id);
+        Assert.Contains("Update rejected by rate limiter", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("policy=per-user-command", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("retry_after=00:00:15", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-user-input", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateRateLimitDecision_DefaultValueIsAccepted()
+    {
+        var decision = default(UpdateRateLimitDecision);
+
+        Assert.True(decision.IsAccepted);
+        Assert.False(decision.IsRejected);
+    }
+
+    [Fact]
+    public void UpdateRateLimitDecision_RejectsNegativeRetryAfter()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => UpdateRateLimitDecision.Rejected(TimeSpan.FromMilliseconds(-1)));
+    }
+
     private static ServiceProvider CreateTelegramServiceProvider(
         Action<IServiceCollection> configureServices,
         string token = "test-token")
@@ -1253,10 +1299,25 @@ public sealed class StageSixStateAndMiddlewareTests
 
     private sealed class RecordingRateLimiter(List<string> trace) : IUpdateRateLimiter
     {
-        public ValueTask WaitAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        public ValueTask<UpdateRateLimitDecision> CheckAsync(
+            UpdateContext context,
+            CancellationToken cancellationToken = default)
         {
             trace.Add("rate-limit");
-            return ValueTask.CompletedTask;
+            return ValueTask.FromResult(UpdateRateLimitDecision.Accepted);
+        }
+    }
+
+    private sealed class RejectingRateLimiter : IUpdateRateLimiter
+    {
+        public ValueTask<UpdateRateLimitDecision> CheckAsync(
+            UpdateContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(
+                UpdateRateLimitDecision.Rejected(
+                    TimeSpan.FromSeconds(15),
+                    "per-user-command"));
         }
     }
 
@@ -1671,9 +1732,9 @@ public sealed class StageSixStateAndMiddlewareTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+            Entries.Add(new LogEntry(eventId, logLevel, formatter(state, exception), exception));
         }
     }
 
-    private sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+    private sealed record LogEntry(EventId EventId, LogLevel Level, string Message, Exception? Exception);
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -132,6 +132,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 2 &&
                      entry.Category.EndsWith("TelegramHandlerDispatcher", StringComparison.Ordinal) &&
                      entry.Message.Contains("Telegram handler matched", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=StartCommandHandler.Handle", StringComparison.Ordinal) &&
@@ -140,6 +141,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 4 &&
                      entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler_ms=", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=0", StringComparison.Ordinal) &&
@@ -167,6 +169,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 4 &&
                      entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=OneTelegramRequestMessageHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=1", StringComparison.Ordinal) &&
@@ -194,6 +197,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 4 &&
                      entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=TwoTelegramRequestsCallbackHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=2", StringComparison.Ordinal) &&
@@ -248,6 +252,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 1 &&
                      entry.Message.Contains("No Telegram handler matched", StringComparison.Ordinal) &&
                      entry.Message.Contains("type=message", StringComparison.Ordinal) &&
                      entry.Message.Contains("match_ms=", StringComparison.Ordinal));
@@ -274,6 +279,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Error &&
+                     entry.EventId.Id == 3 &&
                      ReferenceEquals(entry.Exception, expected) &&
                      entry.Message.Contains("Telegram handler failed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=ThrowingMessageHandler.Handle", StringComparison.Ordinal) &&
@@ -304,6 +310,7 @@ public sealed class TelegramHandlerDispatcherTests
         var entry = Assert.Single(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Error &&
+                     entry.EventId.Id == 3 &&
                      ReferenceEquals(entry.Exception, expected) &&
                      entry.Message.Contains("Telegram handler failed", StringComparison.Ordinal));
 
@@ -353,6 +360,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 5 &&
                      entry.Message.Contains("Telegram error handler completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=ThrowingMessageHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("error_handler=HandledErrorHandler.Handle", StringComparison.Ordinal) &&
@@ -1524,6 +1532,37 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task FilterRejectedCandidate_LogsDebugDiagnosticWithoutMessageText()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddSingleton<DenyMessageFilter>();
+                services.AddTelegramHandler<DenyCustomFilterMessageHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("sensitive-message-text"));
+
+        Assert.Equal(["message:sensitive-message-text"], probe.Events);
+        var diagnostic = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 2 &&
+                     entry.Category == "TeleFlow.Telegram.Internal.Handlers.TelegramHandlerSelector");
+
+        Assert.Contains("Telegram handler candidate rejected by filters", diagnostic.Message, StringComparison.Ordinal);
+        Assert.Contains("handler=DenyCustomFilterMessageHandler.Handle", diagnostic.Message, StringComparison.Ordinal);
+        Assert.Contains("route=MessageAny", diagnostic.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sensitive-message-text", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ClassAndMethodCustomFilters_AreAndComposed()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -2333,6 +2372,7 @@ public sealed class TelegramHandlerDispatcherTests
             entry => entry.Level == LogLevel.Warning &&
                      entry.Category == "TeleFlow.Telegram.Internal.Handlers.TelegramHandlerSelector");
         Assert.Contains("Telegram callback data failed to deserialize", warning.Message);
+        Assert.Equal(1, warning.EventId.Id);
         Assert.Contains(nameof(CompactDeleteCallback), warning.Message);
         Assert.NotNull(warning.Exception);
     }

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -476,6 +476,7 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 1 &&
                      entry.Message.Contains("Telegram request started", StringComparison.Ordinal) &&
                      entry.Message.Contains("method=sendMessage", StringComparison.Ordinal) &&
                      entry.Message.Contains("attempt=1", StringComparison.Ordinal) &&
@@ -483,6 +484,7 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 2 &&
                      entry.Message.Contains("Telegram request completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("method=sendMessage", StringComparison.Ordinal) &&
                      entry.Message.Contains("status=200", StringComparison.Ordinal) &&
@@ -537,6 +539,7 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Warning &&
+                     entry.EventId.Id == 3 &&
                      entry.Message.Contains("Telegram request throttled", StringComparison.Ordinal) &&
                      entry.Message.Contains("method=getMe", StringComparison.Ordinal) &&
                      entry.Message.Contains("attempt=1", StringComparison.Ordinal) &&
@@ -544,6 +547,7 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 2 &&
                      entry.Message.Contains("Telegram request completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("attempt=2", StringComparison.Ordinal) &&
                      entry.Message.Contains("status=200", StringComparison.Ordinal));
@@ -566,11 +570,13 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Error &&
+                     entry.EventId.Id == 4 &&
                      ReferenceEquals(entry.Exception, exception) &&
                      entry.Message.Contains("Telegram request failed", StringComparison.Ordinal) &&
                      entry.Message.Contains("method=getMe", StringComparison.Ordinal) &&
                      entry.Message.Contains("status=400", StringComparison.Ordinal) &&
-                     entry.Message.Contains("request_ms=", StringComparison.Ordinal));
+                     entry.Message.Contains("request_ms=", StringComparison.Ordinal) &&
+                     entry.Message.Contains("exception_type=TeleFlow.Telegram.TelegramBadRequestException", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -589,11 +595,13 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Error &&
+                     entry.EventId.Id == 4 &&
                      ReferenceEquals(entry.Exception, exception) &&
                      entry.Message.Contains("Telegram request failed", StringComparison.Ordinal) &&
                      entry.Message.Contains("method=getMe", StringComparison.Ordinal) &&
                      entry.Message.Contains("status=502", StringComparison.Ordinal) &&
-                     entry.Message.Contains("request_ms=", StringComparison.Ordinal));
+                     entry.Message.Contains("request_ms=", StringComparison.Ordinal) &&
+                     entry.Message.Contains("exception_type=TeleFlow.Telegram.TelegramNetworkException", StringComparison.Ordinal));
         AssertRequestLogsDoNotContainSensitiveData(loggerFactory);
     }
 
@@ -1629,15 +1637,18 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Information &&
+                     entry.EventId.Id == 1 &&
                      entry.Message.Contains("Starting Telegram long polling", StringComparison.Ordinal) &&
                      entry.Message.Contains("allowed_updates=unset", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Information &&
+                     entry.EventId.Id == 2 &&
                      entry.Message.Contains("Telegram long polling connected", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 3 &&
                      entry.Message.Contains("Telegram update received", StringComparison.Ordinal) &&
                      entry.Message.Contains("update_id=1", StringComparison.Ordinal) &&
                      entry.Message.Contains("type=message", StringComparison.Ordinal) &&
@@ -1645,11 +1656,13 @@ public sealed class TelegramRuntimeIntegrationTests
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 5 &&
                      entry.Message.Contains("Telegram update processed", StringComparison.Ordinal) &&
                      entry.Message.Contains("total_ms=", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Information &&
+                     entry.EventId.Id == 6 &&
                      entry.Message.Contains("Telegram long polling stopped", StringComparison.Ordinal));
     }
 

--- a/tests/TeleFlow.ArchitectureTests/TelegramWebhookTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramWebhookTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using TeleFlow.Telegram;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
@@ -118,6 +119,77 @@ public sealed class TelegramWebhookTests
     }
 
     [Fact]
+    public async Task RawWebhookEndpoint_LogsSecretTokenRejectionWithoutSecretValues()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            configure: options => options.SecretToken = "expected-secret-value",
+            loggerFactory: loggerFactory);
+
+        var context = await InvokeAsync(app, ValidUpdateJson, secretToken: "wrong-secret-value");
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        var warning = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.EventId.Id == 1 &&
+                     entry.Category == "TeleFlow.Telegram.Webhooks.Internal.TelegramRawWebhookEndpoint");
+
+        Assert.Contains("secret token validation failed", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("expected-secret-value", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("wrong-secret-value", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_LogsInvalidPayloadWithoutRequestBody()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            loggerFactory: loggerFactory);
+
+        var context = await InvokeAsync(app, "{ invalid");
+
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        var warning = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.EventId.Id == 2 &&
+                     entry.Category == "TeleFlow.Telegram.Webhooks.Internal.TelegramRawWebhookEndpoint");
+
+        Assert.Contains("payload was invalid", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("{ invalid", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_LogsAcceptedUpdateWithoutMessageText()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            loggerFactory: loggerFactory);
+
+        var context = await InvokeAsync(app, ValidUpdateJson);
+
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 3 &&
+                     entry.Message.Contains("update_id=123", StringComparison.Ordinal) &&
+                     entry.Message.Contains("type=message", StringComparison.Ordinal) &&
+                     !entry.Message.Contains("hello", StringComparison.Ordinal));
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Debug &&
+                     entry.EventId.Id == 4 &&
+                     entry.Message.Contains("update_id=123", StringComparison.Ordinal) &&
+                     entry.Message.Contains("type=message", StringComparison.Ordinal) &&
+                     !entry.Message.Contains("hello", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RawWebhookEndpoint_AcceptsValidSecretToken()
     {
         var invoked = false;
@@ -228,11 +300,16 @@ public sealed class TelegramWebhookTests
         TelegramRawWebhookHandler handler,
         string path = "/telegram",
         FakeTelegramClient? bot = null,
-        Action<TelegramRawWebhookOptions>? configure = null)
+        Action<TelegramRawWebhookOptions>? configure = null,
+        RecordingLoggerFactory? loggerFactory = null)
     {
         var builder = WebApplication.CreateBuilder();
 
         builder.Services.AddSingleton<ITelegramClient>(bot ?? new FakeTelegramClient());
+        if (loggerFactory is not null)
+        {
+            builder.Services.AddSingleton<ILoggerFactory>(loggerFactory);
+        }
 
         var app = builder.Build();
         app.MapTelegramWebhook(path, handler, configure);


### PR DESCRIPTION
## Summary

- replace update-level rate limiting with explicit `UpdateRateLimitDecision` results instead of exception-based throttling
- add safe runtime diagnostics for filter rejections, webhook rejection/processing paths, and Telegram request failures
- document logging levels, event-id expectations, and logging security/privacy rules in English and Russian docs

## Breaking Change

`IUpdateRateLimiter.WaitAsync(...)` is replaced with `CheckAsync(...) -> UpdateRateLimitDecision`.

This is intentional before 1.0. Expected throttling is now represented as a normal decision:

- `Accepted` continues the pipeline
- `Rejected` stops the pipeline and logs a warning
- limiter exceptions remain real failures

## Touched Hot Paths

- `UpdateRateLimitMiddleware`: accepted path uses a value-type decision and does not use exception control flow.
- `TelegramHandlerSelector`: filter rejection diagnostics run only after a route matched and only build diagnostic fields when `Debug` is enabled.
- `TelegramRawWebhookEndpoint`: success diagnostics avoid update-type formatting unless `Debug` is enabled; failures log safe metadata only.
- `TelegramRequestExecutor`: request failure logs now include `exception_type`; broader request executor decomposition is tracked separately in #125.

## Logging Safety

Framework-generated logs continue to avoid bot tokens, webhook secrets, raw callback payloads, request bodies, message text, captions, and arbitrary rate-limit keys by default.

TeleFlow emits static `Microsoft.Extensions.Logging` templates and does not execute, evaluate, or perform lookup operations on log content.

## Validation

- `dotnet build .\TeleFlow.sln --no-restore`
- `dotnet test .\tests\TeleFlow.ArchitectureTests\TeleFlow.ArchitectureTests.csproj --no-restore`
- `git diff --check HEAD~3..HEAD`

Closes #26
Follow-up: #125
