### PR TITLE
fix: enforce command routing contract

### DIFF
--- a/docs/en/fundamentals/handlers-and-routing.md
+++ b/docs/en/fundamentals/handlers-and-routing.md
@@ -28,6 +28,12 @@ public Task Start(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+For slash commands in groups, `/start@my_bot` matches only the named bot. When
+`BotUsername` was not configured, TeleFlow resolves bot identity once before a
+standard long-polling or webhook transport starts. See the
+[routing contract](../reference/routing-contract.md) for mention behavior,
+overlapping prefixes, and precedence rules.
+
 Use `CommandPrefixMode.Optional` when the same route should accept both a
 Telegram command and prefix-less command-like text:
 

--- a/docs/en/reference/routing-contract.md
+++ b/docs/en/reference/routing-contract.md
@@ -1,0 +1,98 @@
+# Routing Contract
+
+This page defines the observable routing rules of TeleFlow. It complements the
+[handlers guide](../fundamentals/handlers-and-routing.md).
+
+## Selection Order
+
+For a message update, TeleFlow tries command routes before message routes. A
+message that matches no command can still reach a `[Message]`, `[Text]`,
+template, or regex handler.
+
+Within each route family, selection is deterministic:
+
+| Rule | Earlier candidate wins |
+| --- | --- |
+| State | A handler for the current state before a stateless handler |
+| Command route kind | Exact command, then command template, then command regex |
+| Message route kind | Exact text, then text template, then text regex, then a bare message handler |
+| Route specificity | The more specific route of the same kind |
+| Final tie | Registration order |
+
+Filters run after the route shape matches. A filter rejection continues search
+for another candidate; it is not an error. Typed callback routes run before raw
+`[Callback]` fallbacks. Chat-member routes require both update kind and declared
+transition to match before filters run.
+
+## Command Prefixes
+
+`CommandPrefixMode.Required` accepts configured prefixes only.
+`CommandPrefixMode.Optional` tries a configured prefix and then prefix-less
+command text. `CommandPrefixMode.NoPrefix` accepts prefix-less text only.
+
+An exact prefix-less command must consume the whole message. Thus
+`[Command("help", PrefixMode = CommandPrefixMode.Optional)]` matches `help`,
+but not `help please`. A prefixed exact command may have arguments, so
+`/help please` still reaches the `help` handler. `AllowSpaceAfterPrefix`
+controls whitespace after a configured prefix.
+
+### Overlapping Prefixes
+
+The longest matching prefix wins, regardless of declaration order:
+
+```csharp
+[Command("confirm", Prefixes = new[] { "!", "!!" })]
+public Task Confirm(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Confirmed.", ct);
+}
+```
+
+`!!confirm` uses `!!`, even when `!` is declared first. Prefixes are normalized
+once while route metadata is built, not for every update.
+
+## Slash Command Mentions
+
+Telegram group commands can include a bot mention, for example
+`/start@my_bot`. TeleFlow accepts it only when `my_bot` is the current bot.
+`/start@another_bot` is never treated as `/start`.
+
+Configure `BotUsername` when the username is known locally:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.BotUsername = "my_bot";
+});
+```
+
+For standard `AddLongPolling()` and `AddWebhook()` applications, TeleFlow calls
+`getMe` once before the transport starts when `BotUsername` is absent. The
+username is cached for the process lifetime. Failure prevents the hosted
+transport from becoming ready. Route selection never performs Telegram I/O.
+
+For a custom/direct update pipeline without a TeleFlow transport, configure
+`BotUsername` when mention-qualified commands must work. A bare `/start` never
+needs bot identity.
+
+## Templates, Regexes, And Text
+
+`[TextTemplate]` and `[CommandTemplate]` are anchored by TeleFlow: the entire
+relevant text or command body must fit the template. Invalid optional or typed
+values simply make the route not match, allowing the next candidate.
+
+`[TextRegex]` and `[CommandRegex]` preserve the application's expression. Add
+`^` and `$` when it must cover the whole input.
+
+Exact command/text comparisons and template matching use the route's
+`IgnoreCase` setting with ordinal, culture-independent semantics. TeleFlow does
+not globally normalize incoming text or alter the text exposed through contexts.
+Unicode normalization remains a separate, evidence-driven decision.
+
+## Registration Parity
+
+Generated registration through `AddTelegramHandlersFromAssembly(...)` and
+explicit `AddTelegramHandler<T>()` use the same runtime route table and
+selector. Generated registration is the recommended application default;
+explicit registration remains useful for focused modules and tests.

--- a/docs/ru/fundamentals/handlers-and-routing.md
+++ b/docs/ru/fundamentals/handlers-and-routing.md
@@ -29,6 +29,12 @@ public Task Start(MessageContext ctx, CancellationToken ct)
 }
 ```
 
