### PR TITLE
feat: add ephemeral message and command helpers

### DIFF
--- a/docs/en/features/callbacks-and-keyboards.md
+++ b/docs/en/features/callbacks-and-keyboards.md
@@ -251,3 +251,20 @@ await ctx.Message.AnswerAsync(
 - `DeleteMessageAsync(...)`.
 
 Use `ctx.Bot` for Bot API methods not covered by helpers.
+
+## Ephemeral Callback Responses
+
+In a group or supergroup, a callback handler can send a response visible only to the user who pressed the button:
+
+```csharp
+[Callback]
+public async Task ShowPrivateDetails(CallbackQueryContext ctx, CancellationToken ct)
+{
+    await ctx.Callback.SendEphemeralAsync("Only you can see these details.", ct);
+    await ctx.Callback.AnswerAsync(ct);
+}
+```
+
+`SendEphemeralAsync(...)` passes the callback query ID to Telegram, but it does **not** answer the callback query. Keep `AnswerAsync(...)` or the auto-answer middleware so Telegram stops showing the loading indicator.
+
+If the button belongs to an ephemeral message, `EditTextAsync(...)` and `DeleteMessageAsync(...)` select Telegram's dedicated ephemeral endpoints automatically. The response is still best-effort: Telegram can fail to deliver it, and an ephemeral message reference is not durable state.

--- a/docs/en/features/telegram-client.md
+++ b/docs/en/features/telegram-client.md
@@ -256,6 +256,52 @@ public Task Document(MessageContext ctx, CancellationToken ct)
 
 Use context helpers when the current chat and reply target are obvious. Use `ctx.Bot.*Async` when you need the full Telegram method surface or a different chat target.
 
+## Ephemeral Messages And Commands
+
+Telegram Bot API 10.2 can send a message visible only to one user in a group or supergroup. This is a Telegram-side privacy feature, not a normal message followed by a timer and deletion.
+
+Register an ephemeral command explicitly during startup:
+
+```csharp
+await bot.SetMyCommandsAsync(
+    [
+        BotCommands.Create("start", "Open the bot"),
+        BotCommands.Ephemeral("help", "Show personal help")
+    ],
+    cancellationToken: ct);
+```
+
+`BotCommands.Ephemeral(...)` only builds the Bot API model. It does not infer a handler or configure command scopes.
+
+From a message handler, use `SendEphemeralAsync` when the response itself should be private:
+
+```csharp
+[Command("help")]
+public async Task Help(MessageContext ctx, CancellationToken ct)
+{
+    var message = await ctx.Message.SendEphemeralAsync(
+        "Only you can see this help message.",
+        ct);
+
+    await message.EditTextAsync("Personal help is ready.", ct);
+}
+```
+
+The helper derives the current group chat and sender from the update. It fails clearly in private chats and channels because Telegram does not support this delivery mode there. `EphemeralMessageReference` exposes Telegram's dedicated edit and delete methods; do not persist it as a durable identifier because Telegram may reuse an ephemeral message ID after deletion or expiry.
+
+When a user sends an ephemeral message to the bot, `ctx.Message.ReplyAsync(...)` automatically uses the required ephemeral reply parameters. Telegram only accepts that reply within 15 seconds. Use `SendEphemeralAsync(...)` when creating a new private response; `AnswerAsync(...)` remains a normal chat message.
+
+For client code outside a handler, construct the target explicitly:
+
+```csharp
+using TeleFlow.Telegram.Schema.Abstractions;
+
+var target = new EphemeralMessageTarget(IntegerString.From(chatId), userId);
+var message = await bot.SendEphemeralMessageAsync(target, "Private result", cancellationToken: ct);
+```
+
+Telegram does not guarantee delivery, especially when the receiver is offline. Do not use ephemeral messages for receipts, durable status, or data the user must be able to retrieve later.
+
 ## Media Groups
 
 `MediaGroup` is a small builder over Telegram `sendMediaGroup`:

--- a/docs/en/fundamentals/application-model.md
+++ b/docs/en/fundamentals/application-model.md
@@ -85,11 +85,8 @@ public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartup
         await bot.SetMyCommandsAsync(
             commands:
             [
-                new BotCommand
-                {
-                    Command = "start",
-                    Description = "Start"
-                }
+                BotCommands.Create("start", "Start"),
+                BotCommands.Ephemeral("help", "Show personal help")
             ],
             cancellationToken: ct);
     }
@@ -97,6 +94,8 @@ public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartup
 ```
 
 Lifecycle tasks are not Telegram handlers. They do not receive `MessageContext`, `CallbackQueryContext`, or fake updates. They are resolved through dependency injection from a dedicated lifecycle scope, so scoped application services can be used safely.
+
+`BotCommands` makes command intent explicit. `Create(...)` creates a normal command; `Ephemeral(...)` sets Telegram's `is_ephemeral` flag, so the command and its response are visible only to the user who invoked it in a group or supergroup. This helper does not discover handlers or publish commands automatically. Telegram still accepts only Bot API command names, so use a lowercase English command name such as `help` for the command menu and add application aliases separately when needed.
 
 If a startup task fails, update processing does not start. If the update source fails after startup has completed, shutdown tasks still run and the original failure is surfaced. If shutdown also fails, TeleFlow reports both failures.
 
@@ -130,7 +129,7 @@ public Task WhoAmI(MessageContext ctx, CancellationToken ct)
 }
 ```
 
