### PR TITLE
fix: contain automatic callback failures

### DIFF
--- a/docs/en/features/errors-and-diagnostics.md
+++ b/docs/en/features/errors-and-diagnostics.md
@@ -54,6 +54,14 @@ Error handler selection is deterministic:
 
 If no compatible error handler returns `Handled`, the original exception is rethrown.
 
+## Delivery Outcome
+
+Returning `Handled` is also a delivery decision: the framework update completes
+normally, so long polling advances its offset and a webhook returns `200 OK`.
+An unhandled route or middleware failure remains visible and is not
+acknowledged. See the full [update failure and delivery contract](../reference/update-failure-contract.md)
+before adding a broad error handler.
+
 ## Let Unknown Errors Fail
 
 Do not turn every exception into a user-facing message. For production systems, handle known application errors and let unknown failures remain observable through logs and hosting infrastructure.

--- a/docs/en/reference/update-failure-contract.md
+++ b/docs/en/reference/update-failure-contract.md
@@ -1,0 +1,166 @@
+# Update Failure And Delivery Contract
+
+This page describes what TeleFlow does after an incoming update reaches the
+framework, which failures acknowledge that update, and which failures are
+deliberately returned to the hosting environment.
+
+The short version is simple: TeleFlow acknowledges an update only after its
+processing has reached an explicit successful outcome. It does not guess that
+failed business work is safe to discard.
+
+## Why This Contract Exists
+
+Telegram can deliver an update again when the previous delivery was not
+acknowledged. That is useful: a temporary process failure should not silently
+lose a user action. It also means that retrying an update after a handler has
+already changed a database, charged a balance, or sent a message can repeat a
+side effect.
+
+TeleFlow therefore provides **at-least-once delivery**, not exactly-once
+delivery. Applications that modify durable state must make their own business
+operations idempotent where repeated delivery is possible.
+
+## Framework Pipeline
+
+For a framework update, the pipeline is:
+
+1. The transport receives an update.
+2. `IUpdateProcessor` creates one scoped `UpdateContext` and runs update
+   middleware.
+3. The Telegram dispatcher selects a route and invokes its handler.
+4. For a callback route, TeleFlow runs the configured automatic callback answer
+   after the handler succeeds.
+5. If route execution fails, compatible `[Error]` and `[Error<TException>]`
+   handlers are tried.
+6. The transport acknowledges the update only after the processor completes
+   successfully.
+
+The selected handler and the automatic callback answer are one **route
+execution boundary**. This matters because an automatic callback answer is a
+framework action that happens after the handler, but it must not bypass the
+same recovery decision that applies to the selected route.
+
+## Outcome Matrix
+
+| Outcome | Framework result | Long polling | Webhook |
+| --- | --- | --- | --- |
+| No route matches the update | Normal completion | Offset advances | `200 OK` |
+| A rate limiter intentionally rejects the update | Normal completion | Offset advances | `200 OK` |
+| Handler and automatic callback answer succeed | Normal completion | Offset advances | `200 OK` |
+| An `[Error]` handler returns `Handled` | Normal completion | Offset advances | `200 OK` |
+| An error handler returns `Unhandled` and no later handler handles the error | Failure propagates | Offset does not advance | Endpoint failure propagates |
+| Handler, middleware, or error handler throws | Failure propagates | Offset does not advance | Endpoint failure propagates |
+| Application cancellation | Processing stops | Offset does not advance | Cancellation semantics apply |
+
+For webhooks, TeleFlow does not manufacture a success response after an
+unhandled failure. ASP.NET Core returns the failure response and Telegram's
+delivery mechanism decides whether to redeliver it.
+
+## Error Handlers Are The Explicit Recovery Point
+
+Use an error handler when the application has made a deliberate recovery
+decision. Returning `Handled` means: *this update reached a durable and
+acceptable outcome; the transport may acknowledge it.*
+
+```csharp
+public sealed class KnownErrors
+{
+    [Error<RejectedUserActionException>]
+    public async Task<TelegramErrorHandlingResult> RejectedAction(
+        MessageContext ctx,
+        RejectedUserActionException exception,
+        CancellationToken ct)
+    {
+        await ctx.Message.AnswerAsync(exception.Message, ct);
+        return TelegramErrorHandlingResult.Handled;
+    }
+}
+```
+
+Returning `Unhandled` asks TeleFlow to try the next compatible error handler.
+Throwing from an error handler means recovery failed; that new failure remains
+visible to the transport and host.
+
+Do not register a catch-all `[Error]` handler that returns `Handled` for every
+exception. That turns defects, failed invariants, and broken configuration into
+acknowledged updates with no reliable recovery path.
+
+## Telegram API Errors
+
+An outgoing Telegram request made inside a handler belongs to that handler's
+route execution. Its failure can be handled by a compatible error handler, or
+it can remain unhandled and preserve at-least-once delivery.
+
+Do not classify every `TelegramBadRequestException` as harmless. A `400` may
+mean an expected no-op such as an unchanged message, but it can also mean
+invalid markup, an invalid chat, or an application bug. Prefer one of these
+paths:
+
+- prevent known no-op requests before sending them;
+- translate a known application condition into a domain exception and handle
+  that exception explicitly;
+- let an unknown Telegram request failure remain observable and unacknowledged.
+
+Telegram request retry is also intentionally narrow. The client automatically
+honours bounded `429 retry_after` responses. Raw `getUpdates` has its own
+transient-failure backoff because it is an idempotent read. TeleFlow does not
+blindly retry all outgoing `network` or `5xx` failures: Telegram may have
+already completed a write before the client lost the response.
+
+## Middleware Is A Different Boundary
+
+Update middleware runs before or around dispatch. A middleware can intentionally
+stop an update by not calling `next(context)`; rate-limit rejection uses that
+model and completes normally.
+
+An exception thrown by middleware is not a selected Telegram route failure, so
+it does not enter `[Error]` handlers. This is intentional. Middleware often
+owns authentication, storage transactions, tenancy, or global safeguards; a
+handler-level recovery decision cannot safely claim those failures succeeded.
+
+Catch and resolve a middleware failure inside that middleware only when the
+middleware itself can make a durable, explicit decision.
+
+## Automatic Callback Answers
+
+Automatic callback answers are opt-in. A callback handler does not send
+`answerCallbackQuery` unless it has `[AutoAnswerCallback]` (on the method or
+handler type), or the application explicitly registers
+`AddAutoCallbackAnswer(...)`. When neither is configured, TeleFlow sends no
+automatic callback answer.
+
+`[AutoAnswerCallback]` and `AddAutoCallbackAnswer(...)` run only after the
+selected callback handler completes successfully. If the automatic
+`answerCallbackQuery` call fails, TeleFlow uses the same `[Error]` pipeline as
+for the selected route.
+
+This avoids a separate hidden rule for an automatic framework action:
+
+- an application can return `Handled` when it has explicitly accepted the
+  outcome;
+- otherwise the failure stays unhandled and the update is not acknowledged;
+- no automatic callback-answer failure is silently swallowed.
+
+## Production Guidance
+
+Keep handlers thin and move durable state changes into application services
+with clear idempotency rules. In particular:
+
+- persist a deduplication key before performing irreversible work when the
+  business operation requires it;
+- use database transactions or an outbox when state and external effects must
+  stay coordinated;
+- handle known user-facing rejections explicitly;
+- let unknown failures reach logs, telemetry, and the host;
+- use a process supervisor for long-polling workers, but do not treat restart
+  as a business retry policy.
+
+This is more work than acknowledging every exception, but it is the difference
+between a visible failure and silently losing a user action.
+
+## Related Pages
+
+- [Errors and diagnostics](../features/errors-and-diagnostics.md)
+- [Long polling](../transports/long-polling.md)
+- [Webhooks](../transports/webhooks.md)
+- [Middleware and rate limiting](../advanced/middleware-and-rate-limiting.md)