+Для slash command в group `/start@my_bot` матчится только на указанного бота.
+Если `BotUsername` не настроен, TeleFlow один раз разрешает identity до запуска
+обычного long-polling или webhook transport. Полные правила mention,
+пересекающихся prefixes и приоритетов описаны в
+[контракте роутинга](../reference/routing-contract.md).
+
 Если один route должен принимать и Telegram command, и текст без prefix,
 используй `CommandPrefixMode.Optional`:
 

--- a/docs/ru/reference/routing-contract.md
+++ b/docs/ru/reference/routing-contract.md
@@ -1,0 +1,101 @@
+# Контракт роутинга
+
+Эта страница фиксирует наблюдаемые правила роутинга TeleFlow. Она дополняет
+[руководство по handlers](../fundamentals/handlers-and-routing.md).
+
+## Порядок выбора
+
+Для message update TeleFlow сначала пробует command routes, затем message routes.
+Если command не сматчилась, update всё ещё может попасть в `[Message]`, `[Text]`,
+template или regex handler.
+
+Внутри семейства routes выбор детерминирован:
+
+| Правило | Кто выбирается раньше |
+| --- | --- |
+| State | Handler текущего state раньше stateless handler |
+| Тип command route | Exact command, затем command template, затем command regex |
+| Тип message route | Exact text, затем text template, text regex и bare message handler |
+| Специфичность route | Более специфичный route того же типа |
+| Последний tie-breaker | Порядок регистрации |
+
+Filters запускаются после совпадения формы route. Если filter отклонил candidate,
+TeleFlow продолжает поиск следующего candidate; это не error. Typed callback routes
+идут раньше raw `[Callback]` fallback. Для chat-member route до filters должны
+совпасть и тип update, и объявленный transition.
+
+## Command prefixes
+
+`CommandPrefixMode.Required` принимает только настроенные prefixes.
+`CommandPrefixMode.Optional` сначала пытается найти настроенный prefix, затем
+command text без prefix. `CommandPrefixMode.NoPrefix` принимает только text без
+prefix.
+
+Exact prefix-less command должна занять всё сообщение. Поэтому
+`[Command("help", PrefixMode = CommandPrefixMode.Optional)]` сматчит `help`,
+но не `help please`. У prefixed exact command могут быть аргументы, поэтому
+`/help please` всё ещё попадёт в handler `help`. `AllowSpaceAfterPrefix`
+определяет, допустим ли пробел после настроенного prefix.
+
+### Пересекающиеся prefixes
+
+Если prefixes пересекаются, выигрывает самый длинный совпавший prefix,
+независимо от порядка объявления:
+
+```csharp
+[Command("confirm", Prefixes = new[] { "!", "!!" })]
+public Task Confirm(MessageContext ctx, CancellationToken ct)
+{
+    return ctx.Message.AnswerAsync("Confirmed.", ct);
+}
+```
+
+`!!confirm` использует `!!`, даже если `!` указан первым. Prefixes
+нормализуются один раз при построении route metadata, а не на каждом update.
+
+## Slash command mentions
+
+Команда в Telegram group может содержать mention бота, например
+`/start@my_bot`. TeleFlow принимает её, только если `my_bot` - это текущий
+бот. `/start@another_bot` никогда не считается `/start`.
+
+Укажи `BotUsername`, если username известен на этапе конфигурации:
+
+```csharp
+builder.Services.AddTelegramBot(options =>
+{
+    options.Token = token;
+    options.BotUsername = "my_bot";
+});
+```
+
+В обычных приложениях с `AddLongPolling()` и `AddWebhook()` TeleFlow один раз
+вызывает `getMe` до запуска transport, если `BotUsername` не указан. Username
+кэшируется на время жизни процесса. Если identity не удалось разрешить, hosted
+transport не считается готовым. Роутинг никогда не делает Telegram I/O во время
+обработки update.
+
+В custom/direct update pipeline без TeleFlow transport укажи `BotUsername`,
+если нужны commands с mention. Обычная `/start` bot identity не требует.
+
+## Templates, regexes и text
+
+`[TextTemplate]` и `[CommandTemplate]` TeleFlow автоматически anchor-ит:
+весь relevant text или command body должен соответствовать template. Некорректное
+optional или typed value просто означает, что route не совпала и можно попробовать
+следующий candidate.
+
+`[TextRegex]` и `[CommandRegex]` сохраняют regex приложения. Добавь `^` и
+`$`, если route должна покрыть весь input.
+
+Exact command/text comparisons и template matching используют `IgnoreCase`
+route с ordinal, culture-independent семантикой. TeleFlow не нормализует
+глобально incoming text и не меняет text, доступный в contexts. Unicode
+normalization остаётся отдельным решением, основанным на воспроизводимом кейсе.
+
+## Паритет регистрации
+
+Generated registration через `AddTelegramHandlersFromAssembly(...)` и явный
+`AddTelegramHandler<T>()` используют одну runtime route table и один selector.
+Generated path - рекомендуемый default приложения; явная регистрация остаётся
+полезной для узких modules и tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Reference:
           - Attributes: en/reference/attributes.md
           - Options and extension points: en/reference/options-and-extension-points.md