-`ctx.Message` contains message actions such as `AnswerAsync`, `ReplyAsync`, `AnswerPhotoAsync`, `ReplyDocumentAsync`, and `DeleteAsync`. These helpers target the current chat. Use `ctx.Bot.*Async` when the target chat or method surface should be explicit.
+`ctx.Message` contains message actions such as `AnswerAsync`, `ReplyAsync`, `AnswerPhotoAsync`, `ReplyDocumentAsync`, `SendEphemeralAsync`, and `DeleteAsync`. These helpers target the current chat. Use `ctx.Bot.*Async` when the target chat or method surface should be explicit.
 
 Callback handlers use `CallbackQueryContext`:
 

--- a/docs/ru/features/callbacks-and-keyboards.md
+++ b/docs/ru/features/callbacks-and-keyboards.md
@@ -252,3 +252,20 @@ await ctx.Message.AnswerAsync(
 - `DeleteMessageAsync(...)`.
 
 Для Bot API методов, которых нет в helpers, используй `ctx.Bot`.
+
+## Ephemeral-ответы на callback
+
+В группе или супергруппе callback handler может отправить ответ, видимый только нажавшему кнопку пользователю:
+
+```csharp
+[Callback]
+public async Task ShowPrivateDetails(CallbackQueryContext ctx, CancellationToken ct)
+{
+    await ctx.Callback.SendEphemeralAsync("Эти детали видите только вы.", ct);
+    await ctx.Callback.AnswerAsync(ct);
+}
+```
+
+`SendEphemeralAsync(...)` передаёт Telegram ID callback query, но **не** отвечает на сам callback. Оставь `AnswerAsync(...)` или auto-answer middleware, чтобы Telegram убрал индикатор загрузки.
+
+Если кнопка находится в ephemeral message, `EditTextAsync(...)` и `DeleteMessageAsync(...)` сами выберут специальные Telegram endpoints для ephemeral messages. Но доставка всё равно best-effort: Telegram может не доставить ответ, а ссылка на ephemeral message не является постоянным состоянием.

--- a/docs/ru/features/telegram-client.md
+++ b/docs/ru/features/telegram-client.md
@@ -256,6 +256,52 @@ public Task Document(MessageContext ctx, CancellationToken ct)
 
 Используй context helpers, когда current chat и reply target очевидны. Используй `ctx.Bot.*Async`, когда нужен полный Telegram method surface или другой chat target.
 
+## Ephemeral messages и commands
+
+Telegram Bot API 10.2 умеет отправлять в группе или супергруппе сообщение, видимое только одному пользователю. Это серверная функция Telegram, а не обычное сообщение с таймером и последующим удалением.
+
+Ephemeral-команду регистрируй явно при старте:
+
+```csharp
+await bot.SetMyCommandsAsync(
+    [
+        BotCommands.Create("start", "Открыть бота"),
+        BotCommands.Ephemeral("help", "Показать личную справку")
+    ],
+    cancellationToken: ct);
+```
+
+`BotCommands.Ephemeral(...)` только создаёт модель Bot API. Он не ищет handler и не настраивает command scopes.
+
+В message handler вызывай `SendEphemeralAsync`, когда сам ответ должен быть личным:
+
+```csharp
+[Command("help")]
+public async Task Help(MessageContext ctx, CancellationToken ct)
+{
+    var message = await ctx.Message.SendEphemeralAsync(
+        "Эту справку видите только вы.",
+        ct);
+
+    await message.EditTextAsync("Личная справка готова.", ct);
+}
+```
+
+Helper берёт текущий group chat и отправителя из update. В private chats и channels он падает с понятной ошибкой, потому что Telegram не поддерживает там такой режим доставки. `EphemeralMessageReference` даёт доступ к специальным Telegram-методам редактирования и удаления. Не сохраняй его как постоянный идентификатор: Telegram может повторно использовать ephemeral message ID после удаления или истечения срока.
+
+Если пользователь отправил боту ephemeral message, `ctx.Message.ReplyAsync(...)` автоматически передаёт обязательные ephemeral reply parameters. Telegram принимает такой ответ только в течение 15 секунд. Для нового личного ответа вызывай `SendEphemeralAsync(...)`; `AnswerAsync(...)` остаётся обычным сообщением в чат.
+
+В client-коде вне handler target задаётся явно:
+
+```csharp
+using TeleFlow.Telegram.Schema.Abstractions;
+
+var target = new EphemeralMessageTarget(IntegerString.From(chatId), userId);
+var message = await bot.SendEphemeralMessageAsync(target, "Личный результат", cancellationToken: ct);
+```
+
+Telegram не гарантирует доставку, особенно когда получатель офлайн. Не используй ephemeral messages для чеков, постоянного статуса или данных, которые пользователь должен потом получить снова.
+
 ## Media groups
 
 `MediaGroup` - небольшой builder поверх Telegram `sendMediaGroup`:

--- a/docs/ru/fundamentals/application-model.md
+++ b/docs/ru/fundamentals/application-model.md
@@ -85,11 +85,8 @@ public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartup
         await bot.SetMyCommandsAsync(
             commands:
             [
-                new BotCommand
-                {
-                    Command = "start",
-                    Description = "Start"
-                }
+                BotCommands.Create("start", "Start"),
+                BotCommands.Ephemeral("help", "Показать личную справку")
             ],
             cancellationToken: ct);
     }