--- a/docs/en/transports/long-polling.md
+++ b/docs/en/transports/long-polling.md
@@ -45,6 +45,17 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
 
 Long polling retries transient `getUpdates` failures with configurable backoff. If the Telegram client surfaces `TelegramRetryAfterException`, polling waits for the Telegram-provided retry delay instead of using the generic backoff delay. Handler failures are not swallowed. The offset advances only after successful update processing.
 
+The exact acknowledgement outcome for handled route failures, middleware
+failures, cancellation, and automatic callback answers is defined by the
+[update failure and delivery contract](../reference/update-failure-contract.md).
+
+At `Information`, framework long polling writes one event when an update is
+received, one when a Telegram handler is matched or no handler matches, and one
+after the update is acknowledged. This gives production logs a complete update
+path without enabling `Debug`. `Debug` adds candidate-rejection diagnostics and
+route and handler timing. The `Information` path does not start timing scopes
+or calculate elapsed durations.
+
 ## When To Use Long Polling
 
 Use long polling when:

--- a/docs/en/transports/webhooks.md
+++ b/docs/en/transports/webhooks.md
@@ -35,6 +35,10 @@ await app.RunAsync();
 
 `MapTelegramWebhook()` uses the configured `TelegramWebhookOptions.Path` and forwards incoming Telegram updates to the TeleFlow update processor.
 
+The endpoint returns `200 OK` only after the update processor completes
+normally. The full handling and failure contract is documented in
+[update failure and delivery contract](../reference/update-failure-contract.md).
+
 ## When To Use Webhooks
 
 Use webhooks when:

--- a/docs/ru/features/errors-and-diagnostics.md
+++ b/docs/ru/features/errors-and-diagnostics.md
@@ -54,6 +54,14 @@ Error handlers могут получать context, exception, cancellation toke
 
 Если ни один compatible error handler не вернул `Handled`, исходное exception выбрасывается дальше.
 
+## Исход Доставки
+
+Возврат `Handled` - это также решение о доставке: framework update завершается
+нормально, поэтому long polling продвигает offset, а webhook возвращает
+`200 OK`. Unhandled route или middleware failure остаётся видимым и не
+подтверждается. Перед broad error handler прочитай полный
+[контракт ошибок и подтверждения update](../reference/update-failure-contract.md).
+
 ## Не скрывай unknown errors
 
 Не превращай каждое exception в user-facing message. В production systems стоит обрабатывать known application errors, а unknown failures оставлять observable через logs и hosting infrastructure.