+          - Routing contract: en/reference/routing-contract.md
           - Troubleshooting: en/reference/troubleshooting.md
       - Roadmap: en/roadmap.md
       - Benchmark: en/benchmark-1.0.0-alpha.2.md
@@ -153,6 +154,7 @@ nav:
       - Reference:
           - Attributes: ru/reference/attributes.md
           - Options and extension points: ru/reference/options-and-extension-points.md
+          - Контракт роутинга: ru/reference/routing-contract.md
           - Troubleshooting: ru/reference/troubleshooting.md
       - Roadmap: ru/roadmap.md
       - Benchmark: ru/benchmark-1.0.0-alpha.2.md

--- a/src/TeleFlow.Framework.LongPolling/Internal/TelegramLongPollingUpdateSource.cs
+++ b/src/TeleFlow.Framework.LongPolling/Internal/TelegramLongPollingUpdateSource.cs
@@ -12,6 +12,8 @@ namespace TeleFlow.Telegram.Internal;
 internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
 {
     private readonly ITelegramLongPollingClient _pollingClient;
+    private readonly ITelegramClient _bot;
+    private readonly TelegramBotIdentity _botIdentity;
     private readonly TelegramLongPollingOptions _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<TelegramLongPollingUpdateSource> _logger;
@@ -19,18 +21,24 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
 
     public TelegramLongPollingUpdateSource(
         ITelegramLongPollingClient pollingClient,
+        ITelegramClient bot,
+        TelegramBotIdentity botIdentity,
         TelegramLongPollingOptions options,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory,
         IEnumerable<TelegramHandlerDescriptor> handlerDescriptors)
     {
         ArgumentNullException.ThrowIfNull(pollingClient);
+        ArgumentNullException.ThrowIfNull(bot);
+        ArgumentNullException.ThrowIfNull(botIdentity);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(handlerDescriptors);
 
         _pollingClient = pollingClient;
+        _bot = bot;
+        _botIdentity = botIdentity;
         _options = options;
         _timeProvider = timeProvider;
         _logger = loggerFactory.CreateLogger<TelegramLongPollingUpdateSource>();
@@ -42,6 +50,8 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(updateHandler);
+
+        await _botIdentity.EnsureResolvedAsync(_bot, cancellationToken).ConfigureAwait(false);
 
         var allowedUpdates = TelegramAllowedUpdatesResolver.Resolve(_options.AllowedUpdates, _handlerDescriptors, _logger);
         var rawOptions = CreateRawOptions(allowedUpdates);

--- a/src/TeleFlow.Framework.Webhooks/Internal/TelegramBotIdentityStartupService.cs
+++ b/src/TeleFlow.Framework.Webhooks/Internal/TelegramBotIdentityStartupService.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Hosting;
+using TeleFlow.Telegram.Internal;
+
+namespace TeleFlow.Telegram.Webhooks.Internal;
+
+/// <summary>
+/// Resolves the current bot identity before the ASP.NET Core host starts accepting Telegram webhook updates,
+/// allowing command routing to reject mentions addressed to another bot without network access per update.
+/// </summary>
+internal sealed class TelegramBotIdentityStartupService(
+    ITelegramClient bot,
+    TelegramBotIdentity botIdentity) : IHostedLifecycleService
+{
+    public Task StartingAsync(CancellationToken cancellationToken)
+    {
+        return botIdentity.EnsureResolvedAsync(bot, cancellationToken);
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StartedAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StoppingAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StoppedAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/TeleFlow.Framework.Webhooks/TelegramWebhookServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework.Webhooks/TelegramWebhookServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using TeleFlow.Framework.Updates;
+using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Webhooks.Internal;
 
 namespace TeleFlow.Telegram.Webhooks;
@@ -23,6 +25,7 @@ public static class TelegramWebhookServiceCollectionExtensions
         services.AddSingleton(options);
         services.TryAddSingleton<IUpdateProcessor, DefaultUpdateProcessor>();
         services.AddSingleton<IUpdateSource, TelegramWebhookUpdateSource>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, TelegramBotIdentityStartupService>());
 
         return services;
     }

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramCommandPolicy.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramCommandPolicy.cs
@@ -24,7 +24,12 @@ internal sealed class TelegramCommandPolicy
             throw new InvalidOperationException("Telegram command route prefixes must contain at least one non-empty prefix.");
         }
 
-        Prefixes = prefixes.Select(static prefix => prefix.Trim()).Distinct(StringComparer.Ordinal).ToArray();
+        Prefixes = prefixes
+            .Select(static prefix => prefix.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(static prefix => prefix.Length)
+            .ThenBy(static prefix => prefix, StringComparer.Ordinal)
+            .ToArray();
         AllowSpaceAfterPrefix = allowSpaceAfterPrefix;
         IgnoreCase = ignoreCase;
         PrefixMode = prefixMode;

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -24,18 +24,20 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         IEnumerable<TelegramHandlerDescriptor> descriptors,
         IEnumerable<TelegramErrorHandlerDescriptor> errorHandlers,
         IEnumerable<TelegramAutoAnswerCallbackOptions> autoAnswerCallbackOptions,
+        TelegramBotIdentity botIdentity,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(descriptors);
         ArgumentNullException.ThrowIfNull(errorHandlers);
         ArgumentNullException.ThrowIfNull(autoAnswerCallbackOptions);
+        ArgumentNullException.ThrowIfNull(botIdentity);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         var table = new TelegramHandlerTable(descriptors);
 
-        _selector = new TelegramHandlerSelector(table, loggerFactory);
+        _selector = new TelegramHandlerSelector(table, botIdentity, loggerFactory);
         _errorHandlerIndex = new TelegramErrorHandlerIndex(errorHandlers);
         _timeProvider = timeProvider;
         _globalAutoAnswerCallback = CreateGlobalAutoAnswerDescriptor(autoAnswerCallbackOptions.LastOrDefault());

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerSelector.cs
@@ -24,16 +24,20 @@ internal sealed partial class TelegramHandlerSelector
     private static readonly ConcurrentDictionary<Type, CallbackPayloadDeserializer> CallbackPayloadDeserializers = new();
 
     private readonly TelegramHandlerTable _table;
+    private readonly TelegramBotIdentity _botIdentity;
     private readonly ILogger<TelegramHandlerSelector> _logger;
 
     public TelegramHandlerSelector(
         TelegramHandlerTable table,
+        TelegramBotIdentity botIdentity,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(botIdentity);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _table = table;
+        _botIdentity = botIdentity;
         _logger = loggerFactory.CreateLogger<TelegramHandlerSelector>();
     }
 
@@ -318,7 +322,7 @@ internal sealed partial class TelegramHandlerSelector
             TelegramUpdateLogFormatter.FormatRoute(route));
     }
 