@@ -97,6 +94,8 @@ public sealed class ConfigureBotCommands(ITelegramClient bot) : ITeleFlowStartup
 ```
 
 Lifecycle tasks не являются Telegram handlers. Они не получают `MessageContext`, `CallbackQueryContext` или fake updates. TeleFlow создаёт их через dependency injection в отдельном lifecycle scope, поэтому scoped application services можно использовать безопасно.
+
+`BotCommands` явно задаёт смысл команды. `Create(...)` создаёт обычную команду, а `Ephemeral(...)` выставляет Telegram-флаг `is_ephemeral`: в группе или супергруппе команда и её ответ видны только вызвавшему пользователю. Этот helper не ищет handlers и не публикует команды автоматически. Telegram по-прежнему принимает для меню только имена команд по правилам Bot API, поэтому используй строчное английское имя вроде `help`, а локальные алиасы добавляй отдельно.
 
 Если startup task падает, update processing не стартует. Если update source падает уже после успешного startup, shutdown tasks всё равно выполняются, а исходная ошибка пробрасывается наружу. Если shutdown тоже падает, TeleFlow сообщает обе ошибки.
 
@@ -130,7 +129,7 @@ public Task WhoAmI(MessageContext ctx, CancellationToken ct)
 }
 ```
 
-`ctx.Message` содержит message actions: `AnswerAsync`, `ReplyAsync`, `AnswerPhotoAsync`, `ReplyDocumentAsync`, `DeleteAsync`. Эти helpers нацелены на current chat. Используй `ctx.Bot.*Async`, когда target chat или method surface должны быть явными.
+`ctx.Message` содержит message actions: `AnswerAsync`, `ReplyAsync`, `AnswerPhotoAsync`, `ReplyDocumentAsync`, `SendEphemeralAsync`, `DeleteAsync`. Эти helpers нацелены на current chat. Используй `ctx.Bot.*Async`, когда target chat или method surface должны быть явными.
 
 Callback handlers используют `CallbackQueryContext`:
 

--- a/src/TeleFlow.Framework/CallbackQueryActions.cs
+++ b/src/TeleFlow.Framework/CallbackQueryActions.cs
@@ -77,6 +77,11 @@ public sealed class CallbackQueryActions
 
         if (CallbackQueryMessageTargetResolver.TryResolve(_context.TelegramCallbackQuery, out var target))
         {
+            if (target.IsEphemeral)
+            {
+                return EditEphemeralTextAsync(target, text, replyMarkup, cancellationToken);
+            }
+
             return _context.Bot.EditMessageTextAsync(
                 chatId: IntegerString.From(target.ChatId),
                 messageId: target.MessageId,
@@ -106,10 +111,83 @@ public sealed class CallbackQueryActions
                 "The current callback query does not contain a deletable chat message target.");
         }
 
+        if (target.IsEphemeral)
+        {
+            return _context.Bot.DeleteEphemeralMessageAsync(
+                IntegerString.From(target.ChatId),
+                EphemeralMessageTargetResolver.ResolveReceiverUserId(_context.TelegramCallbackQuery, target),
+                target.EphemeralMessageId!.Value,
+                ResolveCancellationToken(cancellationToken));
+        }
+
         return _context.Bot.DeleteMessageAsync(
             IntegerString.From(target.ChatId),
             target.MessageId,
             ResolveCancellationToken(cancellationToken));
