### PR TITLE
feat(client): add Telegram Bot API test environment

### DIFF
--- a/docs/en/features/telegram-client.md
+++ b/docs/en/features/telegram-client.md
@@ -54,6 +54,38 @@ public Task Photo(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+## Telegram Test Environment
+
+Telegram's Bot API test environment is separate from production. Create a dedicated test Telegram account and bot, then use that bot's token. Do not reuse a production token.
+
+For framework applications:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = testBotToken;
+    options.Environment = TelegramBotApiEnvironment.Test;
+});
+```
+
+For client-only applications:
+
+```csharp
+services.AddTelegramClient(options =>
+{
+    options.Token = testBotToken;
+    options.Environment = TelegramBotApiEnvironment.Test;
+});
+```
+
+The client sends every Bot API request through Telegram's test endpoint, including generated methods, long polling, webhook setup, and payment API calls. Production remains the default.
+
+`BaseUrl` stays the API root. Do not put `/bot`, a token, or `/test` into it. For example, with the default root, TeleFlow builds `https://api.telegram.org/bot<TOKEN>/test/getMe`.
+
+This setting only selects Telegram's endpoint. It does not emulate payments or add framework routes for payment updates. In particular, `TelegramAllowedUpdates.Auto` does not currently infer `pre_checkout_query`; configure that update explicitly when using a raw payment-update path.
+
+Telegram notes that test-environment flood limits are not relaxed and can be stricter than production. Keep retry and throttling behavior realistic while testing.
+
 ## Defaults
 
 `TelegramBotDefaults` can configure common request defaults:

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -10,6 +10,7 @@ builder.Services.AddTelegramBot(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.Environment = TelegramBotApiEnvironment.Production;
     options.Defaults.ParseMode = TelegramParseMode.Html;
     options.RetryAfter = TelegramRetryAfterPolicy.Default;
     options.RoleFilter.CacheEnabled = true;
@@ -27,11 +28,14 @@ services.AddTelegramClient(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.Environment = TelegramBotApiEnvironment.Production;
     options.RetryAfter = TelegramRetryAfterPolicy.Default;
 });
 ```
 
 Use this for client-only applications.
+
+`BaseUrl` is the API root. TeleFlow appends the bot token, test-environment segment when selected, and method name. Set `Environment` to `TelegramBotApiEnvironment.Test` only with a dedicated Telegram test account and test bot token.
 
 `RetryAfter` controls bounded automatic handling of Telegram `429` responses. The default policy retries one short retry-after response and throws `TelegramRetryAfterException` when the configured bounds are exceeded.
 

--- a/docs/ru/features/telegram-client.md
+++ b/docs/ru/features/telegram-client.md
@@ -54,6 +54,38 @@ public Task Photo(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+## Telegram test environment
+
+Telegram Bot API test environment отделён от production. Создай отдельный test Telegram account и bot, затем используй token этого test bot. Production token сюда не подставляй.
+
+Для framework applications:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = testBotToken;
+    options.Environment = TelegramBotApiEnvironment.Test;
+});
+```
+
+Для client-only applications:
+
+```csharp
+services.AddTelegramClient(options =>
+{
+    options.Token = testBotToken;
+    options.Environment = TelegramBotApiEnvironment.Test;
+});
+```
+
+Client отправляет через Telegram test endpoint все Bot API requests: generated methods, long polling, webhook setup и payment API calls. Production остаётся default.
+
+`BaseUrl` остаётся корнем API. Не добавляй в него `/bot`, token или `/test`. Например, с default root TeleFlow построит `https://api.telegram.org/bot<TOKEN>/test/getMe`.
+
+Настройка только выбирает Telegram endpoint. Она не эмулирует payments и не добавляет framework routes для payment updates. В частности, `TelegramAllowedUpdates.Auto` пока не выводит `pre_checkout_query`; настрой этот update явно, если используешь raw payment-update path.
+
+Telegram предупреждает, что flood limits в test environment не ослаблены и могут быть строже production. Не отключай реальные retry и throttling rules только ради теста.
+
 ## Дефолты
 
 `TelegramBotDefaults` задаёт common request defaults:

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -10,6 +10,7 @@ builder.Services.AddTelegramBot(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.Environment = TelegramBotApiEnvironment.Production;
     options.Defaults.ParseMode = TelegramParseMode.Html;
     options.RetryAfter = TelegramRetryAfterPolicy.Default;
     options.RoleFilter.CacheEnabled = true;
@@ -27,11 +28,14 @@ services.AddTelegramClient(options =>
     options.Token = token;
     options.BotUsername = "my_bot";
     options.BaseUrl = "https://api.telegram.org";
+    options.Environment = TelegramBotApiEnvironment.Production;
     options.RetryAfter = TelegramRetryAfterPolicy.Default;
 });
 ```
 
 Используй это для client-only applications.
+
+`BaseUrl` - это API root. TeleFlow сам добавляет bot token, test-environment segment при выбранном режиме и method name. Ставь `Environment = TelegramBotApiEnvironment.Test` только с отдельными test Telegram account и test bot token.
 
 `RetryAfter` управляет bounded automatic handling для Telegram `429` responses. Default policy retry-ит один короткий retry-after response и бросает `TelegramRetryAfterException`, когда настроенные границы превышены.
 

--- a/src/TeleFlow.Framework/Internal/Options/TelegramBotOptionsValidator.cs
+++ b/src/TeleFlow.Framework/Internal/Options/TelegramBotOptionsValidator.cs
@@ -11,6 +11,12 @@ internal static class TelegramBotOptionsValidator
             throw new InvalidOperationException("Telegram role filter options must be configured.");
         }
 
+        if (!Enum.IsDefined(options.Environment))
+        {
+            throw new InvalidOperationException(
+                $"Telegram Bot API environment '{options.Environment}' is not supported.");
+        }
+
         if (options.RoleFilter.CacheTtl <= TimeSpan.Zero)
         {
             throw new InvalidOperationException("Telegram role filter cache TTL must be greater than zero.");

--- a/src/TeleFlow.Framework/TelegramBotOptions.cs
+++ b/src/TeleFlow.Framework/TelegramBotOptions.cs
@@ -12,6 +12,11 @@ public sealed class TelegramBotOptions
         Justification = "Options use a string BaseUrl to preserve simple configuration binding from JSON, environment variables, and user secrets.")]
     public string BaseUrl { get; set; } = "https://api.telegram.org";
 
+    /// <summary>
+    /// Gets or sets the Telegram Bot API environment forwarded to the underlying client.
+    /// </summary>
+    public TelegramBotApiEnvironment Environment { get; set; } = TelegramBotApiEnvironment.Production;
+
     public TelegramBotDefaults Defaults { get; set; } = new();
 
     public TelegramRoleFilterOptions RoleFilter { get; set; } = new();

--- a/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class TelegramServiceCollectionExtensions
             clientOptions.Token = options.Token;
             clientOptions.BotUsername = options.BotUsername;
             clientOptions.BaseUrl = options.BaseUrl;
+            clientOptions.Environment = options.Environment;
             clientOptions.Defaults = options.Defaults;
             clientOptions.RetryAfter = options.RetryAfter;
         });

--- a/src/TeleFlow.Telegram.Client/Internal/Options/TelegramClientOptionsValidator.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/Options/TelegramClientOptionsValidator.cs
@@ -21,6 +21,12 @@ internal static class TelegramClientOptionsValidator
             throw new InvalidOperationException("Telegram base URL must be an absolute URI.");
         }
 
+        if (!Enum.IsDefined(options.Environment))
+        {
+            throw new InvalidOperationException(
+                $"Telegram Bot API environment '{options.Environment}' is not supported.");
+        }
+
         if (!TelegramBotUsernameNormalizer.TryNormalize(options.BotUsername, out _, out var botUsernameError))
         {
             throw new InvalidOperationException(botUsernameError);

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramRequestSender.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramRequestSender.cs
@@ -67,6 +67,10 @@ internal sealed class TelegramRequestSender
     private Uri BuildMethodUri(string methodName)
     {
         var baseUrl = _options.BaseUrl.TrimEnd('/');
-        return new Uri($"{baseUrl}/bot{_options.Token}/{methodName}", UriKind.Absolute);
+        var environmentPath = _options.Environment == TelegramBotApiEnvironment.Test
+            ? "/test"
+            : string.Empty;
+
+        return new Uri($"{baseUrl}/bot{_options.Token}{environmentPath}/{methodName}", UriKind.Absolute);
     }
 }

--- a/src/TeleFlow.Telegram.Client/TelegramBotApiEnvironment.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramBotApiEnvironment.cs
@@ -1,0 +1,18 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Selects the Telegram Bot API environment used for every outgoing client request.
+/// The test environment uses a separate Telegram account and bot token while preserving the normal client pipeline.
+/// </summary>
+public enum TelegramBotApiEnvironment
+{
+    /// <summary>
+    /// Sends requests to the production Telegram Bot API endpoint.
+    /// </summary>
+    Production = 0,
+
+    /// <summary>
+    /// Sends requests to Telegram's dedicated Bot API test environment.
+    /// </summary>
+    Test = 1
+}

--- a/src/TeleFlow.Telegram.Client/TelegramClientOptions.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramClientOptions.cs
@@ -14,6 +14,11 @@ public sealed class TelegramClientOptions
         Justification = "Client options must bind naturally from JSON, environment variables, and user secrets.")]
     public string BaseUrl { get; set; } = "https://api.telegram.org";
 
+    /// <summary>
+    /// Gets or sets the Telegram Bot API environment used to build outgoing method URIs.
+    /// </summary>
+    public TelegramBotApiEnvironment Environment { get; set; } = TelegramBotApiEnvironment.Production;
+
     public TelegramBotDefaults Defaults { get; set; } = new();
 
     /// <summary>

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -33,6 +33,7 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.TelegramConflictException",
         "TeleFlow.Telegram.TelegramEntityTooLargeException",
         "TeleFlow.Telegram.TelegramRetryAfterPolicy",
+        "TeleFlow.Telegram.TelegramBotApiEnvironment",
         "TeleFlow.Telegram.TelegramRetryAfterException",
         "TeleFlow.Telegram.TelegramMigrateToChatException",
         "TeleFlow.Telegram.TelegramServerException",

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -456,6 +456,115 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task TelegramClient_SendAsync_UsesTestEnvironmentEndpoint()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse("""{"ok":true,"result":{"id":42,"is_bot":true,"first_name":"TeleFlow Test Bot"}}"""));
+
+        var services = new ServiceCollection();
+        services.AddTelegramClient(options =>
+        {
+            options.Token = "test-token";
+            options.Environment = TelegramBotApiEnvironment.Test;
+        });
+        services.AddTelegramHttpTransport(_ => new HttpClient(handler));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        _ = await client.SendAsync(new GetMe());
+
+        Assert.Equal("https://api.telegram.org/bottest-token/test/getMe", handler.Requests.Single().RequestUri);
+    }
+
+    [Fact]
+    public async Task TelegramClient_SendAsync_UsesTestEnvironmentEndpointWithCustomBaseUrl()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse("""{"ok":true,"result":{"id":42,"is_bot":true,"first_name":"TeleFlow Test Bot"}}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(
+            handler,
+            configureBot: options =>
+            {
+                options.BaseUrl = "https://telegram-proxy.example/bot-api/";
+                options.Environment = TelegramBotApiEnvironment.Test;
+            });
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        _ = await client.SendAsync(new GetMe());
+
+        Assert.Equal(
+            "https://telegram-proxy.example/bot-api/bottest-token/test/getMe",
+            handler.Requests.Single().RequestUri);
+    }
+
+    [Fact]
+    public async Task TelegramClient_SendAsync_UsesProductionEndpointWithCustomBaseUrl()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse("""{"ok":true,"result":{"id":42,"is_bot":true,"first_name":"TeleFlow Bot"}}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(
+            handler,
+            configureBot: options => options.BaseUrl = "https://telegram-proxy.example/bot-api/");
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        _ = await client.SendAsync(new GetMe());
+
+        Assert.Equal(
+            "https://telegram-proxy.example/bot-api/bottest-token/getMe",
+            handler.Requests.Single().RequestUri);
+    }
+
+    [Fact]
+    public void AddTelegramBot_ForwardsTestEnvironmentToClientOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            options.Environment = TelegramBotApiEnvironment.Test;
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.Equal(
+            TelegramBotApiEnvironment.Test,
+            serviceProvider.GetRequiredService<TelegramClientOptions>().Environment);
+    }
+
+    [Fact]
+    public void TelegramClientOptions_RejectsUnsupportedEnvironment()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            services.AddTelegramClient(options =>
+            {
+                options.Token = "test-token";
+                options.Environment = (TelegramBotApiEnvironment)42;
+            }));
+
+        Assert.Contains("environment", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TelegramBotOptions_RejectsUnsupportedEnvironment()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            services.AddTelegramBot(options =>
+            {
+                options.Token = "test-token";
+                options.Environment = (TelegramBotApiEnvironment)42;
+            }));
+
+        Assert.Contains("environment", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task TelegramClient_SendAsync_DeserializesResultFromUtf8TransportBody()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- add explicit `TelegramBotApiEnvironment` configuration to low-level and framework registration
- construct Telegram test endpoint URLs after the bot token while preserving custom root URLs
- document separate test-account/test-bot credentials and current payment-update boundary

## Touched hot paths
- `src/TeleFlow.Telegram.Client/Internal/TelegramRequestSender.cs`: one environment branch during method URI construction
- client transport, retry policy, executor, and generated client methods are intentionally unchanged

## Validation
- `dotnet test tests/TeleFlow.ArchitectureTests/TeleFlow.ArchitectureTests.csproj --no-build --filter "FullyQualifiedName~TelegramRuntimeIntegrationTests|FullyQualifiedName~PublicSurfaceTests"` (208 passed)
- `python -m mkdocs build --strict --site-dir "$env:TEMP\teleflow-docs-138"`
- `git diff --check`

Closes #138