### PR TITLE
docs: clarify cancellation ergonomics

### DIFF
--- a/docs/en/enterprise/production-checklist.md
+++ b/docs/en/enterprise/production-checklist.md
@@ -41,7 +41,8 @@ Related pages:
 
 - Keep handlers thin.
 - Move business logic into application services.
-- Pass `CancellationToken` to I/O.
+- Pass `CancellationToken` to application I/O.
+- Use context-bound Telegram helpers without an explicit token when update cancellation is intended.
 - Keep template and regex routes readable.
 - Avoid overly broad catch-all handlers.
 

--- a/docs/en/fundamentals/cancellation.md
+++ b/docs/en/fundamentals/cancellation.md
@@ -1,6 +1,6 @@
 # Cancellation
 
-TeleFlow passes cancellation through the update pipeline. Handler methods can receive `CancellationToken`, and context helpers use the update cancellation token when you do not pass one explicitly.
+TeleFlow carries cancellation through the update pipeline. Handler methods can receive the current update token, and context-bound Telegram helpers use that token when you do not pass one explicitly.
 
 ## Handler Tokens
 
@@ -8,54 +8,69 @@ TeleFlow passes cancellation through the update pipeline. Handler methods can re
 [Command("start")]
 public Task Start(MessageContext ctx, CancellationToken ct)
 {
-    return ctx.Message.AnswerAsync("Ready.", ct);
+    return ctx.Message.AnswerAsync("Ready.");
 }
 ```
 
-Use the token for I/O:
+Keep the token in the handler signature even if a small handler does not use it yet. The handler is the boundary where application services, repositories, HTTP clients, queues, and other I/O should receive cancellation explicitly.
 
 ```csharp
 [Command("report")]
 public async Task Report(MessageContext ctx, IReportService reports, CancellationToken ct)
 {
     var report = await reports.BuildAsync(ctx.Sender?.Id, ct);
-    await ctx.Message.AnswerAsync(report.Title, ct);
+    await ctx.Message.AnswerAsync(report.Title);
 }
 ```
 
-## Context Helpers
+## Context-Bound Telegram Helpers
 
-Message and callback helpers accept optional cancellation tokens:
+The helpers exposed by TeleFlow contexts are bound to the current update:
 
 ```csharp