--- a/docs/ru/reference/update-failure-contract.md
+++ b/docs/ru/reference/update-failure-contract.md
@@ -1,0 +1,160 @@
+# Контракт Ошибок И Подтверждения Update
+
+Эта страница описывает, что происходит после того, как incoming update попал
+во framework: какие исходы подтверждают update, а какие намеренно возвращаются
+в hosting environment как ошибка.
+
+Коротко: TeleFlow подтверждает update только после явного успешного исхода. Он
+не пытается угадать, что упавшая бизнес-операция безопасна для игнорирования.
+
+## Зачем Нужен Этот Контракт
+
+Telegram может повторно доставить update, если предыдущая доставка не была
+подтверждена. Это полезно: временное падение процесса не должно молча потерять
+действие пользователя. Но если handler уже изменил базу, списал баланс или
+отправил сообщение, повторная доставка может повторить side effect.
+
+Поэтому TeleFlow даёт **at-least-once delivery**, а не exactly-once delivery.
+Приложение, меняющее durable state, само отвечает за idempotency бизнес-операций
+в местах, где возможна повторная доставка.
+
+## Pipeline Framework
+
+Для framework update путь выглядит так:
+
+1. Transport получает update.
+2. `IUpdateProcessor` создаёт scoped `UpdateContext` и запускает update
+   middleware.
+3. Telegram dispatcher выбирает route и вызывает его handler.
+4. Для callback route TeleFlow после успешного handler запускает настроенный
+   automatic callback answer.
+5. Если route execution упал, вызываются compatible `[Error]` и
+   `[Error<TException>]` handlers.
+6. Transport подтверждает update только после успешного завершения processor.
+
+Выбранный handler и automatic callback answer образуют одну границу **route
+execution**. Auto-answer выполняется после handler, но это не повод обходить
+то же recovery-решение, которое действует для выбранного route.
+
+## Матрица Исходов
+
+| Исход | Результат framework | Long polling | Webhook |
+| --- | --- | --- | --- |
+| Для update нет подходящего route | Нормальное завершение | Offset продвигается | `200 OK` |
+| Rate limiter намеренно отклонил update | Нормальное завершение | Offset продвигается | `200 OK` |
+| Handler и automatic callback answer успешно завершились | Нормальное завершение | Offset продвигается | `200 OK` |
+| `[Error]` handler вернул `Handled` | Нормальное завершение | Offset продвигается | `200 OK` |
+| Error handler вернул `Unhandled`, и дальше никто не обработал ошибку | Ошибка идёт выше | Offset не продвигается | Ошибка endpoint идёт выше |
+| Handler, middleware или error handler бросил exception | Ошибка идёт выше | Offset не продвигается | Ошибка endpoint идёт выше |
+| Application cancellation | Обработка останавливается | Offset не продвигается | Работает cancellation semantics |
+
+Для webhook TeleFlow не подделывает успешный response после unhandled failure.
+ASP.NET Core возвращает failure response, а решение о повторной доставке остаётся
+у механизма доставки Telegram.
+
+## Error Handlers Это Явная Точка Recovery
+
+Используй error handler, когда приложение действительно приняло решение о
+recovery. Возврат `Handled` означает: *этот update дошёл до durable и
+приемлемого результата, transport может его подтвердить.*
+
+```csharp
+public sealed class KnownErrors
+{
+    [Error<RejectedUserActionException>]
+    public async Task<TelegramErrorHandlingResult> RejectedAction(
+        MessageContext ctx,
+        RejectedUserActionException exception,
+        CancellationToken ct)
+    {
+        await ctx.Message.AnswerAsync(exception.Message, ct);
+        return TelegramErrorHandlingResult.Handled;
+    }
+}
+```
+
+`Unhandled` просит TeleFlow попробовать следующий compatible error handler.
+Если error handler сам бросил exception, recovery не удался: новая ошибка
+остаётся видимой transport-у и host-у.
+
+Не регистрируй catch-all `[Error]`, который возвращает `Handled` на любой
+exception. Иначе defects, failed invariants и сломанная конфигурация превратятся
+в подтверждённые updates без честного пути восстановления.
+
+## Ошибки Telegram API
+
+Outgoing Telegram request, сделанный внутри handler, является частью route
+execution. Его ошибку можно обработать compatible error handler-ом или оставить
+unhandled, сохранив at-least-once delivery.
+
+Не считай любой `TelegramBadRequestException` безопасным. `400` может означать
+ожидаемый no-op вроде unchanged message, но может говорить о невалидной
+разметке, неверном chat или баге приложения. Предпочитай один из путей:
+
+- предотврати известный no-op до отправки запроса;
+- переведи известное состояние приложения в domain exception и обработай именно
+  его;
+- оставь неизвестную ошибку Telegram request видимой и неподтверждённой.
+
+Retry Telegram requests тоже намеренно узкий. Client автоматически учитывает
+bounded `429 retry_after`. Raw `getUpdates` имеет собственный transient backoff,
+потому что это idempotent read. TeleFlow не retry-ит вслепую все outgoing
+`network` или `5xx` failures: Telegram мог уже выполнить write до того, как
+client потерял response.
+
+## Middleware Это Другая Граница
+
+Update middleware выполняется до dispatch или вокруг него. Middleware может
+намеренно остановить update, не вызвав `next(context)`; так работает rate-limit
+rejection, и это нормальное завершение.
+
+Exception из middleware не является ошибкой выбранного Telegram route, поэтому
+не попадает в `[Error]` handlers. Это намеренно. Middleware часто владеет
+authentication, storage transactions, tenancy или глобальными safeguards;
+handler-level recovery не может честно заявить, что такая ошибка успешно
+завершилась.
+
+Лови и решай ошибку внутри middleware только когда само middleware может принять
+durable и явное решение.
+
+## Automatic Callback Answers
+
+Automatic callback answer включается только явно. Обычный callback handler не
+посылает `answerCallbackQuery`, если на методе или типе нет
+`[AutoAnswerCallback]` и приложение не зарегистрировало
+`AddAutoCallbackAnswer(...)`. Если не задано ни одно из этих двух условий,
+TeleFlow не отправляет автоматический callback answer.
+
+`[AutoAnswerCallback]` и `AddAutoCallbackAnswer(...)` работают только после
+успешного выбранного callback handler. Если автоматический `answerCallbackQuery`
+падает, TeleFlow использует тот же `[Error]` pipeline, что и для выбранного
+route.
+
+Так не появляется отдельное скрытое правило для framework action:
+
+- приложение может вернуть `Handled`, когда явно принимает этот исход;
+- иначе ошибка остаётся unhandled, и update не подтверждается;
+- ошибка automatic callback answer не проглатывается молча.
+
+## Рекомендации Для Production
+
+Держи handlers тонкими, а durable state changes выноси в application services с
+явными idempotency rules. В частности:
+
+- сохраняй deduplication key до необратимой работы, когда это нужно бизнесу;
+- используй database transaction или outbox, когда state и external effects
+  должны оставаться согласованными;
+- явно обрабатывай известные user-facing rejections;
+- оставляй неизвестные failures логам, telemetry и host-у;
+- используй process supervisor для long-polling worker, но не считай restart
+  бизнесовой retry policy.
+
+Это сложнее, чем подтверждать каждый exception, но именно так не теряются
+действия пользователя молча.
+
+## Связанные Страницы
+
+- [Errors and diagnostics](../features/errors-and-diagnostics.md)
+- [Long polling](../transports/long-polling.md)
+- [Webhooks](../transports/webhooks.md)
+- [Middleware and rate limiting](../advanced/middleware-and-rate-limiting.md)