-    private static bool TryMatchRoute(
+    private bool TryMatchRoute(
         Message message,
         TelegramRouteDescriptor route,
         out IReadOnlyDictionary<string, object?> routeValues)
@@ -401,7 +405,7 @@ internal sealed partial class TelegramHandlerSelector
         return serializer.Deserialize<TPayload>(data);
     }
 
-    private static bool TryGetCommandBody(
+    private bool TryGetCommandBody(
         string? text,
         TelegramRouteDescriptor route,
         out string commandBody,
@@ -438,7 +442,7 @@ internal sealed partial class TelegramHandlerSelector
         }
     }
 
-    private static bool TryGetPrefixedCommandBody(
+    private bool TryGetPrefixedCommandBody(
         string text,
         TelegramRouteDescriptor route,
         out string commandBody)
@@ -461,7 +465,10 @@ internal sealed partial class TelegramHandlerSelector
 
             if (prefix == "/")
             {
-                commandBody = TrimSlashCommandBotMention(commandBody);
+                if (!TryTrimSlashCommandBotMention(commandBody, out commandBody))
+                {
+                    return false;
+                }
             }
 
             return !string.IsNullOrWhiteSpace(commandBody);
@@ -479,7 +486,9 @@ internal sealed partial class TelegramHandlerSelector
         return !string.IsNullOrWhiteSpace(commandBody);
     }
 
