### PR TITLE
ci: add schema update guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,22 @@ jobs:
         shell: pwsh
         run: dotnet test ./TeleFlow.sln -c Release --no-build --no-restore /nodeReuse:false --logger "console;verbosity=minimal"
 
+  schema-update-guardrails:
+    name: Schema update guardrails
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify schema update guardrails
+        shell: pwsh
+        run: ./eng/verify-schema-update-guardrails.ps1 -BaseRef "${{ github.base_ref }}"
+
   minimum-sdk-generator-smoke:
     name: Minimum SDK generator smoke
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
-No unreleased changes yet.
+### Added
+
+- Added CI guardrails for generated Telegram schema/client updates, requiring changelog acknowledgement and validating Telegram Bot API manifest, badge, and generated header consistency.
 
 ## 1.0.0-alpha.9 - 2026-07-02
 

--- a/docs/en/enterprise/versioning.md
+++ b/docs/en/enterprise/versioning.md
@@ -107,6 +107,8 @@ Policy:
 
 - schema updates should be automated as much as possible;
 - generated output must be reviewed before release;
+- generated schema/client changes must include a `CHANGELOG.md` note that mentions the Telegram Bot API version;
+- CI validates that the generated manifest, Telegram Bot API badge, and generated file headers stay aligned;
 - schema changes that only add new Telegram fields or methods can be minor releases;
 - schema changes that rename or reshape existing public generated types can require a major release, even if Telegram changed upstream behavior.
 

--- a/docs/ru/enterprise/versioning.md
+++ b/docs/ru/enterprise/versioning.md
@@ -107,6 +107,8 @@ Policy:
 
 - schema updates нужно автоматизировать насколько возможно;
 - generated output должен проходить review перед release;
+- generated schema/client changes должны включать note в `CHANGELOG.md` с версией Telegram Bot API;
+- CI проверяет, что generated manifest, Telegram Bot API badge и generated file headers согласованы между собой;
 - schema changes, которые только добавляют новые Telegram fields или methods, могут быть minor releases;
 - schema changes, которые rename или reshape existing public generated types, могут требовать major release, даже если upstream behavior поменял Telegram.
 