+    }
+
+    /// <summary>
+    /// Sends a text message visible only to the user who triggered the callback in a group or supergroup chat.
+    /// Sending the message does not acknowledge the callback query.
+    /// </summary>
+    public Task<EphemeralMessageReference> SendEphemeralAsync(
+        string text,
+        CancellationToken cancellationToken = default)
+    {
+        return SendEphemeralCoreAsync(text, inlineKeyboard: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a text message with an inline keyboard visible only to the user who triggered the callback in a group or supergroup chat.
+    /// Sending the message does not acknowledge the callback query.
+    /// </summary>
+    public Task<EphemeralMessageReference> SendEphemeralAsync(
+        string text,
+        InlineKeyboardMarkup replyMarkup,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(replyMarkup);
+        return SendEphemeralCoreAsync(text, replyMarkup, cancellationToken);
+    }
+
+    private async Task<MessageBoolean> EditEphemeralTextAsync(
+        TelegramMessageTarget target,
+        string text,
+        InlineKeyboardMarkup? replyMarkup,
+        CancellationToken cancellationToken)
+    {
+        var result = await _context.Bot.EditEphemeralMessageTextAsync(
+            IntegerString.From(target.ChatId),
+            EphemeralMessageTargetResolver.ResolveReceiverUserId(_context.TelegramCallbackQuery, target),
+            target.EphemeralMessageId!.Value,
+            text,
+            replyMarkup: replyMarkup,
+            cancellationToken: ResolveCancellationToken(cancellationToken)).ConfigureAwait(false);
+
+        return MessageBoolean.From(result);
+    }
+
+    private Task<EphemeralMessageReference> SendEphemeralCoreAsync(
+        string text,
+        InlineKeyboardMarkup? inlineKeyboard,
+        CancellationToken cancellationToken)
+    {
+        if (!CallbackQueryMessageTargetResolver.TryResolve(_context.TelegramCallbackQuery, out var target))
+        {
+            throw new InvalidOperationException(
+                "The current callback query does not contain a group or supergroup chat target for an ephemeral message.");
+        }
+
+        var ephemeralTarget = EphemeralMessageTargetResolver.ResolveForCallback(
+            _context.TelegramCallbackQuery,
+            target);
+
+        return _context.Bot.SendEphemeralMessageAsync(
+            ephemeralTarget,
+            text,
+            replyMarkup: inlineKeyboard,
+            callbackQueryId: _context.TelegramCallbackQuery.Id,
+            cancellationToken: ResolveCancellationToken(cancellationToken));
     }
 
     private CancellationToken ResolveCancellationToken(CancellationToken cancellationToken)

--- a/src/TeleFlow.Framework/Internal/CallbackQueryMessageTargetResolver.cs
+++ b/src/TeleFlow.Framework/Internal/CallbackQueryMessageTargetResolver.cs
@@ -17,13 +17,21 @@ internal static class CallbackQueryMessageTargetResolver
 
         if (message.TryGetMessage(out var accessibleMessage) && accessibleMessage is not null)
         {
-            target = new TelegramMessageTarget(accessibleMessage.Chat.Id, accessibleMessage.MessageId);
+            target = new TelegramMessageTarget(
+                accessibleMessage.Chat,
+                accessibleMessage.MessageId,
+                accessibleMessage.EphemeralMessageId,
+                accessibleMessage.ReceiverUser?.Id);
             return true;
         }
 
         if (message.TryGetInaccessibleMessage(out var inaccessibleMessage) && inaccessibleMessage is not null)
         {
-            target = new TelegramMessageTarget(inaccessibleMessage.Chat.Id, inaccessibleMessage.MessageId);
+            target = new TelegramMessageTarget(
+                inaccessibleMessage.Chat,
+                inaccessibleMessage.MessageId,
+                EphemeralMessageId: null,
+                ReceiverUserId: null);
             return true;
         }
 

--- a/src/TeleFlow.Framework/Internal/EphemeralMessageTargetResolver.cs
+++ b/src/TeleFlow.Framework/Internal/EphemeralMessageTargetResolver.cs
@@ -1,0 +1,75 @@
+using TeleFlow.Telegram.Schema.Constants;
+using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Derives the Bot API target for ephemeral actions from message and callback updates.
+/// It keeps Telegram's group-only recipient rules out of the public action classes.
+/// </summary>
+internal static class EphemeralMessageTargetResolver
+{
+    public static EphemeralMessageTarget ResolveForMessage(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return CreateTarget(
+            message.Chat,
+            message.ReceiverUser?.Id ?? message.From?.Id,
+            "The current message does not identify a user who can receive an ephemeral message.");
+    }
+
+    public static EphemeralMessageTarget ResolveForCallback(
+        CallbackQuery callbackQuery,
+        TelegramMessageTarget messageTarget)
+    {
+        ArgumentNullException.ThrowIfNull(callbackQuery);
+
+        return CreateTarget(
+            messageTarget.Chat,
+            callbackQuery.From.Id,
+            "The current callback query does not identify a user who can receive an ephemeral message.");
+    }
+
+    public static EphemeralMessageTarget ResolveForEphemeralMessage(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return CreateTarget(
+            message.Chat,
+            message.ReceiverUser?.Id,
+            "The current ephemeral message does not identify its receiver.");
+    }
+
+    public static long ResolveReceiverUserId(
+        CallbackQuery callbackQuery,
+        TelegramMessageTarget messageTarget)
+    {
+        ArgumentNullException.ThrowIfNull(callbackQuery);
+
+        return messageTarget.ReceiverUserId ?? callbackQuery.From.Id;
+    }
+
+    private static EphemeralMessageTarget CreateTarget(
+        Chat chat,
+        long? receiverUserId,
+        string missingReceiverMessage)
+    {
+        ArgumentNullException.ThrowIfNull(chat);
+
+        if (!string.Equals(chat.Type, ChatTypes.Group, StringComparison.Ordinal) &&
+            !string.Equals(chat.Type, ChatTypes.Supergroup, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Ephemeral messages can only be sent in a group or supergroup chat.");
+        }
+
+        if (receiverUserId is not long userId || userId <= 0)
+        {
+            throw new InvalidOperationException(missingReceiverMessage);
+        }
+
+        return new EphemeralMessageTarget(IntegerString.From(chat.Id), userId);
+    }
+}

--- a/src/TeleFlow.Framework/Internal/EphemeralMessageTargetResolver.cs
+++ b/src/TeleFlow.Framework/Internal/EphemeralMessageTargetResolver.cs
@@ -1,5 +1,5 @@
-using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Internal;

--- a/src/TeleFlow.Framework/Internal/TelegramMessageTarget.cs
+++ b/src/TeleFlow.Framework/Internal/TelegramMessageTarget.cs
@@ -1,3 +1,14 @@
+using TeleFlow.Telegram.Schema.Types;
+
 namespace TeleFlow.Telegram.Internal;
 
-internal readonly record struct TelegramMessageTarget(long ChatId, long MessageId);
+internal readonly record struct TelegramMessageTarget(
+    Chat Chat,
+    long MessageId,
+    long? EphemeralMessageId,
+    long? ReceiverUserId)
+{
+    public long ChatId => Chat.Id;
+
+    public bool IsEphemeral => EphemeralMessageId is not null;
+}

--- a/src/TeleFlow.Framework/MessageActions.Media.cs
+++ b/src/TeleFlow.Framework/MessageActions.Media.cs
@@ -534,12 +534,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(photo);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendPhotoAsync(
             CurrentChatId,
             photo,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -553,12 +555,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(document);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendDocumentAsync(
             CurrentChatId,
             document,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -572,12 +576,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(video);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendVideoAsync(
             CurrentChatId,
             video,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -591,12 +597,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(animation);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendAnimationAsync(
             CurrentChatId,
             animation,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -610,12 +618,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(audio);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendAudioAsync(
             CurrentChatId,
             audio,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -629,12 +639,14 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(voice);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendVoiceAsync(
             CurrentChatId,
             voice,
             caption: caption,
             parseMode: parseMode,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -646,10 +658,12 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(sticker);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendStickerAsync(
             CurrentChatId,
             sticker,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
@@ -661,24 +675,16 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(videoNote);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
         return _context.Bot.SendVideoNoteAsync(
             CurrentChatId,
             videoNote,
-            replyParameters: CreateReplyParameters(replyToCurrentMessage),
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
 
     private IntegerString CurrentChatId => IntegerString.From(_context.TelegramChat.Id);
-
-    private ReplyParameters? CreateReplyParameters(bool replyToCurrentMessage)
-    {
-        return replyToCurrentMessage
-            ? new ReplyParameters
-            {
-                MessageId = _context.TelegramMessage.MessageId
-            }
-            : null;
-    }
 
 }

--- a/src/TeleFlow.Framework/MessageActions.cs
+++ b/src/TeleFlow.Framework/MessageActions.cs
@@ -1,5 +1,5 @@
-using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Internal;
+using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram;

--- a/src/TeleFlow.Framework/MessageActions.cs
+++ b/src/TeleFlow.Framework/MessageActions.cs
@@ -1,4 +1,5 @@
 using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram;
@@ -136,6 +137,28 @@ public sealed partial class MessageActions
         return SendTextAsync(text, replyMarkup, replyToCurrentMessage: true, cancellationToken);
     }
 
+    /// <summary>
+    /// Sends a text message visible only to the user represented by the current group or supergroup update.
+    /// </summary>
+    public Task<EphemeralMessageReference> SendEphemeralAsync(
+        string text,
+        CancellationToken cancellationToken = default)
+    {
+        return SendEphemeralCoreAsync(text, inlineKeyboard: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a text message with an inline keyboard visible only to the user represented by the current group or supergroup update.
+    /// </summary>
+    public Task<EphemeralMessageReference> SendEphemeralAsync(
+        string text,
+        InlineKeyboardMarkup replyMarkup,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(replyMarkup);
+        return SendEphemeralCoreAsync(text, replyMarkup, cancellationToken);
+    }
+
     [Obsolete("Use ReplyAsync instead.")]
     public Task<Message> ReplyTextAsync(string text, CancellationToken cancellationToken = default)
     {
@@ -169,26 +192,65 @@ public sealed partial class MessageActions
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        var reply = CreateReplyConfiguration(replyToCurrentMessage);
 
         return _context.Bot.SendMessageAsync(
             IntegerString.From(_context.TelegramChat.Id),
             text,
-            replyParameters: replyToCurrentMessage
-                ? new ReplyParameters
-                {
-                    MessageId = _context.TelegramMessage.MessageId
-                }
-                : null,
+            receiverUserId: reply.ReceiverUserId,
+            replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken));
     }
 
     public Task<bool> DeleteAsync(CancellationToken cancellationToken = default)
     {
+        if (_context.TelegramMessage.EphemeralMessageId is long ephemeralMessageId)
+        {
+            var target = EphemeralMessageTargetResolver.ResolveForEphemeralMessage(_context.TelegramMessage);
+            return _context.Bot.DeleteEphemeralMessageAsync(
+                target.ChatId,
+                target.ReceiverUserId,
+                ephemeralMessageId,
+                ResolveCancellationToken(cancellationToken));
+        }
+
         return _context.Bot.DeleteMessageAsync(
             IntegerString.From(_context.TelegramChat.Id),
             _context.TelegramMessage.MessageId,
             ResolveCancellationToken(cancellationToken));
+    }
+
+    private Task<EphemeralMessageReference> SendEphemeralCoreAsync(
+        string text,
+        InlineKeyboardMarkup? inlineKeyboard,
+        CancellationToken cancellationToken)
+    {
+        var target = EphemeralMessageTargetResolver.ResolveForMessage(_context.TelegramMessage);
+        return _context.Bot.SendEphemeralMessageAsync(
+            target,
+            text,
+            replyMarkup: inlineKeyboard,
+            cancellationToken: ResolveCancellationToken(cancellationToken));
+    }
+
+    private (ReplyParameters? ReplyParameters, long? ReceiverUserId) CreateReplyConfiguration(
+        bool replyToCurrentMessage)
+    {
+        if (!replyToCurrentMessage)
+        {
+            return default;
+        }
+
+        if (_context.TelegramMessage.EphemeralMessageId is long ephemeralMessageId)
+        {
+            var target = EphemeralMessageTargetResolver.ResolveForEphemeralMessage(_context.TelegramMessage);
+            return (
+                new ReplyParameters { EphemeralMessageId = ephemeralMessageId },
+                target.ReceiverUserId);
+        }
+
+        return (new ReplyParameters { MessageId = _context.TelegramMessage.MessageId }, null);
     }
 
     private CancellationToken ResolveCancellationToken(CancellationToken cancellationToken)

--- a/src/TeleFlow.Telegram.Client/BotCommands.cs
+++ b/src/TeleFlow.Telegram.Client/BotCommands.cs
@@ -1,0 +1,30 @@
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Creates explicit Bot API command descriptors for application startup configuration.
+/// It does not discover handler routes or publish commands automatically.
+/// </summary>
+public static class BotCommands
+{
+    public static BotCommand Create(string command, string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+
+        return new BotCommand
+        {
+            Command = command,
+            Description = description
+        };
+    }
+
+    public static BotCommand Ephemeral(string command, string description)
+    {
+        return Create(command, description) with
+        {
+            IsEphemeral = true
+        };
+    }
+}

--- a/src/TeleFlow.Telegram.Client/EphemeralMessageReference.cs
+++ b/src/TeleFlow.Telegram.Client/EphemeralMessageReference.cs
@@ -1,0 +1,108 @@
+using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Represents an ephemeral message sent through the Telegram Bot API.
+/// It retains the addressing identity required by Telegram's dedicated ephemeral edit and delete methods.
+/// </summary>
+public sealed class EphemeralMessageReference
+{
+    private readonly ITelegramClient _bot;
+
+    internal EphemeralMessageReference(
+        ITelegramClient bot,
+        EphemeralMessageTarget target,
+        long ephemeralMessageId,
+        Message telegramMessage)
+    {
+        ArgumentNullException.ThrowIfNull(bot);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(telegramMessage);
+
+        _bot = bot;
+        Target = target;
+        EphemeralMessageId = ephemeralMessageId;
+        TelegramMessage = telegramMessage;
+    }
+
+    public EphemeralMessageTarget Target { get; }
+
+    public long ReceiverUserId => Target.ReceiverUserId;
+
+    public long EphemeralMessageId { get; }
+
+    public Message TelegramMessage { get; }
+
+    public Task<bool> EditTextAsync(
+        string text,
+        InlineKeyboardMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        return _bot.EditEphemeralMessageTextAsync(
+            chatId: Target.ChatId,
+            receiverUserId: ReceiverUserId,
+            ephemeralMessageId: EphemeralMessageId,
+            text: text,
+            replyMarkup: replyMarkup,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<bool> EditCaptionAsync(
+        string? caption = null,
+        TelegramParseMode? parseMode = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
+        InlineKeyboardMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _bot.EditEphemeralMessageCaptionAsync(
+            chatId: Target.ChatId,
+            receiverUserId: ReceiverUserId,
+            ephemeralMessageId: EphemeralMessageId,
+            caption: caption,
+            parseMode: parseMode,
+            captionEntities: captionEntities,
+            replyMarkup: replyMarkup,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<bool> EditMediaAsync(
+        InputMedia media,
+        InlineKeyboardMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(media);
+
+        return _bot.EditEphemeralMessageMediaAsync(
+            chatId: Target.ChatId,
+            receiverUserId: ReceiverUserId,
+            ephemeralMessageId: EphemeralMessageId,
+            media: media,
+            replyMarkup: replyMarkup,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<bool> EditReplyMarkupAsync(
+        InlineKeyboardMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _bot.EditEphemeralMessageReplyMarkupAsync(
+            chatId: Target.ChatId,
+            receiverUserId: ReceiverUserId,
+            ephemeralMessageId: EphemeralMessageId,
+            replyMarkup: replyMarkup,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<bool> DeleteAsync(CancellationToken cancellationToken = default)
+    {
+        return _bot.DeleteEphemeralMessageAsync(
+            chatId: Target.ChatId,
+            receiverUserId: ReceiverUserId,
+            ephemeralMessageId: EphemeralMessageId,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/EphemeralMessageTarget.cs
+++ b/src/TeleFlow.Telegram.Client/EphemeralMessageTarget.cs
@@ -1,0 +1,23 @@
+using TeleFlow.Telegram.Schema.Abstractions;
+
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Identifies the group or supergroup chat and recipient required to address an ephemeral Telegram message.
+/// The target is used by client-level helpers outside an incoming TeleFlow update context.
+/// </summary>
+public sealed record EphemeralMessageTarget
+{
+    public EphemeralMessageTarget(IntegerString chatId, long receiverUserId)
+    {
+        ArgumentNullException.ThrowIfNull(chatId);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(receiverUserId);
+
+        ChatId = chatId;
+        ReceiverUserId = receiverUserId;
+    }
+
+    public IntegerString ChatId { get; }
+
+    public long ReceiverUserId { get; }
+}

--- a/src/TeleFlow.Telegram.Client/TelegramClientEphemeralMessageExtensions.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramClientEphemeralMessageExtensions.cs
@@ -1,0 +1,45 @@
+using TeleFlow.Telegram.Schema.Abstractions;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Provides explicit client-level conveniences for sending Telegram ephemeral text messages.
+/// Framework context helpers use this surface after deriving an ephemeral target from an incoming update.
+/// </summary>
+public static class TelegramClientEphemeralMessageExtensions
+{
+    public static async Task<EphemeralMessageReference> SendEphemeralMessageAsync(
+        this ITelegramClient bot,
+        EphemeralMessageTarget target,
+        string text,
+        InlineKeyboardMarkup? replyMarkup = null,
+        string? callbackQueryId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bot);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        if (callbackQueryId is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(callbackQueryId);
+        }
+
+        var message = await bot.SendMessageAsync(
+            target.ChatId,
+            text,
+            receiverUserId: target.ReceiverUserId,
+            callbackQueryId: callbackQueryId,
+            replyMarkup: replyMarkup is null ? null : ReplyMarkup.From(replyMarkup),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (message.EphemeralMessageId is not long ephemeralMessageId)
+        {
+            throw new InvalidOperationException(
+                "Telegram returned an ephemeral message without an ephemeral_message_id.");
+        }
+
+        return new EphemeralMessageReference(bot, target, ephemeralMessageId, message);
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -2527,6 +2527,304 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task MessageSendEphemeralAsync_UsesCurrentSenderAndGroupChat()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendMessage => new Message
+                {
+                    MessageId = 0,
+                    EphemeralMessageId = 30,
+                    ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" },
+                    Text = "private"
+                },
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    Message = new Message
+                    {
+                        MessageId = 10,
+                        Date = 0,
+                        From = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Chat = new Chat { Id = 100, Type = "supergroup" },
+                        Text = "/help"
+                    }
+                }));
+
+        var message = await context.GetMessageContext().Message.SendEphemeralAsync("private");
+
+        var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
+        Assert.Equal(100L, sendMessage.ChatId.Integer);
+        Assert.Equal(7L, sendMessage.ReceiverUserId);
+        Assert.Null(sendMessage.CallbackQueryId);
+        Assert.Equal(30L, message.EphemeralMessageId);
+        Assert.Equal(7L, message.ReceiverUserId);
+    }
+
+    [Fact]
+    public async Task MessageReplyAsync_UsesEphemeralReplyParametersForIncomingEphemeralMessage()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendMessage => new Message
+                {
+                    MessageId = 0,
+                    EphemeralMessageId = 31,
+                    ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" },
+                    Text = "reply"
+                },
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    Message = new Message
+                    {
+                        MessageId = 0,
+                        EphemeralMessageId = 12,
+                        ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Date = 0,
+                        From = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Chat = new Chat { Id = 100, Type = "supergroup" },
+                        Text = "/help"
+                    }
+                }));
+
+        await context.GetMessageContext().Message.ReplyAsync("reply");
+
+        var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
+        Assert.Equal(7L, sendMessage.ReceiverUserId);
+        Assert.Null(sendMessage.ReplyParameters?.MessageId);
+        Assert.Equal(12L, sendMessage.ReplyParameters?.EphemeralMessageId);
+    }
+
+    [Fact]
+    public async Task MessageSendEphemeralAsync_FailsClearlyOutsideGroupChats()
+    {
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: new RecordingTelegramClient());
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    Message = new Message
+                    {
+                        MessageId = 10,
+                        Date = 0,
+                        From = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Chat = new Chat { Id = 100, Type = "private" },
+                        Text = "/help"
+                    }
+                }));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.GetMessageContext().Message.SendEphemeralAsync("private"));
+
+        Assert.Contains("group or supergroup", exception.Message);
+    }
+
+    [Fact]
+    public async Task MessageReplyPhotoAsync_UsesEphemeralReplyParametersForIncomingEphemeralMessage()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendPhoto => new Message
+                {
+                    MessageId = 0,
+                    EphemeralMessageId = 31,
+                    ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" }
+                },
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    Message = new Message
+                    {
+                        MessageId = 0,
+                        EphemeralMessageId = 12,
+                        ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Date = 0,
+                        From = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Chat = new Chat { Id = 100, Type = "supergroup" }
+                    }
+                }));
+
+        await context.GetMessageContext().Message.ReplyPhotoAsync(InputFileString.From("file-id"));
+
+        var sendPhoto = Assert.IsType<SendPhoto>(fakeClient.Methods.Single());
+        Assert.Equal(7L, sendPhoto.ReceiverUserId);
+        Assert.Null(sendPhoto.ReplyParameters?.MessageId);
+        Assert.Equal(12L, sendPhoto.ReplyParameters?.EphemeralMessageId);
+    }
+
+    [Fact]
+    public async Task MessageDeleteAsync_UsesEphemeralEndpointForIncomingEphemeralMessage()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                DeleteEphemeralMessage => true,
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    Message = new Message
+                    {
+                        MessageId = 0,
+                        EphemeralMessageId = 12,
+                        ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Date = 0,
+                        From = new User { Id = 7, IsBot = false, FirstName = "User" },
+                        Chat = new Chat { Id = 100, Type = "supergroup" }
+                    }
+                }));
+
+        await context.GetMessageContext().Message.DeleteAsync();
+
+        var delete = Assert.IsType<DeleteEphemeralMessage>(fakeClient.Methods.Single());
+        Assert.Equal(100L, delete.ChatId.Integer);
+        Assert.Equal(7L, delete.ReceiverUserId);
+        Assert.Equal(12L, delete.EphemeralMessageId);
+    }
+
+    [Fact]
+    public void BotCommands_Ephemeral_CreatesExplicitEphemeralCommand()
+    {
+        var command = BotCommands.Ephemeral("help", "Show personal help");
+
+        Assert.Equal("help", command.Command);
+        Assert.Equal("Show personal help", command.Description);
+        Assert.True(command.IsEphemeral);
+    }
+
+    [Fact]
+    public async Task EphemeralMessageReference_UsesDedicatedEditAndDeleteMethods()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendMessage => new Message
+                {
+                    MessageId = 0,
+                    EphemeralMessageId = 30,
+                    ReceiverUser = new User { Id = 7, IsBot = false, FirstName = "User" },
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" },
+                    Text = "private"
+                },
+                EditEphemeralMessageText => true,
+                EditEphemeralMessageCaption => true,
+                EditEphemeralMessageMedia => true,
+                EditEphemeralMessageReplyMarkup => true,
+                DeleteEphemeralMessage => true,
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        var message = await fakeClient.SendEphemeralMessageAsync(
+            new EphemeralMessageTarget(IntegerString.From(100), 7),
+            "private");
+
+        await message.EditTextAsync("edited");
+        await message.EditCaptionAsync("caption");
+        await message.EditMediaAsync(InputMedia.From(new InputMediaPhoto { Media = "file-id" }));
+        await message.EditReplyMarkupAsync();
+        await message.DeleteAsync();
+
+        Assert.Collection(
+            fakeClient.Methods,
+            method => Assert.IsType<SendMessage>(method),
+            method => Assert.IsType<EditEphemeralMessageText>(method),
+            method => Assert.IsType<EditEphemeralMessageCaption>(method),
+            method => Assert.IsType<EditEphemeralMessageMedia>(method),
+            method => Assert.IsType<EditEphemeralMessageReplyMarkup>(method),
+            method => Assert.IsType<DeleteEphemeralMessage>(method));
+    }
+
+    [Fact]
+    public async Task SendEphemeralMessageAsync_FailsClearlyWhenTelegramOmitsEphemeralMessageId()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendMessage => new Message
+                {
+                    MessageId = 0,
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" },
+                    Text = "private"
+                },
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fakeClient.SendEphemeralMessageAsync(
+                new EphemeralMessageTarget(IntegerString.From(100), 7),
+                "private"));
+
+        Assert.Contains("ephemeral_message_id", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendEphemeralMessageAsync_RejectsWhitespaceCallbackQueryId()
+    {
+        var fakeClient = new RecordingTelegramClient();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => fakeClient.SendEphemeralMessageAsync(
+                new EphemeralMessageTarget(IntegerString.From(100), 7),
+                "private",
+                callbackQueryId: " "));
+
+        Assert.Empty(fakeClient.Methods);
+    }
+
+    [Fact]
     public async Task MessageAnswerAsync_CanSendInlineKeyboardWithTypedCallbackData()
     {
         var fakeClient = new RecordingTelegramClient
@@ -3342,6 +3640,116 @@ public sealed class TelegramRuntimeIntegrationTests
                 Assert.Equal("inline-42", edit.InlineMessageId);
                 Assert.Null(edit.ChatId);
                 Assert.Null(edit.MessageId);
+            });
+    }
+
+    [Fact]
+    public async Task CallbackSendEphemeralAsync_UsesCallbackTargetAndTriggerId()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                SendMessage => new Message
+                {
+                    MessageId = 0,
+                    EphemeralMessageId = 40,
+                    ReceiverUser = new User { Id = 5, IsBot = false, FirstName = "User" },
+                    Date = 0,
+                    Chat = new Chat { Id = 100, Type = "supergroup" },
+                    Text = "private"
+                },
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    CallbackQuery = new CallbackQuery
+                    {
+                        Id = "callback-1",
+                        From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                        Message = MaybeInaccessibleMessage.From(
+                            new Message
+                            {
+                                MessageId = 99,
+                                Date = 1,
+                                Chat = new Chat { Id = 100, Type = "supergroup" }
+                            }),
+                        ChatInstance = "chat-instance"
+                    }
+                }));
+
+        await context.GetCallbackQueryContext().Callback.SendEphemeralAsync("private");
+
+        var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
+        Assert.Equal(100L, sendMessage.ChatId.Integer);
+        Assert.Equal(5L, sendMessage.ReceiverUserId);
+        Assert.Equal("callback-1", sendMessage.CallbackQueryId);
+    }
+
+    [Fact]
+    public async Task CallbackActions_UseEphemeralEndpointsForEphemeralMessageTargets()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                EditEphemeralMessageText => true,
+                DeleteEphemeralMessage => true,
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    CallbackQuery = new CallbackQuery
+                    {
+                        Id = "callback-1",
+                        From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                        Message = MaybeInaccessibleMessage.From(
+                            new Message
+                            {
+                                MessageId = 0,
+                                EphemeralMessageId = 40,
+                                ReceiverUser = new User { Id = 5, IsBot = false, FirstName = "User" },
+                                Date = 1,
+                                Chat = new Chat { Id = 100, Type = "supergroup" }
+                            }),
+                        ChatInstance = "chat-instance"
+                    }
+                }));
+
+        var callback = context.GetCallbackQueryContext().Callback;
+        var editResult = await callback.EditTextAsync("edited");
+        await callback.DeleteMessageAsync();
+
+        Assert.True(editResult.Boolean);
+        Assert.Collection(
+            fakeClient.Methods,
+            method =>
+            {
+                var edit = Assert.IsType<EditEphemeralMessageText>(method);
+                Assert.Equal(100L, edit.ChatId.Integer);
+                Assert.Equal(5L, edit.ReceiverUserId);
+                Assert.Equal(40L, edit.EphemeralMessageId);
+            },
+            method =>
+            {
+                var delete = Assert.IsType<DeleteEphemeralMessage>(method);
+                Assert.Equal(100L, delete.ChatId.Integer);
+                Assert.Equal(5L, delete.ReceiverUserId);
+                Assert.Equal(40L, delete.EphemeralMessageId);
             });
     }
 


