### PR TITLE
Fix callback answer overload recursion

### DIFF
--- a/src/TeleFlow.Framework/CallbackQueryActions.cs
+++ b/src/TeleFlow.Framework/CallbackQueryActions.cs
@@ -15,12 +15,12 @@ public sealed class CallbackQueryActions
 
     public Task<bool> AnswerAsync(CancellationToken cancellationToken)
     {
-        return AnswerAsync(text: null, showAlert: null, cancellationToken);
+        return AnswerCoreAsync(text: null, showAlert: null, cancellationToken);
     }
 
     public Task<bool> AnswerAsync(string? text, CancellationToken cancellationToken)
     {
-        return AnswerAsync(text, showAlert: null, cancellationToken);
+        return AnswerCoreAsync(text, showAlert: null, cancellationToken);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -29,13 +29,21 @@ public sealed class CallbackQueryActions
         Justification = "Callback action methods intentionally remain instance methods for a consistent fluent context API.")]
     public Task<bool> AnswerAsync(string? text, bool showAlert, CancellationToken cancellationToken)
     {
-        return AnswerAsync(text, showAlert: showAlert, cancellationToken);
+        return AnswerCoreAsync(text, showAlert, cancellationToken);
     }
 
-    public async Task<bool> AnswerAsync(
+    public Task<bool> AnswerAsync(
         string? text = null,
         bool? showAlert = null,
         CancellationToken cancellationToken = default)
+    {
+        return AnswerCoreAsync(text, showAlert, cancellationToken);
+    }
+
+    private async Task<bool> AnswerCoreAsync(
+        string? text,
+        bool? showAlert,
+        CancellationToken cancellationToken)
     {
         var result = await _context.Bot.AnswerCallbackQueryAsync(
             _context.TelegramCallbackQuery.Id,

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -2243,6 +2243,65 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task CallbackQueryActions_AnswerAsync_DefaultOverload_SendsCallbackAnswerOnce()
+    {
+        var fakeClient = CreateCallbackAnswerClient();
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var callbackContext = CreateCallbackQueryUpdateContext(serviceProvider).GetCallbackQueryContext();
+
+        var result = await callbackContext.Callback.AnswerAsync(CancellationToken.None);
+
+        Assert.True(result);
+        Assert.True(callbackContext.IsCallbackQueryAnswered);
+        AssertAnswerCallbackQuery(fakeClient, expectedText: null, expectedShowAlert: null);
+    }
+
+    [Fact]
+    public async Task CallbackQueryActions_AnswerAsync_TextOverload_SendsCallbackAnswerOnce()
+    {
+        var fakeClient = CreateCallbackAnswerClient();
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var callbackContext = CreateCallbackQueryUpdateContext(serviceProvider).GetCallbackQueryContext();
+
+        var result = await callbackContext.Callback.AnswerAsync("done", CancellationToken.None);
+
+        Assert.True(result);
+        Assert.True(callbackContext.IsCallbackQueryAnswered);
+        AssertAnswerCallbackQuery(fakeClient, expectedText: "done", expectedShowAlert: null);
+    }
+
+    [Fact]
+    public async Task CallbackQueryActions_AnswerAsync_NonNullableShowAlertOverload_SendsCallbackAnswerOnce()
+    {
+        var fakeClient = CreateCallbackAnswerClient();
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var callbackContext = CreateCallbackQueryUpdateContext(serviceProvider).GetCallbackQueryContext();
+
+        var result = await callbackContext.Callback.AnswerAsync("alert", showAlert: true, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.True(callbackContext.IsCallbackQueryAnswered);
+        AssertAnswerCallbackQuery(fakeClient, expectedText: "alert", expectedShowAlert: true);
+    }
+
+    [Fact]
+    public async Task CallbackQueryActions_AnswerAsync_NullableShowAlertOverload_SendsCallbackAnswerOnce()
+    {
+        var fakeClient = CreateCallbackAnswerClient();
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var callbackContext = CreateCallbackQueryUpdateContext(serviceProvider).GetCallbackQueryContext();
+
+        var result = await callbackContext.Callback.AnswerAsync(
+            text: "notification",
+            showAlert: (bool?)false,
+            cancellationToken: CancellationToken.None);
+
+        Assert.True(result);
+        Assert.True(callbackContext.IsCallbackQueryAnswered);
+        AssertAnswerCallbackQuery(fakeClient, expectedText: "notification", expectedShowAlert: false);
+    }
+
+    [Fact]
     public async Task ChatActions_ActionAsync_UsesUpdateCancellationWhenTokenIsDefault()
     {
         using var updateCancellation = new CancellationTokenSource();
@@ -3288,6 +3347,28 @@ public sealed class TelegramRuntimeIntegrationTests
         }
 
         return services.BuildServiceProvider();
+    }
+
+    private static RecordingTelegramClient CreateCallbackAnswerClient()
+    {
+        return new RecordingTelegramClient
+        {
+            Handler = method => method is AnswerCallbackQuery
+                ? true
+                : throw new InvalidOperationException("Unexpected method.")
+        };
+    }
+
+    private static void AssertAnswerCallbackQuery(
+        RecordingTelegramClient client,
+        string? expectedText,
+        bool? expectedShowAlert)
+    {
+        var answer = Assert.IsType<AnswerCallbackQuery>(Assert.Single(client.Methods));
+
+        Assert.Equal("cb-1", answer.CallbackQueryId);
+        Assert.Equal(expectedText, answer.Text);
+        Assert.Equal(expectedShowAlert, answer.ShowAlert);
     }
 
     private static void AssertRequestLogsDoNotContainSensitiveData(RecordingLoggerFactory loggerFactory)

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -3353,9 +3353,11 @@ public sealed class TelegramRuntimeIntegrationTests
     {
         return new RecordingTelegramClient
         {
-            Handler = method => method is AnswerCallbackQuery
-                ? true
-                : throw new InvalidOperationException("Unexpected method.")
+            Handler = method => method switch
+            {
+                AnswerCallbackQuery => true,
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
         };
     }
 


### PR DESCRIPTION
## Summary

- route every `CallbackQueryActions.AnswerAsync(...)` overload through a private `AnswerCoreAsync(...)`
- remove the recursive non-nullable `showAlert` overload path
- add regression coverage for all callback answer overloads

## Why

The previous non-nullable `bool showAlert` overload could recursively resolve to itself instead of the nullable core overload. A private core method makes overload resolution irrelevant for the implementation path.

## Validation

```text
dotnet test .\TeleFlow.sln -c Release --filter "FullyQualifiedName~CallbackQueryActions_AnswerAsync" --no-restore
5 passed

dotnet test .\TeleFlow.sln -c Release --no-restore
741 passed
```

Closes #134