### PR TITLE
perf(client): parse Telegram responses from UTF-8 bytes

### DIFF
--- a/docs/en/features/telegram-client.md
+++ b/docs/en/features/telegram-client.md
@@ -126,6 +126,26 @@ builder.Services.AddTelegramTransport<MyTelegramTransport>();
 
 Use this for tests, custom networking, proxies, diagnostics, or controlled `HttpClient` ownership.
 
+Custom transports return the raw Telegram response body as UTF-8 bytes:
+
+```csharp
+public sealed class MyTelegramTransport : ITelegramTransport
+{
+    public async Task<TelegramTransportResponse> SendAsync(
+        TelegramTransportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        byte[] body = await SendThroughCustomStackAsync(request, cancellationToken);
+
+        return new TelegramTransportResponse(
+            statusCode: 200,
+            body: body);
+    }
+}
+```
+
+The `string` constructor is still available for simple tests and adapters, but the client pipeline parses bytes directly to avoid rebuilding JSON text before deserialization.
+
 ## JSON Options
 
 Telegram JSON options can be replaced:

--- a/docs/ru/features/telegram-client.md
+++ b/docs/ru/features/telegram-client.md
@@ -126,6 +126,26 @@ builder.Services.AddTelegramTransport<MyTelegramTransport>();
 
 Это нужно для tests, custom networking, proxies, diagnostics или контролируемого `HttpClient` ownership.
 
+Custom transport возвращает raw Telegram response body как UTF-8 bytes:
+
+```csharp
+public sealed class MyTelegramTransport : ITelegramTransport
+{
+    public async Task<TelegramTransportResponse> SendAsync(
+        TelegramTransportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        byte[] body = await SendThroughCustomStackAsync(request, cancellationToken);
+
+        return new TelegramTransportResponse(
+            statusCode: 200,
+            body: body);
+    }
+}
+```
+
+`string` constructor остаётся для простых tests и adapters, но client pipeline парсит bytes напрямую, чтобы не пересобирать JSON text перед deserialization.
+
 ## JSON options
 
 Telegram JSON options можно заменить:

--- a/src/TeleFlow.Telegram.Client/HttpClientTelegramTransport.cs
+++ b/src/TeleFlow.Telegram.Client/HttpClientTelegramTransport.cs
@@ -4,6 +4,10 @@ using System.Text;
 
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Default <see cref="ITelegramTransport"/> implementation that sends Telegram Bot API requests through <see cref="HttpClient"/>.
+/// It is used by the generated client pipeline unless an application registers a custom transport.
+/// </summary>
 public sealed class HttpClientTelegramTransport : ITelegramTransport, IDisposable
 {
     private readonly HttpClient _httpClient;
@@ -42,9 +46,9 @@ public sealed class HttpClientTelegramTransport : ITelegramTransport, IDisposabl
         try
         {
             using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
-            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var body = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
-            return new TelegramTransportResponse(
+            return TelegramTransportResponse.FromOwnedBytes(
                 (int)response.StatusCode,
                 body,
                 CopyHeaders(response));

--- a/src/TeleFlow.Telegram.Client/ITelegramTransport.cs
+++ b/src/TeleFlow.Telegram.Client/ITelegramTransport.cs
@@ -1,5 +1,9 @@
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Sends raw Telegram Bot API transport requests and returns raw UTF-8 response bodies for the typed client pipeline.
+/// Applications can replace this boundary for custom networking, proxies, tests, or controlled <see cref="HttpClient"/> ownership.
+/// </summary>
 public interface ITelegramTransport
 {
     Task<TelegramTransportResponse> SendAsync(

--- a/src/TeleFlow.Telegram.Client/Internal/ITelegramExecutableRequest.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/ITelegramExecutableRequest.cs
@@ -2,6 +2,10 @@ using System.Text.Json;
 
 namespace TeleFlow.Telegram.Internal;
 
+/// <summary>
+/// Internal executable form of a Telegram API request used by the request executor after public client calls are normalized.
+/// It deserializes the already-parsed Telegram result element while the transport envelope is still alive.
+/// </summary>
 internal interface ITelegramExecutableRequest<out TResponse> : ITelegramRequest<TResponse>
     where TResponse : ITelegramResponse
 {
@@ -9,5 +13,5 @@ internal interface ITelegramExecutableRequest<out TResponse> : ITelegramRequest<
 
     object Payload { get; }
 
-    TResponse DeserializeResponse(JsonSerializerOptions serializerOptions, string resultJson);
+    TResponse DeserializeResponse(JsonSerializerOptions serializerOptions, JsonElement result);
 }

--- a/src/TeleFlow.Telegram.Client/Internal/SchemaTelegramRequest.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/SchemaTelegramRequest.cs
@@ -5,6 +5,10 @@ using TeleFlow.Telegram.Schema.Abstractions;
 
 namespace TeleFlow.Telegram.Internal;
 
+/// <summary>
+/// Adapts a generated schema method object to the executable request contract used by the Telegram client runtime.
+/// It resolves the generated method name and maps a parsed Telegram result element into the strongly typed method result.
+/// </summary>
 internal sealed class SchemaTelegramRequest<TResult> :
     ITelegramExecutableRequest<TelegramRequestResult<TResult>>
 {
@@ -23,20 +27,19 @@ internal sealed class SchemaTelegramRequest<TResult> :
 
     public TelegramRequestResult<TResult> DeserializeResponse(
         JsonSerializerOptions serializerOptions,
-        string resultJson)
+        JsonElement result)
     {
         ArgumentNullException.ThrowIfNull(serializerOptions);
-        ArgumentNullException.ThrowIfNull(resultJson);
 
-        var result = JsonSerializer.Deserialize<TResult>(resultJson, serializerOptions);
+        var value = result.Deserialize<TResult>(serializerOptions);
 
-        if (result is null)
+        if (value is null)
         {
             throw new TelegramRequestException(
                 $"Telegram response for method '{MethodName}' did not contain a deserializable result payload.");
         }
 
-        return new TelegramRequestResult<TResult>(result);
+        return new TelegramRequestResult<TResult>(value);
     }
 
     private static string ResolveMethodName(Type methodType)

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestExecutor.cs
@@ -76,21 +76,23 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                     parseException);
             }
 
-            if (envelope.Ok)
+            using var parsedEnvelope = envelope;
+
+            if (parsedEnvelope.Ok)
             {
                 return DeserializeSuccessResponse(
                     executableRequest,
                     context,
                     diagnostics,
                     response,
-                    envelope);
+                    parsedEnvelope);
             }
 
             if (await TryDelayRetryAfterAsync(
                     diagnostics,
                     attempt,
                     response,
-                    envelope,
+                    parsedEnvelope,
                     cancellationToken).ConfigureAwait(false))
             {
                 continue;
@@ -100,7 +102,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
                 context,
                 diagnostics,
                 response,
-                envelope);
+                parsedEnvelope);
         }
     }
 