-await ctx.Message.AnswerAsync("Saved.", ct);
-await ctx.Callback.AnswerAsync(ct);
-await ctx.Callback.EditTextAsync("Done.", ct);
+await ctx.Message.AnswerAsync("Saved.");
+await ctx.Callback.AnswerAsync();
+await ctx.Callback.EditTextAsync("Done.");
+await ctx.Chat.ActionAsync(ChatAction.Typing);
 ```
 
-If no token is passed, helpers resolve the token from the current update context.
+If no token is passed, these helpers use the update cancellation token. A non-cancelable token such as `CancellationToken.None` is treated the same way in context-bound Telegram helpers. If you pass a cancelable token explicitly, that token wins.
 
-## Direct Bot API Calls
+## `ctx.Bot` Calls
 
-Generated client methods also accept cancellation tokens:
+Generated client methods also accept cancellation tokens, but `ctx.Bot` is update-scoped inside handlers:
 
 ```csharp
 using TeleFlow.Telegram.Schema.Abstractions;
 
 await ctx.Bot.SendMessageAsync(
     chatId: IntegerString.From(ctx.TelegramChat.Id),
-    text: "Processing complete.",
-    cancellationToken: ct);
+    text: "Processing complete.");
+```
+
+The same generated method called on a root `ITelegramClient` from DI is not update-scoped. Outside a handler context, pass the token explicitly.
+
+```csharp
+public sealed class BroadcastService(ITelegramClient bot)
+{
+    public Task SendAsync(long chatId, string text, CancellationToken ct)
+    {
+        return bot.SendMessageAsync(
+            chatId: IntegerString.From(chatId),
+            text: text,
+            cancellationToken: ct);
+    }
+}
 ```
 
 ## Recommended Rule
 
-Pass `CancellationToken` to:
+Use this rule:
 
-- database calls;
-- HTTP calls;
-- Telegram Bot API calls;
-- storage calls;
-- long-running CPU or background work that supports cancellation.
+- keep `CancellationToken ct` in async handlers;
+- pass `ct` to your own I/O: database calls, HTTP calls, queues, storage, EF Core, and background work;
+- omit `ct` for `ctx.Message`, `ctx.Callback`, `ctx.Chat`, and `ctx.Bot` calls inside handlers when you want the current update token;
+- pass an explicit token only when you intentionally want different cancellation semantics;
+- do not hide cancellation in application services through ambient state or static accessors.
 
-It is acceptable to omit it for tiny pure in-memory operations, but it is usually clearer to keep handler I/O consistently cancellable.
+This keeps small bots readable without making production code depend on hidden cancellation behavior.

--- a/docs/ru/enterprise/production-checklist.md
+++ b/docs/ru/enterprise/production-checklist.md
@@ -41,7 +41,8 @@
 
 - Держи handlers thin.
 - Переноси business logic в application services.
-- Передавай `CancellationToken` в I/O.
+- Передавай `CancellationToken` в application I/O.
+- Используй context-bound Telegram helpers без явного token, если нужна cancellation текущего update.
 - Держи template и regex routes readable.
 - Избегай слишком широких catch-all handlers.
 

--- a/docs/ru/fundamentals/cancellation.md
+++ b/docs/ru/fundamentals/cancellation.md
@@ -1,61 +1,76 @@
 # Cancellation
 
-TeleFlow передаёт cancellation через update pipeline. Handler methods могут принимать `CancellationToken`, а context helpers используют token текущего update, если ты не передал token явно.
+TeleFlow передаёт cancellation через пайплайн обновлений. Хэндлер может принимать token текущего обновления, а Telegram-хелперы, привязанные к context, используют этот token автоматически, если ты не передал другой token явно.
 
-## Handler tokens
+## Токены в хэндлерах
 
 ```csharp
 [Command("start")]
 public Task Start(MessageContext ctx, CancellationToken ct)
 {
-    return ctx.Message.AnswerAsync("Ready.", ct);
+    return ctx.Message.AnswerAsync("Ready.");
 }
 ```
 
-Используй token для I/O:
+Оставляй `CancellationToken` в async хэндлере, даже если маленький хэндлер пока его не использует. Хэндлер - это граница, где прикладные сервисы, репозитории, HTTP-клиенты, очереди и другая I/O-логика должны получать cancellation явно.
 
 ```csharp
 [Command("report")]
 public async Task Report(MessageContext ctx, IReportService reports, CancellationToken ct)
 {
     var report = await reports.BuildAsync(ctx.Sender?.Id, ct);
-    await ctx.Message.AnswerAsync(report.Title, ct);
+    await ctx.Message.AnswerAsync(report.Title);
 }
 ```
 
-## Context helpers
+## Telegram-хелперы из context
 
-Message и callback helpers принимают optional cancellation tokens:
+Хелперы, которые TeleFlow отдаёт через context, привязаны к текущему обновлению:
 
 ```csharp