-    private static string TrimSlashCommandBotMention(string commandBody)
+    private bool TryTrimSlashCommandBotMention(
+        string commandBody,
+        out string trimmedCommandBody)
     {
         var tokenEnd = commandBody.IndexOfAny([' ', '\t', '\r', '\n']);
         var token = tokenEnd < 0 ? commandBody : commandBody[..tokenEnd];
@@ -487,14 +496,22 @@ internal sealed partial class TelegramHandlerSelector
 
         if (mentionIndex < 0)
         {
-            return commandBody;
+            trimmedCommandBody = commandBody;
+            return true;
+        }
+
+        if (!_botIdentity.MatchesMention(token.AsSpan()[(mentionIndex + 1)..]))
+        {
+            trimmedCommandBody = string.Empty;
+            return false;
         }
 
         var trimmedToken = token[..mentionIndex];
 
-        return tokenEnd < 0
+        trimmedCommandBody = tokenEnd < 0
             ? trimmedToken
             : trimmedToken + commandBody[tokenEnd..];
+        return true;
     }
 
     private static bool TryMatchExactCommand(

--- a/src/TeleFlow.Framework/Internal/TelegramBotIdentity.cs
+++ b/src/TeleFlow.Framework/Internal/TelegramBotIdentity.cs
@@ -1,0 +1,81 @@
+using TeleFlow.Telegram.Internal;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Holds the normalized identity of the current Telegram bot for framework features that must distinguish
+/// commands addressed to this bot from commands addressed to another bot. Identity is configured locally or
+/// resolved once during transport startup; handler selection only reads the cached value.
+/// </summary>
+internal sealed class TelegramBotIdentity
+{
+    private readonly object _sync = new();
+    private string? _username;
+    private Task? _resolutionTask;
+
+    public TelegramBotIdentity(TelegramBotOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!TelegramBotUsernameNormalizer.TryNormalize(options.BotUsername, out _username, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+    }
+
+    public bool MatchesMention(ReadOnlySpan<char> mention)
+    {
+        var username = Volatile.Read(ref _username);
+
+        return username is not null &&
+               username.AsSpan().Equals(mention, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public Task EnsureResolvedAsync(
+        ITelegramClient bot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bot);
+
+        if (Volatile.Read(ref _username) is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (_sync)
+        {
+            if (_username is not null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return _resolutionTask ??= ResolveAsync(bot, cancellationToken);
+        }
+    }
+
+    private async Task ResolveAsync(ITelegramClient bot, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var user = await bot.GetMeAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!TelegramBotUsernameNormalizer.TryNormalize(user.Username, out var username, out var error) ||
+                username is null)
+            {
+                throw new InvalidOperationException(
+                    $"Telegram bot identity could not be resolved because getMe returned an invalid username. {error}");
+            }
+
+            Volatile.Write(ref _username, username);
+        }
+        catch
+        {
+            lock (_sync)
+            {
+                _resolutionTask = null;
+            }
+
+            throw;
+        }
+    }
+}

--- a/src/TeleFlow.Framework/Properties/AssemblyInfo.cs
+++ b/src/TeleFlow.Framework/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TeleFlow.Framework.LongPolling")]
+[assembly: InternalsVisibleTo("TeleFlow.Framework.Webhooks")]
 [assembly: InternalsVisibleTo("TeleFlow.ArchitectureTests")]

--- a/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Framework/TelegramServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class TelegramServiceCollectionExtensions
 
         services.AddSingleton(options);
         services.AddSingleton(stateKeyOptions);
+        services.AddSingleton<TelegramBotIdentity>();
         services.AddUpdateContextAccessor();
         services.TryAddSingleton(options.RoleFilter);
         services.AddSingleton<TelegramContextFactory>();

--- a/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageEightGeneratedRegistrationTests.cs
@@ -18,7 +18,6 @@ public sealed class StageEightGeneratedRegistrationTests
     [Theory]
     [InlineData("/start")]
     [InlineData("/start arg")]
-    [InlineData("/start@botname")]
     public async Task GeneratedRegistrar_DispatchesCommandHandlers(string text)
     {
         using var serviceProvider = CreateServiceProvider();
@@ -27,6 +26,43 @@ public sealed class StageEightGeneratedRegistrationTests
         await DispatchAsync(serviceProvider, CreateMessageUpdate(text));
 
         Assert.Equal([$"command:{text}"], probe.Events);
+    }
+
+    [Fact]
+    public async Task GeneratedRegistrar_SlashCommandMention_MatchesConfiguredCurrentBotOnly()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            configureBot: options => options.BotUsername = "teleflow_test_bot");
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@teleflow_test_bot"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@other_bot"));
+
+        Assert.Equal(
+            ["command:/start@teleflow_test_bot", "fallback:/start@other_bot"],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task GeneratedRegistrar_SlashCommandMention_DoesNotMatchWhenBotIdentityIsUnknown()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@teleflow_test_bot"));
+
+        Assert.Equal(["fallback:/start@teleflow_test_bot"], probe.Events);
+    }
+
+    [Fact]
+    public async Task GeneratedRegistrar_OverlappingPrefixes_UsesLongestPrefix()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var probe = serviceProvider.GetRequiredService<GeneratedHandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("!!generated-overlap"));
+
+        Assert.Equal(["generated-overlapping-prefix"], probe.Events);
     }
 
     [Fact]
@@ -421,10 +457,16 @@ public sealed class StageEightGeneratedRegistrationTests
             probe.Events);
     }
 
-    private static ServiceProvider CreateServiceProvider(Action<IServiceCollection>? configureServices = null)
+    private static ServiceProvider CreateServiceProvider(
+        Action<IServiceCollection>? configureServices = null,
+        Action<TelegramBotOptions>? configureBot = null)
     {
         var services = new ServiceCollection();
-        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            configureBot?.Invoke(options);
+        });
         services.AddSingleton<GeneratedHandlerProbe>();
         services.AddSingleton<GeneratedAllowMessageFilter>();
         services.AddSingleton<GeneratedRequireTextFilter>();