--- a/docs/ru/transports/long-polling.md
+++ b/docs/ru/transports/long-polling.md
@@ -45,6 +45,17 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
 
 Long polling retry-ит transient `getUpdates` failures с настраиваемым backoff. Если Telegram client отдаёт `TelegramRetryAfterException`, polling ждёт Telegram-provided retry delay вместо обычной backoff delay. Handler failures не swallowing. Offset продвигается только после успешной обработки update.
 
+Точный исход acknowledgement для handled route failures, middleware failures,
+cancellation и automatic callback answers определён в
+[контракте ошибок и подтверждения update](../reference/update-failure-contract.md).
+
+На уровне `Information` framework long polling пишет одно событие при получении
+update, одно при совпадении Telegram handler или отсутствии совпадения, и одно
+после подтверждения update. Поэтому production logs содержат полный путь update
+без включения `Debug`. На `Debug` остаются диагностика отклонённых candidates и
+тайминги route и Telegram requests внутри handler. Путь `Information` не
+создаёт timing scopes и не вычисляет elapsed durations.
+
 ## Когда использовать long polling
 
 Long polling подходит, когда:

--- a/docs/ru/transports/webhooks.md
+++ b/docs/ru/transports/webhooks.md
@@ -35,6 +35,10 @@ await app.RunAsync();
 
 `MapTelegramWebhook()` использует configured `TelegramWebhookOptions.Path` и передаёт incoming Telegram updates в TeleFlow update processor.
 
+Endpoint возвращает `200 OK` только после нормального завершения update
+processor. Полный handling и failure contract описан в
+[контракте ошибок и подтверждения update](../reference/update-failure-contract.md).
+
 ## Когда использовать webhooks
 
 Webhooks подходят, когда:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
           - Attributes: en/reference/attributes.md
           - Options and extension points: en/reference/options-and-extension-points.md
           - Routing contract: en/reference/routing-contract.md
+          - Update failure contract: en/reference/update-failure-contract.md
           - Troubleshooting: en/reference/troubleshooting.md
       - Roadmap: en/roadmap.md
       - Benchmark: en/benchmark-1.0.0-alpha.2.md
@@ -155,6 +156,7 @@ nav:
           - Attributes: ru/reference/attributes.md
           - Options and extension points: ru/reference/options-and-extension-points.md
           - Контракт роутинга: ru/reference/routing-contract.md
+          - Контракт ошибок и подтверждения update: ru/reference/update-failure-contract.md
           - Troubleshooting: ru/reference/troubleshooting.md
       - Roadmap: ru/roadmap.md
       - Benchmark: ru/benchmark-1.0.0-alpha.2.md

--- a/src/TeleFlow.Framework.Core/Middleware/UpdateExceptionMiddleware.cs
+++ b/src/TeleFlow.Framework.Core/Middleware/UpdateExceptionMiddleware.cs
@@ -31,7 +31,7 @@ public sealed class UpdateExceptionMiddleware : IUpdateMiddleware
         {
             await next(context).ConfigureAwait(false);
         }
-        catch (Exception exception)
+        catch (Exception exception) when (!IsUpdateCancellation(exception, context.CancellationToken))
         {
             if (_logger is not null)
             {
@@ -40,5 +40,10 @@ public sealed class UpdateExceptionMiddleware : IUpdateMiddleware
 
             throw;
         }
+    }
+
+    private static bool IsUpdateCancellation(Exception exception, CancellationToken cancellationToken)
+    {
+        return exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
     }
 }

--- a/src/TeleFlow.Framework.LongPolling/Internal/TelegramLongPollingUpdateSource.cs
+++ b/src/TeleFlow.Framework.LongPolling/Internal/TelegramLongPollingUpdateSource.cs
@@ -74,38 +74,71 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
                 }
 
                 var update = item.Update;
-                var updateType = TelegramUpdateLogFormatter.GetUpdateType(update);
-                var processingStarted = _timeProvider.GetTimestamp();
+                var informationEnabled = _logger.IsEnabled(LogLevel.Information);
+                var errorEnabled = _logger.IsEnabled(LogLevel.Error);
+                var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
+                string? updateType = null;
+                string GetUpdateType() => updateType ??= TelegramUpdateLogFormatter.GetUpdateType(update);
+                var processingStarted = debugEnabled ? _timeProvider.GetTimestamp() : 0;
 
-                LogUpdateReceived(
-                    _logger,
-                    update.UpdateId,
-                    updateType,
-                    item.BatchIndex,
-                    item.BatchCount);
+                if (informationEnabled)
+                {
+                    LogUpdateReceived(
+                        _logger,
+                        update.UpdateId,
+                        GetUpdateType(),
+                        item.BatchIndex,
+                        item.BatchCount);
+                }
 
                 try
                 {
                     await updateHandler(new TelegramUpdatePayload(update), cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception exception)
+                catch (Exception exception) when (!IsUpdateCancellation(exception, cancellationToken))
                 {
-                    LogUpdateProcessingFailed(
-                        _logger,
-                        exception,
-                        update.UpdateId,
-                        updateType,
-                        GetElapsedMilliseconds(processingStarted));
+                    if (errorEnabled)
+                    {
+                        if (debugEnabled)
+                        {
+                            LogUpdateProcessingFailedWithTiming(
+                                _logger,
+                                exception,
+                                update.UpdateId,
+                                GetUpdateType(),
+                                GetElapsedMilliseconds(processingStarted));
+                        }
+                        else
+                        {
+                            LogUpdateProcessingFailed(
+                                _logger,
+                                exception,
+                                update.UpdateId,
+                                GetUpdateType());
+                        }
+                    }
+
                     throw;
                 }
 
                 await item.AcknowledgeAsync(CancellationToken.None).ConfigureAwait(false);
 
-                LogUpdateProcessed(
-                    _logger,
-                    update.UpdateId,
-                    updateType,
-                    GetElapsedMilliseconds(processingStarted));
+                if (informationEnabled)
+                {
+                    LogUpdateProcessed(
+                        _logger,
+                        update.UpdateId,
+                        GetUpdateType());
+                }
+
+                if (debugEnabled)
+                {
+                    LogUpdateProcessedWithTiming(
+                        _logger,
+                        update.UpdateId,
+                        GetUpdateType(),
+                        GetElapsedMilliseconds(processingStarted));
+                }
             }
         }
         finally