--- a/eng/verify-schema-update-guardrails.ps1
+++ b/eng/verify-schema-update-guardrails.ps1
@@ -1,0 +1,261 @@
+param(
+    [string] $BaseRef = "main",
+    [string] $Remote = "origin",
+    [switch] $SkipFetch
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repositoryRoot = Split-Path -Parent $scriptDirectory
+
+function Invoke-Git {
+    param([string[]] $Arguments)
+
+    & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git command failed with exit code ${LASTEXITCODE}: git $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-GitOutput {
+    param([string[]] $Arguments)
+
+    $output = & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git command failed with exit code ${LASTEXITCODE}: git $($Arguments -join ' ')"
+    }
+
+    return $output
+}
+
+function Test-PathMatches {
+    param(
+        [string] $Path,
+        [string[]] $Patterns
+    )
+
+    foreach ($pattern in $Patterns) {
+        if ($Path -match $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-RequiredProperty {
+    param(
+        [object] $Object,
+        [string] $Name,
+        [string] $Path
+    )
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        throw "$Path is missing required property '$Name'."
+    }
+
+    return $property.Value
+}
+
+function Get-RequiredStringProperty {
+    param(
+        [object] $Object,
+        [string] $Name,
+        [string] $Path
+    )
+
+    $value = [string] (Get-RequiredProperty $Object $Name $Path)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "$Path property '$Name' is required."
+    }
+
+    return $value
+}
+
+function Get-RequiredIntProperty {
+    param(
+        [object] $Object,
+        [string] $Name,
+        [string] $Path
+    )
+
+    $value = Get-RequiredProperty $Object $Name $Path
+    if ($null -eq $value) {
+        throw "$Path property '$Name' is required."
+    }
+
+    return [int] $value
+}
+
+function Read-JsonFile {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Required file was not found: $Path"
+    }
+
+    return Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json
+}
+
+function Get-TrackedGeneratedFiles {
+    $trackedFiles = @(Invoke-GitOutput @(
+            "ls-files",
+            "--",
+            "src/TeleFlow.Telegram.Schema",
+            "src/TeleFlow.Telegram.Client/Generated"
+        ) |
+        ForEach-Object { $_.Replace("\", "/", [System.StringComparison]::Ordinal).Trim() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    return @($trackedFiles | Where-Object {
+            $_ -match "^src/TeleFlow\.Telegram\.Schema/.+\.g\.cs$" -or
+            $_ -match "^src/TeleFlow\.Telegram\.Client/Generated/.+\.g\.cs$"
+        } | Sort-Object -Unique)
+}
+
+function Assert-GeneratedHeaders {
+    param(
+        [string[]] $Files,
+        [string] $TelegramBotApiVersion,
+        [string] $TelegramBotApiRelease,
+        [string] $TelegramBotApiChangelogUrl
+    )
+
+    foreach ($relativePath in $Files) {
+        $path = Join-Path $repositoryRoot ($relativePath.Replace("/", [string] [System.IO.Path]::DirectorySeparatorChar))
+        $contents = Get-Content -Raw -LiteralPath $path
+
+        $expectedVersionLine = "//   Telegram Bot API version: $TelegramBotApiVersion"
+        $expectedReleaseLine = "//   Telegram Bot API release: $TelegramBotApiRelease"
+        $expectedChangelogLine = "//   Telegram Bot API changelog: $TelegramBotApiChangelogUrl"
+
+        if (-not $contents.Contains($expectedVersionLine, [System.StringComparison]::Ordinal)) {
+            throw "Generated file '$relativePath' has a Telegram Bot API version header that does not match manifest version '$TelegramBotApiVersion'."
+        }
+
+        if (-not $contents.Contains($expectedReleaseLine, [System.StringComparison]::Ordinal)) {
+            throw "Generated file '$relativePath' has a Telegram Bot API release header that does not match manifest release '$TelegramBotApiRelease'."
+        }
+
+        if (-not $contents.Contains($expectedChangelogLine, [System.StringComparison]::Ordinal)) {
+            throw "Generated file '$relativePath' has a Telegram Bot API changelog header that does not match manifest changelog '$TelegramBotApiChangelogUrl'."
+        }
+    }
+}
+
+Push-Location $repositoryRoot
+try {
+    $baseBranch = "$Remote/$BaseRef"
+    if (-not $SkipFetch) {
+        Invoke-Git @("fetch", "--quiet", $Remote, "+refs/heads/$BaseRef`:refs/remotes/$Remote/$BaseRef")
+    }
+
+    $mergeBase = (Invoke-GitOutput @("merge-base", "HEAD", $baseBranch) | Select-Object -First 1).Trim()
+    if ([string]::IsNullOrWhiteSpace($mergeBase)) {
+        throw "Could not resolve merge base between HEAD and $baseBranch."
+    }
+
+    $changedFiles = @(
+        Invoke-GitOutput @("diff", "--name-only", $mergeBase, "HEAD", "--")
+        Invoke-GitOutput @("diff", "--name-only", "HEAD", "--")
+    ) |
+        ForEach-Object { $_.Replace("\", "/", [System.StringComparison]::Ordinal).Trim() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Sort-Object -Unique
+
+    if ($changedFiles.Count -eq 0) {
+        Write-Host "No changed files against $baseBranch. Schema update guardrails skipped."
+        return
+    }
+
+    $generatedSurfacePatterns = @(
+        "^src/TeleFlow\.Telegram\.Schema/.+\.g\.cs$",
+        "^src/TeleFlow\.Telegram\.Client/Generated/.+\.g\.cs$",
+        "^src/TeleFlow\.Telegram\.Schema/telegram-bot-api\.manifest\.json$"
+    )
+    $schemaMetadataPatterns = @(
+        "^docs/badges/telegram-bot-api\.json$"
+    )
+
+    $generatedSurfaceChanged = $false
+    $schemaMetadataChanged = $false
+
+    foreach ($changedFile in $changedFiles) {
+        if (Test-PathMatches $changedFile $generatedSurfacePatterns) {
+            $generatedSurfaceChanged = $true
+        }
+
+        if (Test-PathMatches $changedFile $schemaMetadataPatterns) {
+            $schemaMetadataChanged = $true
+        }
+    }
+
+    if (-not $generatedSurfaceChanged -and -not $schemaMetadataChanged) {
+        Write-Host "No generated Telegram schema/client or schema metadata files changed. Schema update guardrails skipped."
+        return
+    }
+
+    $manifestPath = Join-Path $repositoryRoot "src/TeleFlow.Telegram.Schema/telegram-bot-api.manifest.json"
+    $manifest = Read-JsonFile $manifestPath
+    $source = Get-RequiredProperty $manifest "source" "manifest"
+    $telegramBotApi = Get-RequiredProperty $manifest "telegramBotApi" "manifest"
+    $pipeline = Get-RequiredProperty $manifest "pipeline" "manifest"
+
+    [void] (Get-RequiredIntProperty $manifest "manifestVersion" "manifest")
+    [void] (Get-RequiredStringProperty $source "url" "manifest.source")
+    [void] (Get-RequiredStringProperty $source "capturedAtUtc" "manifest.source")
+    $sourceSha256 = Get-RequiredStringProperty $source "sha256" "manifest.source"
+    $telegramBotApiVersion = Get-RequiredStringProperty $telegramBotApi "version" "manifest.telegramBotApi"
+    $telegramBotApiRelease = Get-RequiredStringProperty $telegramBotApi "releasedAt" "manifest.telegramBotApi"
+    $telegramBotApiChangelogUrl = Get-RequiredStringProperty $telegramBotApi "changelogUrl" "manifest.telegramBotApi"
+    [void] (Get-RequiredIntProperty $pipeline "schemaVersion" "manifest.pipeline")
+    [void] (Get-RequiredIntProperty $pipeline "generatorVersion" "manifest.pipeline")
+
+    if ($sourceSha256 -notmatch "^[0-9a-f]{64}$") {
+        throw "manifest.source.sha256 must be a 64-character lowercase hexadecimal SHA-256 value."
+    }
+
+    $badgePath = Join-Path $repositoryRoot "docs/badges/telegram-bot-api.json"
+    $badge = Read-JsonFile $badgePath
+    $badgeMessage = Get-RequiredStringProperty $badge "message" "telegram-bot-api badge"
+
+    if ($badgeMessage -ne $telegramBotApiVersion) {
+        throw "Telegram Bot API badge message '$badgeMessage' does not match manifest version '$telegramBotApiVersion'."
+    }
+
+    $generatedFiles = Get-TrackedGeneratedFiles
+    if ($generatedFiles.Count -eq 0) {
+        throw "No tracked generated Telegram schema/client files were found."
+    }
+
+    Assert-GeneratedHeaders `
+        -Files $generatedFiles `
+        -TelegramBotApiVersion $telegramBotApiVersion `
+        -TelegramBotApiRelease $telegramBotApiRelease `
+        -TelegramBotApiChangelogUrl $telegramBotApiChangelogUrl
+
+    if ($generatedSurfaceChanged) {
+        $changelogChanged = $changedFiles -contains "CHANGELOG.md"
+        if (-not $changelogChanged) {
+            throw "Generated Telegram schema/client output changed, but CHANGELOG.md was not updated."
+        }
+
+        $changelogPath = Join-Path $repositoryRoot "CHANGELOG.md"
+        $changelog = Get-Content -Raw -LiteralPath $changelogPath
+        $escapedVersion = [regex]::Escape($telegramBotApiVersion)
+        $versionMentionPattern = "Telegram Bot API(?: schema version)?\s+$escapedVersion"
+
+        if ($changelog -notmatch $versionMentionPattern) {
+            throw "CHANGELOG.md does not mention Telegram Bot API $telegramBotApiVersion."
+        }
+    }
+
+    Write-Host "Telegram schema update guardrails passed."
+    Write-Host "Telegram Bot API version: $telegramBotApiVersion"
+    Write-Host "Tracked generated files checked: $($generatedFiles.Count)"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a TeleFlow-side schema update guardrail script for generated Telegram schema/client changes
- wire the guardrail into pull request CI without duplicating the generator repository monitor
- document the changelog/versioning requirement for generated Telegram schema updates in EN/RU docs

## Guardrail behavior
- skips non-schema PRs clearly
- validates Telegram Bot API manifest shape
- validates badge version against the manifest
- validates generated file headers against the manifest
- requires `CHANGELOG.md` to change when generated schema/client output changes
- requires `CHANGELOG.md` to mention the Telegram Bot API version from the manifest

## Validation
- `./eng/verify-schema-update-guardrails.ps1 -BaseRef main`
- negative check: temporary badge mismatch failed with a clear error
- negative check: temporary manifest change without changelog version mention failed with a clear error
- `git diff --check`

Closes #46