### PR DESCRIPTION
## Summary

- add explicit `BotCommands` helpers and client-level ephemeral message targeting/reference APIs
- add message and callback helpers that preserve Telegram's dedicated ephemeral reply, edit, and delete semantics
- keep callback acknowledgement explicit and document delivery, expiry, and group-only limitations in English and Russian

## Touched hot paths

- `MessageActions` now derives Telegram reply parameters once per send path; normal message behavior remains unchanged
- callback edit/delete select the dedicated endpoint only when the callback target is an ephemeral message
- no dispatcher, route matching, generated registration, or reflection path changed

## Verification

- [x] Tests added or updated for behavior changes.
- [x] Documentation updated for public API and runtime semantics.
- [x] `dotnet build TeleFlow.sln --no-restore` passed with 0 warnings and 0 errors.
- [x] `dotnet test TeleFlow.sln --no-restore --no-build` passed: 757 tests.
- [x] Targeted ephemeral runtime integration tests passed: 175 tests.
- [x] `python -m mkdocs build --strict --site-dir site` passed.
- [x] Generated and reflection paths are not involved in this feature.

## Risk

This adds public helpers without changing existing method signatures. Telegram only supports ephemeral delivery in groups and supergroups and does not guarantee delivery; the helpers fail clearly when a current update cannot establish a valid target. Ephemeral message references are intentionally not durable storage keys.

Closes #155