@@ -140,6 +173,11 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
         return _timeProvider.GetElapsedTime(startingTimestamp).TotalMilliseconds;
     }
 
+    private static bool IsUpdateCancellation(Exception exception, CancellationToken cancellationToken)
+    {
+        return exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+    }
+
     [LoggerMessage(
         EventId = 1,
         Level = LogLevel.Information,
@@ -158,7 +196,7 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
 
     [LoggerMessage(
         EventId = 3,
-        Level = LogLevel.Debug,
+        Level = LogLevel.Information,
         Message = "Telegram update received. update_id={UpdateId}, type={UpdateType}, batch_index={BatchIndex}/{BatchCount}.")]
     private static partial void LogUpdateReceived(
         ILogger logger,
@@ -170,8 +208,18 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
     [LoggerMessage(
         EventId = 4,
         Level = LogLevel.Error,
-        Message = "Telegram update processing failed. update_id={UpdateId}, type={UpdateType}, total_ms={TotalElapsedMilliseconds:F2}.")]
+        Message = "Telegram update processing failed. update_id={UpdateId}, type={UpdateType}.")]
     private static partial void LogUpdateProcessingFailed(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string updateType);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Error,
+        Message = "Telegram update processing failed. update_id={UpdateId}, type={UpdateType}, total_ms={TotalElapsedMilliseconds:F2}.")]
+    private static partial void LogUpdateProcessingFailedWithTiming(
         ILogger logger,
         Exception exception,
         long updateId,
@@ -180,9 +228,18 @@ internal sealed partial class TelegramLongPollingUpdateSource : IUpdateSource
 
     [LoggerMessage(
         EventId = 5,
+        Level = LogLevel.Information,
+        Message = "Telegram update processed. update_id={UpdateId}, type={UpdateType}.")]
+    private static partial void LogUpdateProcessed(
+        ILogger logger,
+        long updateId,
+        string updateType);
+
+    [LoggerMessage(
+        EventId = 5,
         Level = LogLevel.Debug,
         Message = "Telegram update processed. update_id={UpdateId}, type={UpdateType}, total_ms={TotalElapsedMilliseconds:F2}.")]
-    private static partial void LogUpdateProcessed(
+    private static partial void LogUpdateProcessedWithTiming(
         ILogger logger,
         long updateId,
         string updateType,

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.Logging.cs
@@ -20,25 +20,25 @@ internal sealed partial class TelegramHandlerDispatcher
         public const int HandlerMatched = 2;
 
         /// <summary>
-        /// A selected Telegram handler failed.
+        /// A selected Telegram route execution failed.
         /// </summary>
-        public const int HandlerFailed = 3;
+        public const int RouteExecutionFailed = 3;
 
         /// <summary>
-        /// A selected Telegram handler completed successfully.
+        /// A selected Telegram route execution completed successfully.
         /// </summary>
-        public const int HandlerCompleted = 4;
+        public const int RouteExecutionCompleted = 4;
 
         /// <summary>
-        /// A Telegram error handler completed after a selected handler failed.
+        /// A Telegram error handler completed after a selected route execution failed.
         /// </summary>
         public const int ErrorHandlerCompleted = 5;
     }
 
     /// <summary>
-    /// Captures log fields shared by handler failure logs and error-handler completion logs.
+    /// Captures log fields shared by route-execution failure logs and error-handler completion logs.
     /// </summary>
-    private readonly record struct HandlerFailureLogContext(
+    private readonly record struct RouteExecutionFailureLogContext(
         long UpdateId,
         string UpdateType,
         string Handler,
@@ -48,18 +48,18 @@ internal sealed partial class TelegramHandlerDispatcher
         string ExceptionType);
 
     /// <summary>
-    /// Logs a handler failure with optional timing details collected only for debug diagnostics.
+    /// Logs a route-execution failure with optional timing details collected only for debug diagnostics.
     /// </summary>
-    private void LogHandlerFailure(
+    private void LogRouteExecutionFailure(
         Exception exception,
-        HandlerFailureLogContext context,
+        RouteExecutionFailureLogContext context,
         bool includeTiming,
         long handlerStarted,
         TelegramHandlerRequestTimingScope? requestTimingScope)
     {
         if (!includeTiming)
         {
-            LogHandlerFailed(
+            LogRouteExecutionFailed(
                 _logger,
                 exception,
                 context.UpdateId,
@@ -77,7 +77,7 @@ internal sealed partial class TelegramHandlerDispatcher
         var handlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
         var timing = requestTimingScope.CreateSummary(_timeProvider, handlerElapsed);
 
-        LogHandlerFailedWithTiming(
+        LogRouteExecutionFailedWithTiming(
             _logger,
             exception,
             context.UpdateId,
@@ -98,9 +98,18 @@ internal sealed partial class TelegramHandlerDispatcher
     /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.NoHandlerMatched,
+        Level = LogLevel.Information,
+        Message = "No Telegram handler matched. update_id={UpdateId}, type={UpdateType}.")]
+    private static partial void LogNoHandlerMatched(
+        ILogger logger,
+        long updateId,
+        string updateType);
+
+    [LoggerMessage(
+        EventId = LogEventIds.NoHandlerMatched,
         Level = LogLevel.Debug,
         Message = "No Telegram handler matched. update_id={UpdateId}, type={UpdateType}, match_ms={MatchElapsedMilliseconds:F2}.")]
-    private static partial void LogNoHandlerMatched(
+    private static partial void LogNoHandlerMatchedWithTiming(
         ILogger logger,
         long updateId,
         string updateType,
@@ -111,9 +120,22 @@ internal sealed partial class TelegramHandlerDispatcher
     /// </summary>
     [LoggerMessage(
         EventId = LogEventIds.HandlerMatched,
+        Level = LogLevel.Information,
+        Message = "Telegram handler matched. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}.")]
+    private static partial void LogHandlerMatched(
+        ILogger logger,
+        long updateId,
+        string updateType,
+        string handler,
+        string route,
+        string moduleName,
+        string sceneName);
+
+    [LoggerMessage(
+        EventId = LogEventIds.HandlerMatched,
         Level = LogLevel.Debug,
         Message = "Telegram handler matched. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, match_ms={MatchElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerMatched(
+    private static partial void LogHandlerMatchedWithTiming(
         ILogger logger,
         long updateId,
         string updateType,
@@ -124,13 +146,13 @@ internal sealed partial class TelegramHandlerDispatcher
         double matchElapsedMilliseconds);
 
     /// <summary>
-    /// Logs a Telegram handler failure without debug-only timing fields.
+    /// Logs a Telegram route-execution failure without debug-only timing fields.
     /// </summary>
     [LoggerMessage(
-        EventId = LogEventIds.HandlerFailed,
+        EventId = LogEventIds.RouteExecutionFailed,
         Level = LogLevel.Error,
-        Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}.")]
-    private static partial void LogHandlerFailed(
+        Message = "Telegram route execution failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}.")]
+    private static partial void LogRouteExecutionFailed(
         ILogger logger,
         Exception exception,
         long updateId,
@@ -142,13 +164,13 @@ internal sealed partial class TelegramHandlerDispatcher
         string exceptionType);
 
     /// <summary>
-    /// Logs a Telegram handler failure with debug-only timing fields.
+    /// Logs a Telegram route-execution failure with debug-only timing fields.
     /// </summary>
     [LoggerMessage(
-        EventId = LogEventIds.HandlerFailed,
+        EventId = LogEventIds.RouteExecutionFailed,
         Level = LogLevel.Error,
-        Message = "Telegram handler failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerFailedWithTiming(
+        Message = "Telegram route execution failed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, module={ModuleName}, scene={SceneName}, exception_type={ExceptionType}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
+    private static partial void LogRouteExecutionFailedWithTiming(
         ILogger logger,
         Exception exception,
         long updateId,
@@ -164,13 +186,13 @@ internal sealed partial class TelegramHandlerDispatcher
         double handlerLogicElapsedMilliseconds);
 
     /// <summary>
-    /// Logs a successfully completed Telegram handler with debug timing fields.
+    /// Logs a successfully completed Telegram route execution with debug timing fields.
     /// </summary>
     [LoggerMessage(
-        EventId = LogEventIds.HandlerCompleted,
+        EventId = LogEventIds.RouteExecutionCompleted,
         Level = LogLevel.Debug,
-        Message = "Telegram handler completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
-    private static partial void LogHandlerCompleted(
+        Message = "Telegram route execution completed. update_id={UpdateId}, type={UpdateType}, handler={Handler}, route={Route}, handler_ms={HandlerElapsedMilliseconds:F2}, telegram_request_count={TelegramRequestCount}, telegram_request_ms={TelegramRequestElapsedMilliseconds:F2}, handler_logic_ms={HandlerLogicElapsedMilliseconds:F2}.")]
+    private static partial void LogRouteExecutionCompleted(
         ILogger logger,
         long updateId,
         string updateType,

--- a/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
+++ b/src/TeleFlow.Framework/Internal/Handlers/TelegramHandlerDispatcher.cs
@@ -56,6 +56,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             return;
         }
 
+        var routeLoggingEnabled = _logger.IsEnabled(LogLevel.Information);
         var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
         string? updateType = null;
         string GetUpdateType() => updateType ??= TelegramUpdateLogFormatter.GetUpdateType(payload.Update);
@@ -110,11 +111,18 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         {
             if (debugEnabled)
             {
-                LogNoHandlerMatched(
+                LogNoHandlerMatchedWithTiming(
                     _logger,
                     payload.Update.UpdateId,
                     GetUpdateType(),
                     matchElapsedMilliseconds);
+            }
+            else if (routeLoggingEnabled)
+            {
+                LogNoHandlerMatched(
+                    _logger,
+                    payload.Update.UpdateId,
+                    GetUpdateType());
             }
 
             return;
@@ -127,7 +135,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
 
         if (debugEnabled)
         {
-            LogHandlerMatched(
+            LogHandlerMatchedWithTiming(
                 _logger,
                 payload.Update.UpdateId,
                 GetUpdateType(),
@@ -136,6 +144,17 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 selection.Handler.ModuleName ?? string.Empty,
                 selection.Handler.SceneName ?? string.Empty,
                 matchElapsedMilliseconds);
+        }
+        else if (routeLoggingEnabled)
+        {
+            LogHandlerMatched(
+                _logger,
+                payload.Update.UpdateId,
+                GetUpdateType(),
+                GetHandlerName(),
+                GetRouteName(),
+                selection.Handler.ModuleName ?? string.Empty,
+                selection.Handler.SceneName ?? string.Empty);
         }
 
         var handlerTimingEnabled = debugEnabled;
@@ -150,13 +169,18 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
                 selection,
                 telegramContext,
                 effectiveCancellationToken).ConfigureAwait(false);
+
+            await AutoAnswerCallbackAsync(
+                selection.Handler,
+                telegramContext,
+                effectiveCancellationToken).ConfigureAwait(false);
         }
         catch (Exception exception) when (!IsUpdateCancellation(exception, effectiveCancellationToken))
         {
-            HandlerFailureLogContext? logContext = null;
-            HandlerFailureLogContext GetLogContext()
+            RouteExecutionFailureLogContext? logContext = null;
+            RouteExecutionFailureLogContext GetLogContext()
             {
-                logContext ??= new HandlerFailureLogContext(
+                logContext ??= new RouteExecutionFailureLogContext(
                     payload.Update.UpdateId,
                     GetUpdateType(),
                     GetHandlerName(),
@@ -170,7 +194,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
 
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                LogHandlerFailure(
+                LogRouteExecutionFailure(
                     exception,
                     GetLogContext(),
                     handlerTimingEnabled,
@@ -192,11 +216,6 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
             throw;
         }
 
-        await AutoAnswerCallbackAsync(
-            selection.Handler,
-            telegramContext,
-            effectiveCancellationToken).ConfigureAwait(false);
-
         if (!handlerTimingEnabled)
         {
             return;
@@ -205,7 +224,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         var completedHandlerElapsed = _timeProvider.GetElapsedTime(handlerStarted);
         var completedTiming = requestTimingScope!.CreateSummary(_timeProvider, completedHandlerElapsed);
 
-        LogHandlerCompleted(
+        LogRouteExecutionCompleted(
             _logger,
             payload.Update.UpdateId,
             GetUpdateType(),
@@ -271,7 +290,7 @@ internal sealed partial class TelegramHandlerDispatcher : IUpdateDispatcher
         TelegramRouteSelection selection,
         TelegramUpdateContext telegramContext,
         Exception exception,
-        HandlerFailureLogContext? logContext,
+        RouteExecutionFailureLogContext? logContext,
         CancellationToken cancellationToken)
     {
         var errorContext = new TelegramErrorContext(

--- a/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/StageSixStateAndMiddlewareTests.cs
@@ -884,6 +884,25 @@ public sealed class StageSixStateAndMiddlewareTests
     }
 
     [Fact]
+    public async Task UpdateExceptionMiddleware_DoesNotLogExpectedCancellation()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var context = new UpdateContext(
+            serviceProvider,
+            new TestUpdatePayload("cancellation"),
+            cancellation.Token);
+        var logger = new RecordingLogger<UpdateExceptionMiddleware>();
+        var middleware = new UpdateExceptionMiddleware(logger);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            middleware.InvokeAsync(context, _ => Task.FromCanceled(cancellation.Token)));
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
     public async Task UpdateLoggingMiddleware_LogsAndDoesNotChangeExecutionResult()
     {
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();

--- a/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramHandlerDispatcherTests.cs
@@ -141,7 +141,7 @@ public sealed class TelegramHandlerDispatcherTests
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
                      entry.EventId.Id == 4 &&
-                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram route execution completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler_ms=", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=0", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_ms=0", StringComparison.Ordinal) &&
@@ -169,11 +169,35 @@ public sealed class TelegramHandlerDispatcherTests
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
                      entry.EventId.Id == 4 &&
-                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram route execution completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=OneTelegramRequestMessageHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=1", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_ms=", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler_logic_ms=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Dispatcher_LogsMatchedHandlerAtInformationWithoutTiming()
+    {
+        var loggerFactory = new RecordingLoggerFactory(LogLevel.Information);
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<StartCommandHandler>();
+            });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("/start"));
+
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Information &&
+                     entry.EventId.Id == 2 &&
+                     entry.Message.Contains("Telegram handler matched", StringComparison.Ordinal) &&
+                     entry.Message.Contains("handler=StartCommandHandler.Handle", StringComparison.Ordinal) &&
+                     entry.Message.Contains("route=CommandExact('start')", StringComparison.Ordinal) &&
+                     !entry.Message.Contains("match_ms=", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -200,7 +224,7 @@ public sealed class TelegramHandlerDispatcherTests
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
                      entry.EventId.Id == 4 &&
-                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram route execution completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=OneTelegramRequestMessageHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=1", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_ms=10", StringComparison.Ordinal) &&
@@ -228,7 +252,7 @@ public sealed class TelegramHandlerDispatcherTests
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Debug &&
                      entry.EventId.Id == 4 &&
-                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram route execution completed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=TwoTelegramRequestsCallbackHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=2", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_ms=", StringComparison.Ordinal) &&
@@ -258,7 +282,7 @@ public sealed class TelegramHandlerDispatcherTests
         Assert.DoesNotContain(
             loggerFactory.Entries,
             entry => entry.Category.EndsWith("TelegramHandlerDispatcher", StringComparison.Ordinal) &&
-                     entry.Message.Contains("Telegram handler completed", StringComparison.Ordinal));
+                     entry.Message.Contains("Telegram route execution completed", StringComparison.Ordinal));
         Assert.DoesNotContain(
             loggerFactory.Entries,
             entry => entry.Category.EndsWith("TelegramHandlerDispatcher", StringComparison.Ordinal) &&
@@ -289,6 +313,29 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
+    public async Task Dispatcher_LogsNoMatchedHandlerAtInformationWithoutTiming()
+    {
+        var loggerFactory = new RecordingLoggerFactory(LogLevel.Information);
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddTelegramHandler<ExactTextMessageHandler>();
+            });
+
+        await DispatchAsync(serviceProvider, CreateMessageUpdate("not matched"));
+
+        Assert.Contains(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Information &&
+                     entry.EventId.Id == 1 &&
+                     entry.Message.Contains("No Telegram handler matched", StringComparison.Ordinal) &&
+                     entry.Message.Contains("type=message", StringComparison.Ordinal) &&
+                     !entry.Message.Contains("match_ms=", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Dispatcher_LogsFailedHandlerAndRethrowsOriginalException()
     {
         var loggerFactory = new RecordingLoggerFactory();
@@ -311,7 +358,7 @@ public sealed class TelegramHandlerDispatcherTests
             entry => entry.Level == LogLevel.Error &&
                      entry.EventId.Id == 3 &&
                      ReferenceEquals(entry.Exception, expected) &&
-                     entry.Message.Contains("Telegram handler failed", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Telegram route execution failed", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler=ThrowingMessageHandler.Handle", StringComparison.Ordinal) &&
                      entry.Message.Contains("handler_ms=", StringComparison.Ordinal) &&
                      entry.Message.Contains("telegram_request_count=0", StringComparison.Ordinal) &&
@@ -342,7 +389,7 @@ public sealed class TelegramHandlerDispatcherTests
             entry => entry.Level == LogLevel.Error &&
                      entry.EventId.Id == 3 &&
                      ReferenceEquals(entry.Exception, expected) &&
-                     entry.Message.Contains("Telegram handler failed", StringComparison.Ordinal));
+                     entry.Message.Contains("Telegram route execution failed", StringComparison.Ordinal));
 
         Assert.Contains("handler=ThrowingMessageHandler.Handle", entry.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("handler_ms=", entry.Message, StringComparison.Ordinal);
@@ -2732,7 +2779,7 @@ public sealed class TelegramHandlerDispatcherTests
     }
 
     [Fact]
-    public async Task AutoAnswerCallback_FailureBypassesTelegramErrorHandlers()
+    public async Task AutoAnswerCallback_FailureUsesTelegramErrorHandlers()
     {
         var transport = new RecordingTelegramTransport(new TelegramTransportResponse(
             500,
@@ -2744,6 +2791,28 @@ public sealed class TelegramHandlerDispatcherTests
                 services.AddSingleton<ITelegramTransport>(transport);
                 services.AddTelegramHandler<AutoAnswerCallbackHandler>();
                 services.AddTelegramHandler<AutoAnswerFailureErrorHandler>();
+            });
+        var probe = serviceProvider.GetRequiredService<HandlerProbe>();
+
+        await DispatchAsync(serviceProvider, CreateCallbackUpdate("auto"));
+
+        Assert.Equal(
+            ["auto-answer:auto", "auto-answer-error:TelegramServerException"],
+            probe.Events);
+    }
+
+    [Fact]
+    public async Task AutoAnswerCallback_UnhandledFailureRethrows()
+    {
+        var transport = new RecordingTelegramTransport(new TelegramTransportResponse(
+            500,
+            """{"ok":false,"error_code":500,"description":"Internal Server Error"}"""));
+        using var serviceProvider = CreateServiceProvider(
+            services =>
+            {
+                services.RemoveAll<ITelegramTransport>();
+                services.AddSingleton<ITelegramTransport>(transport);
+                services.AddTelegramHandler<AutoAnswerCallbackHandler>();
             });
         var probe = serviceProvider.GetRequiredService<HandlerProbe>();
 

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -1911,7 +1911,7 @@ public sealed class TelegramRuntimeIntegrationTests
                      entry.Message.Contains("Telegram long polling connected", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
-            entry => entry.Level == LogLevel.Debug &&
+            entry => entry.Level == LogLevel.Information &&
                      entry.EventId.Id == 3 &&
                      entry.Message.Contains("Telegram update received", StringComparison.Ordinal) &&
                      entry.Message.Contains("update_id=1", StringComparison.Ordinal) &&
@@ -1919,15 +1919,42 @@ public sealed class TelegramRuntimeIntegrationTests
                      entry.Message.Contains("batch_index=1/1", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
-            entry => entry.Level == LogLevel.Debug &&
+            entry => entry.Level == LogLevel.Information &&
                      entry.EventId.Id == 5 &&
                      entry.Message.Contains("Telegram update processed", StringComparison.Ordinal) &&
-                     entry.Message.Contains("total_ms=", StringComparison.Ordinal));
+                     !entry.Message.Contains("total_ms=", StringComparison.Ordinal));
         Assert.Contains(
             loggerFactory.Entries,
             entry => entry.Level == LogLevel.Information &&
                      entry.EventId.Id == 6 &&
                      entry.Message.Contains("Telegram long polling stopped", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LongPolling_CancellationDuringUpdateProcessing_DoesNotLogFailure()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        var telegramClient = new SequencedTelegramClient(new List<Update> { CreateMessageUpdate(1) });
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateTelegramApplication(
+            services =>
+            {
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(loggerFactory);
+                services.AddSingleton<ITelegramClient>(telegramClient);
+                services.AddSingleton<IUpdateDispatcher>(new CancellationThrowingDispatcher(cancellation));
+            },
+            services => services.AddLongPolling(),
+            cancellation);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => application.RunAsync(cancellation.Token));
+
+        Assert.DoesNotContain(
+            loggerFactory.Entries,
+            entry => entry.Category == "TeleFlow.Telegram.Internal.TelegramLongPollingUpdateSource" &&
+                     entry.Level == LogLevel.Error &&
+                     entry.EventId.Id == 4);
     }
 
     [Fact]
@@ -4317,6 +4344,15 @@ public sealed class TelegramRuntimeIntegrationTests
         public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
         {
             return Task.FromException(exception);
+        }
+    }
+
+    private sealed class CancellationThrowingDispatcher(CancellationTokenSource cancellation) : IUpdateDispatcher
+    {
+        public Task DispatchAsync(UpdateContext context, CancellationToken cancellationToken = default)
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled(cancellation.Token);
         }
     }
 


### PR DESCRIPTION
## Summary

- route automatic callback answers through the existing Telegram `[Error]` handler pipeline when they fail after a handler succeeds;
- preserve fail-fast and non-acknowledgement behavior when no error handler handles the route failure;
- avoid error-level update-failure logs for expected application cancellation;
- add information-level received, matched/no-match, and processed update lifecycle logs without debug-only timing work;
- document the long-polling and webhook failure/acknowledgement contract in English and Russian.

## Touched hot paths

- `TelegramHandlerDispatcher`: route invocation now includes the framework-owned automatic callback answer within the existing error boundary. Debug timing remains opt-in.
- `TelegramLongPollingUpdateSource`: information logging records lifecycle facts only; timestamps and elapsed-time calculations run only when `Debug` is enabled.
- `UpdateExceptionMiddleware`: expected cancellation is rethrown without an error log.

## Intentionally unchanged

- Raw `getUpdates` retry/backoff and offset advancement remain unchanged.
- Middleware failures remain outside handler-level Telegram error recovery.
- No global acknowledgement policy, retry policy, or catch-and-ignore behavior is added.

## Validation

- `dotnet test TeleFlow.sln --no-restore --verbosity minimal` (`771/771`)
- `python -m mkdocs build --strict --site-dir site`
- `git diff --check`

Closes #151