@@ -697,6 +739,31 @@ internal sealed class StageEightGeneratedHandlersRegistrar : ITelegramGeneratedH
             ],
             InvokeShortOptionalPrefixCommandTemplate,
             prefixMode: CommandPrefixMode.Optional));
+
+        registry.RegisterHandler(new TelegramGeneratedHandlerDescriptor(
+            typeof(GeneratedOverlappingPrefixCommandHandler),
+            nameof(GeneratedOverlappingPrefixCommandHandler.Handle),
+            TelegramGeneratedHandlerKind.Command,
+            TelegramGeneratedRouteKind.CommandExact,
+            routePattern: "generated-overlap",
+            commandPrefixes: ["!", "!!"],
+            allowSpaceAfterPrefix: false,
+            ignoreCase: true,
+            registrationOrder: 52,
+            moduleName: null,
+            command: "generated-overlap",
+            callbackPayloadType: null,
+            textFilters: [],
+            filters: [],
+            chatMemberTransitions: [],
+            roleRequirements: [],
+            states: [],
+            parameters:
+            [
+                new(typeof(MessageContext), TelegramGeneratedHandlerParameterKind.Context, "context"),
+                new(typeof(GeneratedHandlerProbe), TelegramGeneratedHandlerParameterKind.Service, "probe")
+            ],
+            InvokeGeneratedOverlappingPrefixCommand));
 
         registry.RegisterHandler(new TelegramGeneratedHandlerDescriptor(
             typeof(GeneratedFallbackMessageHandler),
@@ -1305,6 +1372,16 @@ internal sealed class StageEightGeneratedHandlersRegistrar : ITelegramGeneratedH
         await handler.Handle((MessageContext)arguments[0]!, (GeneratedHandlerProbe)arguments[1]!);
     }
 
+    private static async ValueTask InvokeGeneratedOverlappingPrefixCommand(
+        IServiceProvider services,
+        object?[] arguments,
+        CancellationToken cancellationToken)
+    {
+        var handler = (GeneratedOverlappingPrefixCommandHandler)services.GetRequiredService(
+            typeof(GeneratedOverlappingPrefixCommandHandler));
+        await handler.Handle((MessageContext)arguments[0]!, (GeneratedHandlerProbe)arguments[1]!);
+    }
+
     private static async ValueTask InvokeFallbackMessage(
         IServiceProvider services,
         object?[] arguments,
@@ -1691,6 +1768,15 @@ public sealed class GeneratedShortOptionalPrefixCommandTemplateHandler
     public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
     {
         probe.Events.Add($"generated-short-template:{context.TelegramMessage.Text}");
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class GeneratedOverlappingPrefixCommandHandler
+{
+    public Task Handle(MessageContext context, GeneratedHandlerProbe probe)
+    {
+        probe.Events.Add("generated-overlapping-prefix");
         return Task.CompletedTask;
     }
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramFrameworkWebhookTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramFrameworkWebhookTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using TeleFlow.Annotations;
 using TeleFlow.Framework.Dispatching;
 using TeleFlow.Framework.Updates;
@@ -84,6 +85,23 @@ public sealed class TelegramFrameworkWebhookTests
         using var provider = services.BuildServiceProvider();
 
         Assert.Single(provider.GetServices<IUpdateSource>());
+    }
+
+    [Fact]
+    public void AddWebhook_RegistersBotIdentityStartupService()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            options.BotUsername = "teleflow_test_bot";
+        });
+        services.AddWebhook();
+
+        using var provider = services.BuildServiceProvider();
+        var service = Assert.Single(provider.GetServices<IHostedService>());
+
+        Assert.IsAssignableFrom<IHostedLifecycleService>(service);
     }
 
     [Fact]

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -22,7 +22,6 @@ public sealed class TelegramHandlerDispatcherTests
     [Theory]
     [InlineData("/start")]
     [InlineData("/start arg")]
