### PR TITLE
Fix prefix-less short command matching

### DIFF
--- a/docs/en/fundamentals/handlers-and-routing.md
+++ b/docs/en/fundamentals/handlers-and-routing.md
@@ -50,6 +50,16 @@ public Task HelpText(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+Prefix-less exact `[Command]` routes, and `[CommandTemplate]` routes without
+placeholders, require the whole text to equal the command name. A short command
+such as `[Command("i", PrefixMode = CommandPrefixMode.Optional)]` will match `i`
+and `/i details`, but not the normal sentence `I need help`.
+
+Use `[CommandTemplate]` or `[CommandRegex]` for prefix-less command-like input
+with arguments. For common natural language words, prefer a required prefix:
+`[CommandTemplate("i {text}", PrefixMode = CommandPrefixMode.Optional)]` is
+supposed to match `I need help`.
+
 ## Text Handler
 
 ```csharp

--- a/docs/en/reference/attributes.md
+++ b/docs/en/reference/attributes.md
@@ -51,6 +51,15 @@ Available `CommandPrefixMode` values are:
 | `Optional` | Accepts a configured prefix or no prefix. |
 | `NoPrefix` | Accepts only prefix-less text. Do not combine it with `Prefixes`. |
 
+For prefix-less exact `[Command]` routes, and for `[CommandTemplate]` routes
+without placeholders, the whole text must equal the command name. This prevents
+short commands such as `[Command("i")]` or `[CommandTemplate("i")]` from matching
+a normal sentence like `I need help`. Use `[CommandTemplate]` or
+`[CommandRegex]` when prefix-less command-like text has arguments, but keep
+those routes reserved for command-shaped words. A prefix-less template based on
+a common natural language word plus a string argument will intentionally match
+normal sentences that start with that word.
+
 `[Text]` supports explicit match modes:
 
 ```csharp

--- a/docs/ru/fundamentals/handlers-and-routing.md
+++ b/docs/ru/fundamentals/handlers-and-routing.md
@@ -51,6 +51,16 @@ public Task HelpText(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+Для prefix-less exact `[Command]`, а также для `[CommandTemplate]` без
+placeholders, весь текст должен совпасть с именем команды. Короткая команда
+вроде `[Command("я", PrefixMode = CommandPrefixMode.Optional)]` сматчит `я` и
+`/я детали`, но не сматчит обычную фразу `Я что-то рассказываю`.
+
+Для prefix-less command-like input с аргументами используй `[CommandTemplate]`
+или `[CommandRegex]`. Для обычных слов естественного языка лучше требовать
+prefix: `[CommandTemplate("я {text}", PrefixMode = CommandPrefixMode.Optional)]`
+по смыслу должен матчить `Я что-то рассказываю`.
+
 ## Text handler
 
 ```csharp

--- a/docs/ru/reference/attributes.md
+++ b/docs/ru/reference/attributes.md
@@ -51,6 +51,15 @@ public Task Ticket(MessageContext ctx, long id, CancellationToken ct) { ... }
 | `Optional` | Принимает настроенный prefix или текст без prefix. |
 | `NoPrefix` | Принимает только текст без prefix. Не комбинируй с `Prefixes`. |
 
+Для prefix-less exact `[Command]`, а также для `[CommandTemplate]` без
+placeholders, весь текст должен совпасть с именем команды. Так короткая команда
+вроде `[Command("я")]` или `[CommandTemplate("я")]` не будет случайно матчить
+обычную фразу `Я что-то рассказываю`. Если у prefix-less command-like текста
+есть аргументы, используй `[CommandTemplate]` или `[CommandRegex]`, но оставляй
+такие routes для слов, которые выглядят как команды. Prefix-less template на
+обычном слове естественного языка плюс string-аргумент намеренно будет матчить
+обычные фразы, начинающиеся с этого слова.
+
 `[Text]` поддерживает явный match mode:
 
 ```csharp

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -331,11 +331,11 @@ internal sealed partial class TelegramHandlerSelector
             TelegramRouteKind.TextExact => MatchesTextFilters(message, route),
             TelegramRouteKind.TextTemplate => TryMatchTextPattern(message.Text, route, isTemplate: true, out routeValues),
             TelegramRouteKind.TextRegex => TryMatchTextPattern(message.Text, route, isTemplate: false, out routeValues),
-            TelegramRouteKind.CommandExact => TryGetCommandBody(message.Text, route, out var body) &&
-                                               TryMatchExactCommand(body, route),
-            TelegramRouteKind.CommandTemplate => TryGetCommandBody(message.Text, route, out var body) &&
+            TelegramRouteKind.CommandExact => TryGetCommandBody(message.Text, route, out var body, out var isPrefixLess) &&
+                                               TryMatchExactCommand(body, route, isPrefixLess),
+            TelegramRouteKind.CommandTemplate => TryGetCommandBody(message.Text, route, out var body, out _) &&
                                                  TryMatchCommandPattern(body, route, isTemplate: true, out routeValues),
-            TelegramRouteKind.CommandRegex => TryGetCommandBody(message.Text, route, out var body) &&
+            TelegramRouteKind.CommandRegex => TryGetCommandBody(message.Text, route, out var body, out _) &&
                                               TryMatchCommandPattern(body, route, isTemplate: false, out routeValues),
             _ => false
         };
@@ -404,23 +404,38 @@ internal sealed partial class TelegramHandlerSelector
     private static bool TryGetCommandBody(
         string? text,
         TelegramRouteDescriptor route,
-        out string commandBody)
+        out string commandBody,
+        out bool isPrefixLess)
     {
         commandBody = string.Empty;
+        isPrefixLess = false;
 
         if (string.IsNullOrWhiteSpace(text))
         {
             return false;
         }
 
-        return route.CommandPolicy.PrefixMode switch
+        switch (route.CommandPolicy.PrefixMode)
         {
-            CommandPrefixMode.Required => TryGetPrefixedCommandBody(text, route, out commandBody),
-            CommandPrefixMode.Optional => TryGetPrefixedCommandBody(text, route, out commandBody) ||
-                                          TryGetPrefixLessCommandBody(text, out commandBody),
-            CommandPrefixMode.NoPrefix => TryGetPrefixLessCommandBody(text, out commandBody),
-            _ => false
-        };
+            case CommandPrefixMode.Required:
+                return TryGetPrefixedCommandBody(text, route, out commandBody);
+
+            case CommandPrefixMode.Optional:
+                if (TryGetPrefixedCommandBody(text, route, out commandBody))
+                {
+                    return true;
+                }
+
+                isPrefixLess = true;
+                return TryGetPrefixLessCommandBody(text, out commandBody);
+
+            case CommandPrefixMode.NoPrefix:
+                isPrefixLess = true;
+                return TryGetPrefixLessCommandBody(text, out commandBody);
+
+            default:
+                return false;
+        }
     }
 
     private static bool TryGetPrefixedCommandBody(
@@ -484,11 +499,20 @@ internal sealed partial class TelegramHandlerSelector
 
     private static bool TryMatchExactCommand(
         string commandBody,
-        TelegramRouteDescriptor route)
+        TelegramRouteDescriptor route,
+        bool isPrefixLess)
     {
         if (string.IsNullOrWhiteSpace(route.Pattern))
         {
             return false;
+        }
+
+        if (isPrefixLess)
+        {
+            return string.Equals(
+                commandBody.Trim(),
+                route.Pattern,
+                route.CommandPolicy.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
 
         var tokenEnd = commandBody.IndexOfAny([' ', '\t', '\r', '\n']);

--- a/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
@@ -42,6 +42,46 @@ public sealed class StageEightGeneratedRegistrationTests
     }
 
     [Fact]
+    public async Task GeneratedRegistrar_OptionalPrefixCommand_DoesNotMatchPrefixLessTextWithArguments()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/я рассказываю обычную фразу"));
+
+        Assert.Equal(
+            [
+                "fallback:Я рассказываю обычную фразу",
+                "generated-short-command:я",
+                "generated-short-command:/я рассказываю обычную фразу"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task GeneratedRegistrar_OptionalPrefixCommandTemplateWithoutValues_DoesNotMatchPrefixLessTextWithArguments()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я-темплейт"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/я-темплейт"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/я-темплейт рассказываю обычную фразу"));
+
+        Assert.Equal(
+            [
+                "fallback:Я рассказываю обычную фразу",
+                "generated-short-template:я-темплейт",
+                "generated-short-template:/я-темплейт",
+                "fallback:/я-темплейт рассказываю обычную фразу"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
     public async Task GeneratedRegistrar_DispatchesGeneratedErrorHandlers()
     {
         using var serviceProvider = CreateServiceProvider();
@@ -605,6 +645,58 @@ internal sealed class StageEightGeneratedHandlersRegistrar : ITelegramGeneratedH
                 new(typeof(GeneratedHandlerProbe), TelegramGeneratedHandlerParameterKind.Service, "probe")
             ],
             InvokeStateStart));
+
+        registry.RegisterHandler(new TelegramGeneratedHandlerDescriptor(
+            typeof(GeneratedShortOptionalPrefixCommandHandler),
+            nameof(GeneratedShortOptionalPrefixCommandHandler.Handle),
+            TelegramGeneratedHandlerKind.Command,
+            TelegramGeneratedRouteKind.CommandExact,
+            routePattern: "я",
+            commandPrefixes: ["/"],
+            allowSpaceAfterPrefix: false,
+            ignoreCase: true,
+            registrationOrder: 50,
+            moduleName: null,
+            command: "я",
+            callbackPayloadType: null,
+            textFilters: [],
+            filters: [],
+            chatMemberTransitions: [],
+            roleRequirements: [],
+            states: [],
+            parameters:
+            [
+                new(typeof(MessageContext), TelegramGeneratedHandlerParameterKind.Context, "context"),
+                new(typeof(GeneratedHandlerProbe), TelegramGeneratedHandlerParameterKind.Service, "probe")
+            ],
+            InvokeShortOptionalPrefixCommand,
+            prefixMode: CommandPrefixMode.Optional));
+
+        registry.RegisterHandler(new TelegramGeneratedHandlerDescriptor(
+            typeof(GeneratedShortOptionalPrefixCommandTemplateHandler),
+            nameof(GeneratedShortOptionalPrefixCommandTemplateHandler.Handle),
+            TelegramGeneratedHandlerKind.Command,
+            TelegramGeneratedRouteKind.CommandTemplate,
+            routePattern: "я-темплейт",
+            commandPrefixes: ["/"],
+            allowSpaceAfterPrefix: false,
+            ignoreCase: true,
+            registrationOrder: 51,
+            moduleName: null,
+            command: null,
+            callbackPayloadType: null,
+            textFilters: [],
+            filters: [],
+            chatMemberTransitions: [],
+            roleRequirements: [],
+            states: [],
+            parameters:
+            [
+                new(typeof(MessageContext), TelegramGeneratedHandlerParameterKind.Context, "context"),
+                new(typeof(GeneratedHandlerProbe), TelegramGeneratedHandlerParameterKind.Service, "probe")
+            ],
+            InvokeShortOptionalPrefixCommandTemplate,
+            prefixMode: CommandPrefixMode.Optional));
 
         registry.RegisterHandler(new TelegramGeneratedHandlerDescriptor(
             typeof(GeneratedFallbackMessageHandler),
@@ -1193,6 +1285,26 @@ internal sealed class StageEightGeneratedHandlersRegistrar : ITelegramGeneratedH
         await handler.Handle((MessageContext)arguments[0]!, (GeneratedHandlerProbe)arguments[1]!);
     }
 
+    private static async ValueTask InvokeShortOptionalPrefixCommand(
+        IServiceProvider services,
+        object?[] arguments,
+        CancellationToken cancellationToken)
+    {
+        var handler = (GeneratedShortOptionalPrefixCommandHandler)services.GetRequiredService(
+            typeof(GeneratedShortOptionalPrefixCommandHandler));
+        await handler.Handle((MessageContext)arguments[0]!, (GeneratedHandlerProbe)arguments[1]!);
+    }
+
+    private static async ValueTask InvokeShortOptionalPrefixCommandTemplate(
+        IServiceProvider services,
+        object?[] arguments,
+        CancellationToken cancellationToken)
+    {
+        var handler = (GeneratedShortOptionalPrefixCommandTemplateHandler)services.GetRequiredService(
+            typeof(GeneratedShortOptionalPrefixCommandTemplateHandler));
+        await handler.Handle((MessageContext)arguments[0]!, (GeneratedHandlerProbe)arguments[1]!);
+    }
+
     private static async ValueTask InvokeFallbackMessage(
         IServiceProvider services,
         object?[] arguments,
@@ -1562,6 +1674,24 @@ public sealed class GeneratedStateStartHandler
     {
         await context.State.SetAsync("awaiting");
         probe.Events.Add("state:set");
+    }
+}
+
+public sealed class GeneratedShortOptionalPrefixCommandHandler
+{
+    public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
+    {
+        probe.Events.Add($"generated-short-command:{context.TelegramMessage.Text}");
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class GeneratedShortOptionalPrefixCommandTemplateHandler
+{
+    public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
+    {
+        probe.Events.Add($"generated-short-template:{context.TelegramMessage.Text}");
+        return Task.CompletedTask;
     }
 }
 

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -693,6 +693,54 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task CommandAttribute_OptionalPrefix_DoesNotMatchPrefixLessTextWithArguments()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ShortOptionalPrefixCommandHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/я рассказываю обычную фразу"));
+
+        Assert.Equal(
+            [
+                "message:Я рассказываю обычную фразу",
+                "short-optional-prefix-command:я",
+                "short-optional-prefix-command:/я рассказываю обычную фразу"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandAttribute_NoPrefix_DoesNotMatchPrefixLessTextWithArguments()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ShortNoPrefixCommandHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я"));
+
+        Assert.Equal(
+            [
+                "message:Я рассказываю обычную фразу",
+                "short-no-prefix-command:я"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
     public async Task TextTemplate_BindsRouteValue()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -799,6 +847,31 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task CommandTemplate_OptionalPrefix_DoesNotMatchPrefixLessTextWhenTemplateHasNoRouteValues()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ShortOptionalPrefixCommandTemplateHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/я рассказываю обычную фразу"));
+
+        Assert.Equal(
+            [
+                "message:Я рассказываю обычную фразу",
+                "short-optional-prefix-command-template:я",
+                "message:/я рассказываю обычную фразу"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
     public async Task CommandTemplate_NoPrefix_MatchesOnlyPrefixLessCommands()
     {
         using var serviceProvider = CreateServiceProvider(
@@ -814,6 +887,29 @@ public sealed class TelegramHandlerDispatcherTests
         await DispatchAsync(serviceProvider, CreateMessageUpdate("/ban 43"));
 
         Assert.Equal(["no-prefix-command-template:42", "message:/ban 43"], probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandTemplate_NoPrefix_DoesNotMatchPrefixLessTextWhenTemplateHasNoRouteValues()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ShortNoPrefixCommandTemplateHandler>();
+                services.AddTelegramHandler<AnyMessageHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("Я рассказываю обычную фразу"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("я"));
+
+        Assert.Equal(
+            [
+                "message:Я рассказываю обычную фразу",
+                "short-no-prefix-command-template:я"
+            ],
+            probe.Events);
     }
 
     [Fact]
@@ -3634,6 +3730,26 @@ public sealed class TelegramHandlerDispatcherTests
         }
     }
 
+    public sealed class ShortOptionalPrefixCommandHandler
+    {
+        [Command("я", PrefixMode = CommandPrefixMode.Optional)]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"short-optional-prefix-command:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ShortNoPrefixCommandHandler
+    {
+        [Command("я", PrefixMode = CommandPrefixMode.NoPrefix)]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"short-no-prefix-command:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
     public sealed class TextTemplateRouteHandler
     {
         [TextTemplate("order {orderId:long}")]
@@ -3684,12 +3800,32 @@ public sealed class TelegramHandlerDispatcherTests
         }
     }
 
+    public sealed class ShortOptionalPrefixCommandTemplateHandler
+    {
+        [CommandTemplate("я", PrefixMode = CommandPrefixMode.Optional)]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"short-optional-prefix-command-template:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
     public sealed class NoPrefixCommandTemplateRouteHandler
     {
         [CommandTemplate("ban {userId:int}", PrefixMode = CommandPrefixMode.NoPrefix)]
         public Task Handle(MessageContext context, int userId, HandlerProbe probe)
         {
             probe.Events.Add($"no-prefix-command-template:{userId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ShortNoPrefixCommandTemplateHandler
+    {
+        [CommandTemplate("я", PrefixMode = CommandPrefixMode.NoPrefix)]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"short-no-prefix-command-template:{context.TelegramMessage.Text}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary

- tighten prefix-less exact command matching so short commands do not catch normal natural-language messages
- add manual/reflection dispatcher regressions for `[Command("я")]` and `[CommandTemplate("я")]`
- add generated registration regressions for the same short-command boundary
- document the exact-command/template distinction in EN/RU routing docs

## Touched hot paths

- `TelegramHandlerSelector.TryGetCommandBody(...)`
- `TelegramHandlerSelector.TryMatchExactCommand(...)`

The change keeps prefixed command matching behavior unchanged and only tightens prefix-less exact command matching.

## Validation

```text
dotnet test .\TeleFlow.sln -c Release --no-restore
737 passed
```

Closes #135