@@ -181,7 +183,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
         TelegramTransportEnvelope envelope)
         where TResponse : ITelegramResponse
     {
-        if (string.IsNullOrWhiteSpace(envelope.ResultJson))
+        if (!envelope.HasResult)
         {
             var exception = new TelegramDecodeException(
                 $"Telegram response for method '{context.MethodName}' did not contain a result payload.",
@@ -194,7 +196,7 @@ internal sealed partial class TelegramRequestExecutor : ITelegramRequestExecutor
 
         try
         {
-            return executableRequest.DeserializeResponse(_serializerOptions, envelope.ResultJson);
+            return executableRequest.DeserializeResponse(_serializerOptions, envelope.Result);
         }
         catch (TelegramRequestException)
         {

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramTransportEnvelope.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramTransportEnvelope.cs
@@ -1,16 +1,50 @@
+using System.Text.Json;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal;
 
-internal sealed class TelegramTransportEnvelope
+/// <summary>
+/// Owns a parsed Telegram Bot API response envelope for one request attempt.
+/// The request executor uses it to decide between success, API error, retry-after, and decode failure paths.
+/// </summary>
+internal sealed class TelegramTransportEnvelope : IDisposable
 {
-    public required bool Ok { get; init; }
+    private readonly JsonDocument _document;
 
-    public string? ResultJson { get; init; }
+    public TelegramTransportEnvelope(
+        JsonDocument document,
+        bool ok,
+        bool hasResult,
+        JsonElement result,
+        string? description,
+        int? errorCode,
+        ResponseParameters? responseParameters)
+    {
+        ArgumentNullException.ThrowIfNull(document);
 
-    public string? Description { get; init; }
+        _document = document;
+        Ok = ok;
+        HasResult = hasResult;
+        Result = result;
+        Description = description;
+        ErrorCode = errorCode;
+        ResponseParameters = responseParameters;
+    }
 
-    public int? ErrorCode { get; init; }
+    public bool Ok { get; }
 
-    public ResponseParameters? ResponseParameters { get; init; }
+    public bool HasResult { get; }
+
+    public JsonElement Result { get; }
+
+    public string? Description { get; }
+
+    public int? ErrorCode { get; }
+
+    public ResponseParameters? ResponseParameters { get; }
+
+    public void Dispose()
+    {
+        _document.Dispose();
+    }
 }

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramTransportEnvelopeParser.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramTransportEnvelopeParser.cs
@@ -3,6 +3,10 @@ using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal;
 
+/// <summary>
+/// Parses raw Telegram Bot API response bytes into an owned envelope used by the request executor.
+/// It keeps the parsed JSON document alive so successful result payloads can be deserialized without rematerializing JSON text.
+/// </summary>
 internal sealed class TelegramTransportEnvelopeParser
 {
     private readonly JsonSerializerOptions _serializerOptions;
@@ -14,24 +18,22 @@ internal sealed class TelegramTransportEnvelopeParser
     }
 
     public bool TryParse(
-        string responseText,
+        ReadOnlyMemory<byte> responseBody,
         out TelegramTransportEnvelope envelope,
         out JsonException? exception)
     {
+        JsonDocument? document = null;
+
         try
         {
-            using var document = JsonDocument.Parse(responseText);
+            document = JsonDocument.Parse(responseBody);
             var root = document.RootElement;
 
             var ok = root.TryGetProperty("ok", out var okElement) && okElement.ValueKind is JsonValueKind.True or JsonValueKind.False
                 ? okElement.GetBoolean()
                 : throw new JsonException("Telegram response does not contain a valid 'ok' property.");
 
-            string? resultJson = null;
-            if (root.TryGetProperty("result", out var resultElement))
-            {
-                resultJson = resultElement.GetRawText();
-            }
+            var hasResult = root.TryGetProperty("result", out var resultElement);
 
             string? description = null;
             if (root.TryGetProperty("description", out var descriptionElement) &&
@@ -52,18 +54,19 @@ internal sealed class TelegramTransportEnvelopeParser
             if (root.TryGetProperty("response_parameters", out var responseParametersElement))
             {
                 responseParameters = JsonSerializer.Deserialize<ResponseParameters>(
-                    responseParametersElement.GetRawText(),
+                    responseParametersElement,
                     _serializerOptions);
             }
 
-            envelope = new TelegramTransportEnvelope
-            {
-                Ok = ok,
-                ResultJson = resultJson,
-                Description = description,
-                ErrorCode = errorCode,
-                ResponseParameters = responseParameters
-            };
+            envelope = new TelegramTransportEnvelope(
+                document,
+                ok,
+                hasResult,
+                resultElement,
+                description,
+                errorCode,
+                responseParameters);
+            document = null;
             exception = null;
             return true;
         }
@@ -72,6 +75,10 @@ internal sealed class TelegramTransportEnvelopeParser
             envelope = null!;
             exception = jsonException;
             return false;
+        }
+        finally
+        {
+            document?.Dispose();
         }
     }
 }

--- a/src/TeleFlow.Telegram.Client/TelegramTransportResponse.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramTransportResponse.cs
@@ -1,25 +1,75 @@
+using System.Text;
+
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Represents one raw Telegram Bot API HTTP response returned by an <see cref="ITelegramTransport"/>.
+/// The request executor parses the UTF-8 response body into a Telegram envelope before mapping it to typed API results or exceptions.
+/// </summary>
 public sealed class TelegramTransportResponse
 {
     public TelegramTransportResponse(
         int statusCode,
         string body,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? headers = null)
+        : this(statusCode, EncodeBody(body), headers, copyBody: false)
     {
-        ArgumentNullException.ThrowIfNull(body);
+    }
 
+    public TelegramTransportResponse(
+        int statusCode,
+        byte[] body,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? headers = null)
+        : this(statusCode, AsMemory(body), headers, copyBody: true)
+    {
+    }
+
+    public TelegramTransportResponse(
+        int statusCode,
+        ReadOnlyMemory<byte> body,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? headers = null)
+        : this(statusCode, body, headers, copyBody: true)
+    {
+    }
+
+    private TelegramTransportResponse(
+        int statusCode,
+        ReadOnlyMemory<byte> body,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? headers,
+        bool copyBody)
+    {
         StatusCode = statusCode;
-        Body = body;
+        Body = copyBody ? body.ToArray() : body;
         Headers = CopyHeaders(headers);
     }
 
+    internal static TelegramTransportResponse FromOwnedBytes(
+        int statusCode,
+        byte[] body,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? headers = null)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return new TelegramTransportResponse(statusCode, body, headers, copyBody: false);
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code returned by Telegram.
+    /// </summary>
     public int StatusCode { get; }
 
-    public string Body { get; }
+    /// <summary>
+    /// Gets the raw UTF-8 response body returned by Telegram.
+    /// </summary>
+    public ReadOnlyMemory<byte> Body { get; }
 
+    /// <summary>
+    /// Gets response headers copied from the underlying transport.
+    /// </summary>
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; }
 
+    /// <summary>
+    /// Tries to read response header values by name using case-insensitive lookup.
+    /// </summary>
     public bool TryGetHeaderValues(string name, out IReadOnlyList<string> values)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -38,5 +88,17 @@ public sealed class TelegramTransportResponse
             static pair => pair.Key,
             static pair => (IReadOnlyList<string>)pair.Value.ToArray(),
             StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static byte[] EncodeBody(string body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return Encoding.UTF8.GetBytes(body);
+    }
+
+    private static ReadOnlyMemory<byte> AsMemory(byte[] body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return body.AsMemory();
     }
 }

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using TeleFlow.Framework.Application;
@@ -665,9 +666,30 @@ public sealed class PublicSurfaceTests
         Assert.Equal(global::TeleFlow.Telegram.TelegramParseMode.Html, defaults.ParseMode);
         Assert.False(jsonOptions.SerializerOptions.PropertyNameCaseInsensitive);
         Assert.Same(content, request.Content);
+        Assert.Equal("{}", Encoding.UTF8.GetString(response.Body.Span));
         Assert.True(response.TryGetHeaderValues("retry-after", out var values));
         Assert.Equal("1", Assert.Single(values));
         Assert.Equal(TimeSpan.FromSeconds(1), exception.RetryAfter);
+    }
+
+    [Fact]
+    public void TelegramTransportResponse_BodyUsesUtf8BytesAsPrimaryRepresentation()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"ok":true,"result":true}""");
+        var response = new global::TeleFlow.Telegram.TelegramTransportResponse(200, body);
+
+        Assert.Equal("""{"ok":true,"result":true}""", Encoding.UTF8.GetString(response.Body.Span));
+    }
+
+    [Fact]
+    public void TelegramTransportResponse_CopiesPublicByteArrays()
+    {
+        var body = Encoding.UTF8.GetBytes("{}");
+        var response = new global::TeleFlow.Telegram.TelegramTransportResponse(200, body);
+
+        body[0] = (byte)'[';
+
+        Assert.Equal("{}", Encoding.UTF8.GetString(response.Body.Span));
     }
 
     [Fact]

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -456,6 +456,42 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task TelegramClient_SendAsync_DeserializesResultFromUtf8TransportBody()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddSingleton<ITelegramTransport>(
+            new RecordingTelegramTransport(
+                new TelegramTransportResponse(
+                    200,
+                    Encoding.UTF8.GetBytes(
+                        """{"ok":true,"result":{"id":42,"is_bot":true,"first_name":"TeleFlow Bot"}}"""))));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var user = await client.SendAsync(new GetMe());
+
+        Assert.Equal(42, user.Id);
+        Assert.Equal("TeleFlow Bot", user.FirstName);
+    }
+
+    [Fact]
+    public async Task TelegramClient_SendAsync_ReturnsJsonElementResultAfterEnvelopeDisposal()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse("""{"ok":true,"result":{"id":42,"name":"raw"}}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(handler);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var result = await client.SendAsync(new JsonElementResultMethod());
+
+        Assert.Equal(42, result.GetProperty("id").GetInt32());
+        Assert.Equal("raw", result.GetProperty("name").GetString());
+    }
+
+    [Fact]
     public async Task Executor_LogsSuccessfulRequestDiagnosticsWithoutSensitiveData()
     {
         var loggerFactory = new RecordingLoggerFactory();
@@ -1513,6 +1549,23 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task Executor_InvalidUtf8Response_PreservesHttpStatusCode()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddSingleton<ITelegramTransport>(
+            new RecordingTelegramTransport(new TelegramTransportResponse(200, [0xFF, 0x7B])));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var exception = await Assert.ThrowsAsync<TelegramDecodeException>(() => client.SendAsync(new GetMe()));
+
+        Assert.Equal(200, exception.HttpStatusCode);
+        Assert.Equal("getMe", exception.MethodName);
+    }
+
+    [Fact]
     public async Task Executor_DoesNotRetryNon429Failures()
     {
         var handler = new RecordingHttpMessageHandler(
@@ -1560,7 +1613,7 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
-    public async Task Executor_ThrowsDecodeException_WhenResultJsonIsInvalid()
+    public async Task Executor_ThrowsDecodeException_WhenTypedResultCannotBeDeserialized()
     {
         var handler = new RecordingHttpMessageHandler(
             CreateJsonResponse("""{"ok":true,"result":{"id":"not-a-number","is_bot":true,"first_name":"Bot"}}"""));
@@ -3536,6 +3589,11 @@ public sealed class TelegramRuntimeIntegrationTests
         [JsonIgnore]
         public object Poison =>
             throw new InvalidOperationException("JSON-only request content should not scan ignored properties.");
+    }
+
+    private sealed partial record class JsonElementResultMethod : ITelegramApiMethod<JsonElement>
+    {
+        public static string MethodName => "jsonElementResult";
     }
 
     private sealed class RecordingTelegramTransport : ITelegramTransport


### PR DESCRIPTION
## Summary
- change `TelegramTransportResponse.Body` to a UTF-8 byte buffer while keeping the string constructor for simple tests and adapters
- parse Telegram response envelopes directly from bytes and deserialize successful `result` payloads from `JsonElement`
- keep public byte-array constructors defensive while allowing the default HTTP transport to pass owned response bytes without a second copy
- document the custom transport response-body contract in English and Russian docs

## Touched hot paths
- `HttpClientTelegramTransport.SendAsync`: reads response bodies with `ReadAsByteArrayAsync` instead of `ReadAsStringAsync`
- `TelegramTransportEnvelopeParser.TryParse`: parses the raw byte body into an owned `JsonDocument`
- `TelegramRequestExecutor.ExecuteAsync`: keeps the envelope alive through success deserialization and disposes it after the request result is created
- `SchemaTelegramRequest.DeserializeResponse`: deserializes typed results from the parsed `JsonElement` instead of rematerialized JSON text

## Validation
- `dotnet test .\TeleFlow.sln --no-restore`
- `dotnet build .\TeleFlow.sln -c Release --no-restore`
- `dotnet format .\TeleFlow.sln whitespace --verify-no-changes --no-restore`
- `dotnet build .\benchmarks\TeleFlow.Benchmarks\TeleFlow.Benchmarks.csproj -c Release --no-restore`
- `git diff --check`

## Benchmark note
The benchmark project compiles after the transport API change. Full BenchmarkDotNet before/after numbers should be collected separately before publishing performance claims for this issue.

Closes #51