-    [InlineData("/start@botname")]
     public async Task CommandHandler_DispatchesForSupportedCommandShapes(string text)
     {
         using var cancellation = new CancellationTokenSource();
@@ -676,6 +675,60 @@ public sealed class TelegramHandlerDispatcherTests
         await DispatchAsync(serviceProvider, CreateMessageUpdate("!start@botname"));
 
         Assert.Empty(probe.Events);
+    }
+
+    [Fact]
+    public async Task SlashCommandMention_MatchesConfiguredCurrentBotOnly()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<BotMentionCommandHandler>(),
+            options => options.BotUsername = "@teleflow_test_bot");
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@teleflow_test_bot"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@TELEFLOW_TEST_BOT"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@other_bot"));
+
+        Assert.Equal(
+            [
+                "bot-mention:/start",
+                "bot-mention:/start@teleflow_test_bot",
+                "bot-mention:/start@TELEFLOW_TEST_BOT"
+            ],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task SlashCommandMention_DoesNotMatchWhenBotIdentityIsUnknown()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services => services.AddTelegramHandler<BotMentionCommandHandler>());
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@teleflow_test_bot"));
+
+        Assert.Empty(probe.Events);
+    }
+
+    [Fact]
+    public async Task CommandAttribute_OverlappingPrefixes_UsesLongestPrefixRegardlessOfDeclarationOrder()
+    {
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.AddTelegramHandler<ShortPrefixFirstCommandHandler>();
+                services.AddTelegramHandler<LongPrefixFirstCommandHandler>();
+            });
+
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("!!short-first"));
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("!!long-first"));
+
+        Assert.Equal(["short-prefix-first", "long-prefix-first"], probe.Events);
     }
 
     [Fact]
@@ -3132,17 +3185,24 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.Equal(["state-value-scene:Ada"], probe.Events);
     }
 
-    private static ServiceCollection CreateBaseServices()
+    private static ServiceCollection CreateBaseServices(
+        Action<TelegramBotOptions>? configureBot = null)
     {
         var services = new ServiceCollection();
-        services.AddTelegramBot(options => options.Token = "test-token");
+        services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            configureBot?.Invoke(options);
+        });
         services.AddSingleton<HandlerProbe>();
         return services;
     }
 