-await ctx.Message.AnswerAsync("Saved.", ct);
-await ctx.Callback.AnswerAsync(ct);
-await ctx.Callback.EditTextAsync("Done.", ct);
+await ctx.Message.AnswerAsync("Saved.");
+await ctx.Callback.AnswerAsync();
+await ctx.Callback.EditTextAsync("Done.");
+await ctx.Chat.ActionAsync(ChatAction.Typing);
 ```
 
-Если token не передан, helpers берут token из current update context.
+Если token не передан, эти helpers используют cancellation token текущего обновления. Token, который нельзя отменить, например `CancellationToken.None`, в этих Telegram-хелперах трактуется так же. Если ты передал cancelable token явно, он переопределит token обновления.
 
-## Прямые вызовы Bot API
+## Вызовы через `ctx.Bot`
 
-Generated client methods тоже принимают cancellation tokens:
+Сгенерированные методы клиента тоже принимают cancellation tokens, но `ctx.Bot` внутри хэндлера является update-scoped:
 
 ```csharp
 using TeleFlow.Telegram.Schema.Abstractions;
 
 await ctx.Bot.SendMessageAsync(
     chatId: IntegerString.From(ctx.TelegramChat.Id),
-    text: "Processing complete.",
-    cancellationToken: ct);
+    text: "Processing complete.");
+```
+
+Тот же generated method, вызванный на root `ITelegramClient` из DI, уже не привязан к обновлению. Вне context хэндлера передавай token явно.
+
+```csharp
+public sealed class BroadcastService(ITelegramClient bot)
+{
+    public Task SendAsync(long chatId, string text, CancellationToken ct)
+    {
+        return bot.SendMessageAsync(
+            chatId: IntegerString.From(chatId),
+            text: text,
+            cancellationToken: ct);
+    }
+}
 ```
 
 ## Рекомендуемое правило
 
-Передавай `CancellationToken` в:
+Держи правило таким:
 
-- database calls;
-- HTTP calls;
-- Telegram Bot API calls;
-- storage calls;
-- долгие CPU/background operations, если они поддерживают cancellation.
+- оставляй `CancellationToken ct` в async хэндлерах;
+- передавай `ct` в свою I/O-логику: database calls, HTTP calls, очереди, storage, EF Core и background work;
+- не передавай `ct` в `ctx.Message`, `ctx.Callback`, `ctx.Chat` и `ctx.Bot` внутри хэндлера, если тебе нужен token текущего обновления;
+- передавай явный token только если тебе намеренно нужны другие cancellation semantics;
+- не прячь cancellation в application services через ambient state или static accessors.
 
-Для маленьких pure in-memory operations token можно не передавать, но обычно понятнее держать handler I/O consistently cancellable.
+Так маленький бот остаётся читаемым, а production code не начинает зависеть от скрытой магии.

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -2173,6 +2173,96 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task MessageActions_AnswerAsync_UsesUpdateCancellationWhenTokenIsDefault()
+    {
+        using var updateCancellation = new CancellationTokenSource();
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method is SendMessage
+                ? new Message
+                {
+                    MessageId = 20,
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "private" },
+                    Text = "done"
+                }
+                : throw new InvalidOperationException("Unexpected method.")
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateScopedMessageUpdateContext(serviceProvider, updateCancellation.Token);
+
+        await context.GetMessageContext().Message.AnswerAsync("done");
+
+        Assert.Equal(updateCancellation.Token, fakeClient.CancellationTokens.Single());
+    }
+
+    [Fact]
+    public async Task MessageActions_AnswerAsync_ExplicitTokenOverridesUpdateCancellation()
+    {
+        using var updateCancellation = new CancellationTokenSource();
+        using var explicitCancellation = new CancellationTokenSource();
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method is SendMessage
+                ? new Message
+                {
+                    MessageId = 20,
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "private" },
+                    Text = "done"
+                }
+                : throw new InvalidOperationException("Unexpected method.")
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateScopedMessageUpdateContext(serviceProvider, updateCancellation.Token);
+
+        await context.GetMessageContext().Message.AnswerAsync("done", explicitCancellation.Token);
+
+        Assert.Equal(explicitCancellation.Token, fakeClient.CancellationTokens.Single());
+    }
+
+    [Fact]
+    public async Task CallbackQueryActions_AnswerAsync_UsesUpdateCancellationWhenTokenIsDefault()
+    {
+        using var updateCancellation = new CancellationTokenSource();
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method is AnswerCallbackQuery
+                ? true
+                : throw new InvalidOperationException("Unexpected method.")
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateCallbackQueryUpdateContext(serviceProvider, updateCancellation.Token);
+
+        await context.GetCallbackQueryContext().Callback.AnswerAsync();
+
+        Assert.Equal(updateCancellation.Token, fakeClient.CancellationTokens.Single());
+    }
+
+    [Fact]
+    public async Task ChatActions_ActionAsync_UsesUpdateCancellationWhenTokenIsDefault()
+    {
+        using var updateCancellation = new CancellationTokenSource();
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method is SendChatAction
+                ? true
+                : throw new InvalidOperationException("Unexpected method.")
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateScopedMessageUpdateContext(serviceProvider, updateCancellation.Token);
+
+        var lease = await context.GetMessageContext().Chat.ActionAsync(ChatAction.Typing);
+        await lease.DisposeAsync();
+
+        Assert.Equal(updateCancellation.Token, fakeClient.CancellationTokens.Single());
+    }
+
+    [Fact]
     public void TelegramContextBot_ForwardsDefaults()
     {
         var fakeClient = new RecordingTelegramClient();
@@ -3225,6 +3315,33 @@ public sealed class TelegramRuntimeIntegrationTests
                         Date = 0,
                         Chat = new Chat { Id = 100, Type = "private" },
                         Text = "hello"
+                    }
+                }),
+            cancellationToken);
+    }
+
+    private static UpdateContext CreateCallbackQueryUpdateContext(
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default)
+    {
+        return new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    CallbackQuery = new CallbackQuery
+                    {
+                        Id = "cb-1",
+                        From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                        Message = MaybeInaccessibleMessage.From(
+                            new Message
+                            {
+                                MessageId = 99,
+                                Date = 1,
+                                Chat = new Chat { Id = 100, Type = "private" }
+                            }),
+                        ChatInstance = "chat-instance"
                     }
                 }),
             cancellationToken);


### PR DESCRIPTION
## Summary
- document the cancellation model for handler code, context-bound Telegram helpers, and root `ITelegramClient` usage
- clarify the EN/RU production checklist so application I/O stays explicit while context helpers can use update cancellation automatically
- add regression coverage for update-scoped cancellation fallback in message, callback, chat action, and generated client flows

## Validation
- `dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj --no-restore --filter "FullyQualifiedName~TelegramRuntimeIntegrationTests"`
- `git diff --check`

Closes #34