-    private static ServiceProvider CreateServiceProvider(Action<IServiceCollection> configureServices)
+    private static ServiceProvider CreateServiceProvider(
+        Action<IServiceCollection> configureServices,
+        Action<TelegramBotOptions>? configureBot = null)
     {
-        var services = CreateBaseServices();
+        var services = CreateBaseServices(configureBot);
         configureServices(services);
         return services.BuildServiceProvider(new ServiceProviderOptions
         {
@@ -3716,6 +3776,36 @@ public sealed class TelegramHandlerDispatcherTests
         public Task Handle(MessageContext context, HandlerProbe probe)
         {
             probe.Events.Add($"custom-prefix:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class BotMentionCommandHandler
+    {
+        [Command("start")]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add($"bot-mention:{context.TelegramMessage.Text}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ShortPrefixFirstCommandHandler
+    {
+        [Command("short-first", Prefixes = new[] { "!", "!!" })]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add("short-prefix-first");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class LongPrefixFirstCommandHandler
+    {
+        [Command("long-first", Prefixes = new[] { "!!", "!" })]
+        public Task Handle(MessageContext context, HandlerProbe probe)
+        {
+            probe.Events.Add("long-prefix-first");
             return Task.CompletedTask;
         }
     }

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerGeneratorTests.cs
@@ -384,6 +384,71 @@ public sealed class TelegramHandlerGeneratorTests
     }
 
     [Fact]
+    public async Task Generator_RuntimeCommandRouting_MatchesDirectMentionAndPrefixContracts()
+    {
+        var runId = Guid.NewGuid().ToString("N");
+        GeneratedErrorRuntimeProbe.Clear(runId);
+        var compilation = CreateCompilation(
+            $$"""
+            using System.Threading.Tasks;
+            using TeleFlow.Annotations;
+            using TeleFlow.Telegram;
+
+            namespace GeneratedRouteContracts;
+
+            public sealed class RouteHandlers
+            {
+                [Command("start")]
+                public Task Start(MessageContext context)
+                {
+                    global::TeleFlow.ArchitectureTests.GeneratedErrorRuntimeProbe.Record(
+                        "{{runId}}",
+                        $"start:{context.TelegramMessage.Text}");
+                    return Task.CompletedTask;
+                }
+
+                [Command("overlap", Prefixes = new[] { "!", "!!" })]
+                public Task Overlap(MessageContext context)
+                {
+                    global::TeleFlow.ArchitectureTests.GeneratedErrorRuntimeProbe.Record(
+                        "{{runId}}",
+                        $"overlap:{context.TelegramMessage.Text}");
+                    return Task.CompletedTask;
+                }
+            }
+            """);
+        var generatedCompilation = RunGenerator(compilation, out var diagnostics);
+        var errors = generatedCompilation.GetDiagnostics()
+            .Concat(diagnostics)
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        Assert.Empty(errors);
+
+        var assembly = EmitAndLoad(generatedCompilation);
+        var services = new ServiceCollection();
+        services.AddTelegramBot(options =>
+        {
+            options.Token = "test-token";
+            options.BotUsername = "teleflow_test_bot";
+        });
+        services.AddTelegramHandlersFromAssembly(assembly);
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@teleflow_test_bot"), CancellationToken.None);
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start@other_bot"), CancellationToken.None);
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("!!overlap"), CancellationToken.None);
+
+        Assert.Equal(
+            ["start:/start@teleflow_test_bot", "overlap:!!overlap"],
+            GeneratedErrorRuntimeProbe.GetEvents(runId));
+    }
+
+    [Fact]
     public void Generator_EmitsTemplateRegexRoutesAndSharedInvoker()
     {
         var compilation = CreateCompilation(

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -1794,6 +1794,62 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task LongPolling_ResolvesBotIdentityBeforePollingWhenUsernameIsNotConfigured()
+    {
+        var telegramClient = new SequencedTelegramClient(
+            new User
+            {
+                Id = 42,
+                IsBot = true,
+                FirstName = "TeleFlow Bot",
+                Username = "teleflow_test_bot"
+            },
+            new List<Update> { CreateMessageUpdate(1) });
+        var dispatcher = new RecordingDispatcher(cancelAfter: 1);
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateTelegramApplication(
+            services =>
+            {
+                services.AddSingleton<ITelegramClient>(telegramClient);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+            },
+            services => services.AddLongPolling(),
+            cancellation,
+            configureDefaultBotUsername: false);
+
+        await application.RunAsync(cancellation.Token);
+
+        Assert.Collection(
+            telegramClient.Methods,
+            method => Assert.IsType<GetMe>(method),
+            method => Assert.IsType<GetUpdates>(method));
+    }
+
+    [Fact]
+    public async Task LongPolling_UsesConfiguredBotIdentityWithoutGetMe()
+    {
+        var telegramClient = new SequencedTelegramClient(
+            new List<Update> { CreateMessageUpdate(1) });
+        var dispatcher = new RecordingDispatcher(cancelAfter: 1);
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateTelegramApplication(
+            services =>
+            {
+                services.AddSingleton<ITelegramClient>(telegramClient);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+            },
+            services => services.AddLongPolling(),
+            cancellation,
+            options => options.BotUsername = "teleflow_test_bot");
+
+        await application.RunAsync(cancellation.Token);
+
+        Assert.Collection(telegramClient.Methods, method => Assert.IsType<GetUpdates>(method));
+    }
+
+    [Fact]
     public async Task LongPolling_AdvancesOffsetAfterHandledTelegramError()
     {
         var handler = new RecordingHttpMessageHandler(
@@ -4012,12 +4068,19 @@ public sealed class TelegramRuntimeIntegrationTests
         Action<IServiceCollection> configureServices,
         Action<IServiceCollection> configureTelegram,
         CancellationTokenSource? cancellation = null,
-        Action<TelegramBotOptions>? configureBot = null)
+        Action<TelegramBotOptions>? configureBot = null,
+        bool configureDefaultBotUsername = true)
     {
         var builder = TeleFlowApplication.CreateBuilder();
         builder.Services.AddTelegramBot(options =>
         {
             options.Token = "test-token";
+
+            if (configureDefaultBotUsername)
+            {
+                options.BotUsername = "test_bot";
+            }
+
             configureBot?.Invoke(options);
         });
         configureTelegram(builder.Services);
@@ -4507,12 +4570,16 @@ public sealed class TelegramRuntimeIntegrationTests
         public TelegramDeepLinks DeepLinks { get; } =
             new("test_bot", new Base64UrlJsonDeepLinkPayloadSerializer());
 
+        public List<object> Methods { get; } = [];
+
         public List<GetUpdates> GetUpdatesRequests { get; } = [];
 
         public Task<TResult> SendAsync<TResult>(
             ITelegramApiMethod<TResult> method,
             CancellationToken cancellationToken = default)
         {
+            Methods.Add(method);
+
             if (method is GetUpdates getUpdates)
             {
                 GetUpdatesRequests.Add(getUpdates);


### PR DESCRIPTION
## Summary
- reject slash commands addressed to another bot instead of silently treating them as local commands
- resolve and cache the current bot username once at long-polling or webhook startup when `BotUsername` is not configured
- make overlapping command prefixes deterministic: the longest prefix wins regardless of configuration order
- document the handler-selection contract in English and Russian

## Routing Contract
- Bare `/start` keeps its current behavior.
- `/start@name` matches only when `name` is the current bot username, using ordinal case-insensitive comparison.
- Unknown identity and mismatched mentions do not select a command route; a general message route may still handle the update.
- Direct/custom update pipelines should configure `BotUsername` when they need mention-qualified commands.

## Touched Hot Paths
- `TelegramHandlerSelector` reads cached bot identity only; route selection performs no network I/O.
- `TelegramCommandPolicy` sorts configured prefixes once during construction; per-update matching does not sort or calculate ordering.
- Template and regex matching behavior is intentionally unchanged.

## Validation
- `dotnet test TeleFlow.sln --no-restore` (766 passed)
- `mkdocs build --strict --site-dir site`
- `git diff main...HEAD --check`

Closes #150