### PR TITLE
feat: add formatted Telegram text builders

### DIFF
--- a/docs/en/features/formatted-text.md
+++ b/docs/en/features/formatted-text.md
@@ -1,0 +1,165 @@
+# Formatted Text And Custom Emoji
+
+Use the formatted-text builders for normal Telegram messages with names, links,
+balances, spoilers, code, or custom emoji. Builders escape plain values and
+render one explicit Bot API parse mode.
+
+```csharp
+using TeleFlow.Telegram.Formatting;
+
+var text = TelegramHtml.Create()
+    .Text("Balance: ")
+    .Bold(balance.ToString("N0") + " BB")
+    .LineBreak()
+    .Link(profileUrl, "Open profile")
+    .Text(" ")
+    .CustomEmoji(
+        customEmojiId: "5368324170671202286",
+        fallbackEmoji: "💎")
+    .Build();
+
+await ctx.Message.AnswerAsync(text, ct);
+```
+
+The result is `TelegramFormattedText`. It contains rendered `Text` and an
+explicit `TelegramParseMode`, so it never relies on
+`TelegramBotDefaults.ParseMode`.
+
+## Choose A Mode Explicitly
+
+```csharp
+var html = TelegramHtml.Create()
+    .Text("Status: ")
+    .Bold("active")
+    .Build();
+
+var markdown = TelegramMarkdownV2.Create()
+    .Text("Status: ")
+    .Bold("active")
+    .Build();
+```
+
+HTML and MarkdownV2 are different formats. TeleFlow neither detects a format
+from a string nor converts between formats. An HTML formatted value cannot be
+appended to a MarkdownV2 builder, and vice versa.
+
+## Safe Text And Composition
+
+`Text(...)` and every normal text argument escape their input. Pass user names,
+database values, and external text directly:
+
+```csharp
+var text = TelegramHtml.Create()
+    .Text(player.DisplayName)
+    .Text(" joined the chat.")
+    .Build();
+```
+
+Do not escape a value yourself first. The builder preserves formatted fragments
+during composition, so nested content is escaped exactly once:
+
+```csharp
+var text = TelegramHtml.Create()
+    .Bold(content => content
+        .Text("Active ")
+        .Spoiler(secretValue))
+    .Build();
+```
+
+The safe vocabulary is `Text`, `LineBreak`, `Bold`, `Italic`, `Underline`,
+`Strikethrough`, `Spoiler`, `Code`, `Pre`, `Link`, `Mention`,
+`BlockQuote`, and `CustomEmoji`.
+
+`Code`, `Pre`, links, mentions, custom emoji, and block quotes receive plain
+content rather than nested builders. Telegram does not allow arbitrary nested
+entities in all of these constructs, so the API does not pretend otherwise.
+
+```csharp
+var text = TelegramMarkdownV2.Create()
+    .BlockQuote("This is a quoted note.", expandable: true)
+    .LineBreak()
+    .Code("dotnet test")
+    .LineBreak()
+    .Pre("Console.WriteLine(\"Hello\");", language: "csharp")
+    .Build();
+```
+
+## Links, Mentions, And Custom Emoji
+
+```csharp
+var text = TelegramHtml.Create()
+    .Link(new Uri("https://example.com/profile/42"), "Profile")
+    .Text(" for ")
+    .Mention(123456789, "Alice")
+    .LineBreak()
+    .CustomEmoji(customEmojiId, fallbackEmoji: "💎")
+    .Build();
+```
+
+The builder requires an absolute URI and a positive user id. Custom emoji also
+require a fallback emoji. Telegram may show that fallback in notifications,
+forwarded messages, unsupported clients, or destinations where the bot/account
+cannot render the custom emoji. TeleFlow neither calls
+`getCustomEmojiStickers` implicitly nor promises availability.
+
+Custom emoji inside **inline keyboard buttons** are a different Bot API field:
+
+```csharp
+var keyboard = InlineKeyboardBuilder.Create()
+    .Button(
+        "Open",
+        new OpenProfileCallback(),
+        new InlineKeyboardButtonOptions
+        {
+            IconCustomEmojiId = customEmojiId
+        })
+    .Build();
+```
+
+## Sending And Editing
+
+Framework context helpers accept `TelegramFormattedText`:
+
+```csharp
+await ctx.Message.AnswerAsync(text, ct);
+await ctx.Message.ReplyAsync(text, ct);
+await ctx.Callback.EditTextAsync(text, ct);
+
+await ctx.Message.AnswerAsync(text, keyboard, ct);
+await ctx.Callback.EditTextAsync(text, keyboard, ct);
+```
+
+These overloads forward the value's explicit parse mode through the normal
+generated-client path. Existing `string` overloads retain their existing
+behavior, including a configured client default parse mode.
+
+For reply keyboards, force replies, captions, explicit `MessageEntity` values,
+or another advanced request field, use the generated client directly:
+
+```csharp
+await ctx.Bot.SendMessageAsync(
+    chatId: IntegerString.From(ctx.TelegramChat.Id),
+    text: text.Text,
+    parseMode: text.ParseMode,
+    cancellationToken: ct);
+```
+
+## Unsafe Markup
+
+`UnsafeMarkup` is only for static reviewed templates:
+
+```csharp
+var text = TelegramHtml.UnsafeMarkup(
+    "<b>Static reviewed copy</b>");
+```
+
+It bypasses escaping and structural validation. Never pass user-controlled,
+database-controlled, or external text to it.
+
+## Entities And Rich Messages
+
+Builders target ordinary Bot API `text` plus `parse_mode`. They do not replace
+explicit `MessageEntity` values. They also do not create Bot API **Rich
+Messages** (`InputRichMessage`, blocks, media, drafts, tables, or formulas).
+That is a separate Telegram API surface and intentionally remains outside this
+helper.

--- a/docs/en/features/telegram-client.md
+++ b/docs/en/features/telegram-client.md
@@ -102,6 +102,14 @@ builder.Services.AddTelegramBot(options =>
 
 Defaults are useful for cross-cutting Telegram request settings. Keep handler-specific values in the handler.
 
+## Formatted Text
+
+For normal HTML or MarkdownV2 messages, use the safe
+[formatted-text builders](formatted-text.md). They escape plain values, keep the
+parse mode explicit, and work with `AnswerAsync`, `ReplyAsync`, and callback
+message edits. Use explicit `MessageEntity` values or Bot API Rich Messages
+directly when the request needs a more advanced representation.
+
 ## Retry-After Policy
 
 Telegram may return `429 Too Many Requests` with `response_parameters.retry_after` or an HTTP `Retry-After` header. TeleFlow handles this through an explicit bounded policy:

--- a/docs/ru/features/formatted-text.md
+++ b/docs/ru/features/formatted-text.md
@@ -1,0 +1,163 @@
+# Форматированный текст и custom emoji
+
+Используй builders форматированного текста для обычных Telegram-сообщений с
+именами, ссылками, балансами, spoiler, кодом или custom emoji. Builders
+экранируют обычные значения и всегда задают явный Bot API parse mode.
+
+```csharp
+using TeleFlow.Telegram.Formatting;
+
+var text = TelegramHtml.Create()
+    .Text("Баланс: ")
+    .Bold(balance.ToString("N0") + " BB")
+    .LineBreak()
+    .Link(profileUrl, "Открыть профиль")
+    .Text(" ")
+    .CustomEmoji(
+        customEmojiId: "5368324170671202286",
+        fallbackEmoji: "💎")
+    .Build();
+
+await ctx.Message.AnswerAsync(text, ct);
+```
+
+Результат - `TelegramFormattedText`. В нём есть готовый `Text` и явный
+`TelegramParseMode`, поэтому он не зависит от `TelegramBotDefaults.ParseMode`.
+
+## Формат выбирается явно
+
+```csharp
+var html = TelegramHtml.Create()
+    .Text("Статус: ")
+    .Bold("активен")
+    .Build();
+
+var markdown = TelegramMarkdownV2.Create()
+    .Text("Статус: ")
+    .Bold("активен")
+    .Build();
+```
+
+HTML и MarkdownV2 - разные форматы. TeleFlow не угадывает формат по строке и
+не конвертирует один формат в другой. HTML-результат нельзя добавить в
+MarkdownV2 builder, и наоборот.
+
+## Безопасный текст и композиция
+
+`Text(...)` и все обычные текстовые аргументы экранируют входные данные. Имя
+пользователя, значение из БД или внешний текст передавай напрямую:
+
+```csharp
+var text = TelegramHtml.Create()
+    .Text(player.DisplayName)
+    .Text(" вошёл в чат.")
+    .Build();
+```
+
+Не экранируй значение вручную заранее. Builder сохраняет форматированные
+фрагменты при композиции, поэтому вложенный контент экранируется ровно один раз:
+
+```csharp
+var text = TelegramHtml.Create()
+    .Bold(content => content
+        .Text("Активен: ")
+        .Spoiler(secretValue))
+    .Build();
+```
+
+Безопасный vocabulary: `Text`, `LineBreak`, `Bold`, `Italic`, `Underline`,
+`Strikethrough`, `Spoiler`, `Code`, `Pre`, `Link`, `Mention`, `BlockQuote` и
+`CustomEmoji`.
+
+В `Code`, `Pre`, ссылках, mentions, custom emoji и block quote передаётся
+обычный текст, а не вложенный builder. Telegram разрешает вложенные entities не
+во всех этих конструкциях, поэтому API не создаёт ложную свободу.
+
+```csharp
+var text = TelegramMarkdownV2.Create()
+    .BlockQuote("Здесь важное примечание.", expandable: true)
+    .LineBreak()
+    .Code("dotnet test")
+    .LineBreak()
+    .Pre("Console.WriteLine(\"Hello\");", language: "csharp")
+    .Build();
+```
+
+## Ссылки, mentions и custom emoji
+
+```csharp
+var text = TelegramHtml.Create()
+    .Link(new Uri("https://example.com/profile/42"), "Профиль")
+    .Text(" пользователя ")
+    .Mention(123456789, "Алиса")
+    .LineBreak()
+    .CustomEmoji(customEmojiId, fallbackEmoji: "💎")
+    .Build();
+```
+
+Builder требует absolute URI и положительный user id. Для custom emoji нужен
+ещё и fallback emoji. Telegram может показать его в notification, forwarded
+message, старом клиенте или там, где bot/account/destination не имеет права
+отрисовать custom emoji. TeleFlow не вызывает `getCustomEmojiStickers`
+автоматически и не обещает доступность emoji.
+
+Custom emoji внутри **inline keyboard button** - отдельное поле Bot API:
+
+```csharp
+var keyboard = InlineKeyboardBuilder.Create()
+    .Button(
+        "Открыть",
+        new OpenProfileCallback(),
+        new InlineKeyboardButtonOptions
+        {
+            IconCustomEmojiId = customEmojiId
+        })
+    .Build();
+```
+
+## Отправка и редактирование
+
+Framework context helpers принимают `TelegramFormattedText`:
+
+```csharp
+await ctx.Message.AnswerAsync(text, ct);
+await ctx.Message.ReplyAsync(text, ct);
+await ctx.Callback.EditTextAsync(text, ct);
+
+await ctx.Message.AnswerAsync(text, keyboard, ct);
+await ctx.Callback.EditTextAsync(text, keyboard, ct);
+```
+
+Formatted overloads передают явный parse mode через обычный generated-client
+path. Старые `string` overloads не меняются и продолжают учитывать client
+default parse mode.
+
+Для reply keyboards, force replies, captions, явных `MessageEntity` или другого
+сложного поля Bot API используй generated client напрямую:
+
+```csharp
+await ctx.Bot.SendMessageAsync(
+    chatId: IntegerString.From(ctx.TelegramChat.Id),
+    text: text.Text,
+    parseMode: text.ParseMode,
+    cancellationToken: ct);
+```
+
+## Unsafe markup
+
+`UnsafeMarkup` существует только для статичных проверенных шаблонов:
+
+```csharp
+var text = TelegramHtml.UnsafeMarkup(
+    "<b>Проверенный статичный текст</b>");
+```
+
+Он отключает экранирование и structural validation. Никогда не передавай в него
+данные пользователя, значения из БД или внешний текст.
+
+## Entities и Rich Messages
+
+Builders работают с обычным Bot API `text` и `parse_mode`. Они не заменяют
+явные `MessageEntity` и не строят Bot API **Rich Messages**
+(`InputRichMessage`, blocks, media, drafts, tables, formulas). Это отдельная
+модель Telegram API, и она намеренно не смешана с этим helper-слоем.

--- a/docs/ru/features/telegram-client.md
+++ b/docs/ru/features/telegram-client.md
@@ -102,6 +102,14 @@ builder.Services.AddTelegramBot(options =>
 
 Defaults удобны для cross-cutting Telegram request settings. Handler-specific values держи в handler.
 
+## Форматированный текст
+
+Для обычных HTML- или MarkdownV2-сообщений используй безопасные
+[builders форматированного текста](formatted-text.md). Они экранируют обычные
+значения, всегда задают parse mode явно и работают с `AnswerAsync`,
+`ReplyAsync` и callback message edits. Для сложных request shapes используй
+явные `MessageEntity` или Bot API Rich Messages напрямую.
+
 ## Retry-After policy
 
 Telegram может вернуть `429 Too Many Requests` с `response_parameters.retry_after` или HTTP header `Retry-After`. TeleFlow обрабатывает это через явную bounded policy:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - Cancellation: en/fundamentals/cancellation.md
       - Features:
           - Telegram client and schema: en/features/telegram-client.md
+          - Formatted text and custom emoji: en/features/formatted-text.md
           - Callbacks and keyboards: en/features/callbacks-and-keyboards.md
           - State and wizard: en/features/state-and-wizard.md
           - Roles and chat members: en/features/roles-and-chat-members.md
@@ -132,6 +133,7 @@ nav:
           - Cancellation: ru/fundamentals/cancellation.md
       - Features:
           - Telegram client and schema: ru/features/telegram-client.md
+          - Форматированный текст и custom emoji: ru/features/formatted-text.md
           - Callbacks and keyboards: ru/features/callbacks-and-keyboards.md
           - State and wizard: ru/features/state-and-wizard.md
           - Roles and chat members: ru/features/roles-and-chat-members.md

--- a/src/TeleFlow.Framework/CallbackQueryActions.cs
+++ b/src/TeleFlow.Framework/CallbackQueryActions.cs
@@ -1,6 +1,7 @@
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
+using TeleFlow.Telegram.Formatting;
 
 namespace TeleFlow.Telegram;
 
@@ -56,7 +57,19 @@ public sealed class CallbackQueryActions
 
     public Task<MessageBoolean> EditTextAsync(string text, CancellationToken cancellationToken = default)
     {
-        return EditTextCoreAsync(text, replyMarkup: null, cancellationToken);
+        return EditTextCoreAsync(text, replyMarkup: null, parseMode: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Edits the callback message with formatted text.
+    /// The formatted value carries its explicit Telegram parse mode and does not use the client's parse-mode default.
+    /// </summary>
+    public Task<MessageBoolean> EditTextAsync(
+        TelegramFormattedText text,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return EditTextCoreAsync(text.Text, replyMarkup: null, text.ParseMode, cancellationToken);
     }
 
     public Task<MessageBoolean> EditTextAsync(
@@ -65,12 +78,26 @@ public sealed class CallbackQueryActions
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(replyMarkup);
-        return EditTextCoreAsync(text, replyMarkup, cancellationToken);
+        return EditTextCoreAsync(text, replyMarkup, parseMode: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Edits the callback message with formatted text and an inline keyboard.
+    /// </summary>
+    public Task<MessageBoolean> EditTextAsync(
+        TelegramFormattedText text,
+        InlineKeyboardMarkup replyMarkup,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(replyMarkup);
+        return EditTextCoreAsync(text.Text, replyMarkup, text.ParseMode, cancellationToken);
     }
 
     private Task<MessageBoolean> EditTextCoreAsync(
         string text,
         InlineKeyboardMarkup? replyMarkup,
+        TelegramParseMode? parseMode,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
@@ -79,13 +106,14 @@ public sealed class CallbackQueryActions
         {
             if (target.IsEphemeral)
             {
-                return EditEphemeralTextAsync(target, text, replyMarkup, cancellationToken);
+                return EditEphemeralTextAsync(target, text, replyMarkup, parseMode, cancellationToken);
             }
 
             return _context.Bot.EditMessageTextAsync(
                 chatId: IntegerString.From(target.ChatId),
                 messageId: target.MessageId,
                 text: text,
+                parseMode: parseMode,
                 replyMarkup: replyMarkup,
                 cancellationToken: ResolveCancellationToken(cancellationToken));
         }
@@ -95,6 +123,7 @@ public sealed class CallbackQueryActions
             return _context.Bot.EditMessageTextAsync(
                 inlineMessageId: _context.TelegramCallbackQuery.InlineMessageId,
                 text: text,
+                parseMode: parseMode,
                 replyMarkup: replyMarkup,
                 cancellationToken: ResolveCancellationToken(cancellationToken));
         }
@@ -154,6 +183,7 @@ public sealed class CallbackQueryActions
         TelegramMessageTarget target,
         string text,
         InlineKeyboardMarkup? replyMarkup,
+        TelegramParseMode? parseMode,
         CancellationToken cancellationToken)
     {
         var result = await _context.Bot.EditEphemeralMessageTextAsync(
@@ -161,6 +191,7 @@ public sealed class CallbackQueryActions
             EphemeralMessageTargetResolver.ResolveReceiverUserId(_context.TelegramCallbackQuery, target),
             target.EphemeralMessageId!.Value,
             text,
+            parseMode: parseMode,
             replyMarkup: replyMarkup,
             cancellationToken: ResolveCancellationToken(cancellationToken)).ConfigureAwait(false);
 

--- a/src/TeleFlow.Framework/CallbackQueryActions.cs
+++ b/src/TeleFlow.Framework/CallbackQueryActions.cs
@@ -1,7 +1,7 @@
+using TeleFlow.Telegram.Formatting;
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
-using TeleFlow.Telegram.Formatting;
 
 namespace TeleFlow.Telegram;
 

--- a/src/TeleFlow.Framework/MessageActions.cs
+++ b/src/TeleFlow.Framework/MessageActions.cs
@@ -1,6 +1,7 @@
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
+using TeleFlow.Telegram.Formatting;
 
 namespace TeleFlow.Telegram;
 
@@ -18,6 +19,17 @@ public sealed partial class MessageActions
         return SendTextAsync(text, replyMarkup: null, replyToCurrentMessage: false, cancellationToken);
     }
 
+    /// <summary>
+    /// Sends formatted text to the current chat without replying to the current message.
+    /// The formatted value carries its explicit Telegram parse mode and does not use the client's parse-mode default.
+    /// </summary>
+    public Task<Message> AnswerAsync(
+        TelegramFormattedText text,
+        CancellationToken cancellationToken = default)
+    {
+        return SendFormattedTextAsync(text, replyMarkup: null, replyToCurrentMessage: false, cancellationToken);
+    }
+
     public Task<Message> AnswerAsync(
         string text,
         InlineKeyboardMarkup inlineKeyboard,
@@ -27,6 +39,22 @@ public sealed partial class MessageActions
         return AnswerAsync(
             text,
             ReplyMarkup.From(inlineKeyboard),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends formatted text with an inline keyboard to the current chat without replying to the current message.
+    /// </summary>
+    public Task<Message> AnswerAsync(
+        TelegramFormattedText text,
+        InlineKeyboardMarkup inlineKeyboard,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(inlineKeyboard);
+        return SendFormattedTextAsync(
+            text,
+            ReplyMarkup.From(inlineKeyboard),
+            replyToCurrentMessage: false,
             cancellationToken);
     }
 
@@ -80,6 +108,17 @@ public sealed partial class MessageActions
         return SendTextAsync(text, replyMarkup: null, replyToCurrentMessage: true, cancellationToken);
     }
 
+    /// <summary>
+    /// Sends formatted text as a reply to the current message.
+    /// The formatted value carries its explicit Telegram parse mode and does not use the client's parse-mode default.
+    /// </summary>
+    public Task<Message> ReplyAsync(
+        TelegramFormattedText text,
+        CancellationToken cancellationToken = default)
+    {
+        return SendFormattedTextAsync(text, replyMarkup: null, replyToCurrentMessage: true, cancellationToken);
+    }
+
     public Task<Message> ReplyAsync(
         string text,
         InlineKeyboardMarkup inlineKeyboard,
@@ -89,6 +128,22 @@ public sealed partial class MessageActions
         return ReplyAsync(
             text,
             ReplyMarkup.From(inlineKeyboard),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends formatted text with an inline keyboard as a reply to the current message.
+    /// </summary>
+    public Task<Message> ReplyAsync(
+        TelegramFormattedText text,
+        InlineKeyboardMarkup inlineKeyboard,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(inlineKeyboard);
+        return SendFormattedTextAsync(
+            text,
+            ReplyMarkup.From(inlineKeyboard),
+            replyToCurrentMessage: true,
             cancellationToken);
     }
 
@@ -189,7 +244,8 @@ public sealed partial class MessageActions
         string text,
         ReplyMarkup? replyMarkup,
         bool replyToCurrentMessage,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TelegramParseMode? parseMode = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
         var reply = CreateReplyConfiguration(replyToCurrentMessage);
@@ -200,7 +256,24 @@ public sealed partial class MessageActions
             receiverUserId: reply.ReceiverUserId,
             replyParameters: reply.ReplyParameters,
             replyMarkup: replyMarkup,
+            parseMode: parseMode,
             cancellationToken: ResolveCancellationToken(cancellationToken));
+    }
+
+    private Task<Message> SendFormattedTextAsync(
+        TelegramFormattedText text,
+        ReplyMarkup? replyMarkup,
+        bool replyToCurrentMessage,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        return SendTextAsync(
+            text.Text,
+            replyMarkup,
+            replyToCurrentMessage,
+            cancellationToken,
+            text.ParseMode);
     }
 
     public Task<bool> DeleteAsync(CancellationToken cancellationToken = default)

--- a/src/TeleFlow.Framework/MessageActions.cs
+++ b/src/TeleFlow.Framework/MessageActions.cs
@@ -1,7 +1,7 @@
+using TeleFlow.Telegram.Formatting;
 using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Types;
-using TeleFlow.Telegram.Formatting;
 
 namespace TeleFlow.Telegram;
 

--- a/src/TeleFlow.Telegram.Client/Formatting/TelegramFormattedText.cs
+++ b/src/TeleFlow.Telegram.Client/Formatting/TelegramFormattedText.cs
@@ -1,0 +1,27 @@
+namespace TeleFlow.Telegram.Formatting;
+
+/// <summary>
+/// Represents Telegram text rendered with an explicit Bot API parse mode.
+/// Instances are created by the safe HTML and MarkdownV2 builders, then passed
+/// to framework context helpers or unwrapped explicitly for generated Telegram client methods.
+/// </summary>
+public sealed class TelegramFormattedText
+{
+    internal TelegramFormattedText(string text, TelegramParseMode parseMode)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+
+        Text = text;
+        ParseMode = parseMode;
+    }
+
+    /// <summary>
+    /// Gets the rendered text sent to Telegram.
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// Gets the explicit Bot API parse mode used to interpret <see cref="Text"/>.
+    /// </summary>
+    public TelegramParseMode ParseMode { get; }
+}

--- a/src/TeleFlow.Telegram.Client/Formatting/TelegramHtml.cs
+++ b/src/TeleFlow.Telegram.Client/Formatting/TelegramHtml.cs
@@ -1,0 +1,26 @@
+namespace TeleFlow.Telegram.Formatting;
+
+/// <summary>
+/// Creates safe HTML-formatted Telegram text for normal Bot API messages.
+/// Plain values passed to the returned builder are escaped automatically.
+/// </summary>
+public static class TelegramHtml
+{
+    /// <summary>
+    /// Creates a builder that renders Telegram-compatible HTML.
+    /// </summary>
+    public static TelegramTextBuilder Create()
+    {
+        return new TelegramTextBuilder(TelegramHtmlTextRenderer.Instance);
+    }
+
+    /// <summary>
+    /// Creates an HTML formatted-text value from reviewed static markup.
+    /// This bypasses escaping and structural validation and must never receive user-controlled input.
+    /// </summary>
+    public static TelegramFormattedText UnsafeMarkup(string markup)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markup);
+        return new TelegramFormattedText(markup, TelegramParseMode.Html);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Formatting/TelegramMarkdownV2.cs
+++ b/src/TeleFlow.Telegram.Client/Formatting/TelegramMarkdownV2.cs
@@ -1,0 +1,26 @@
+namespace TeleFlow.Telegram.Formatting;
+
+/// <summary>
+/// Creates safe MarkdownV2-formatted Telegram text for normal Bot API messages.
+/// Plain values passed to the returned builder are escaped automatically.
+/// </summary>
+public static class TelegramMarkdownV2
+{
+    /// <summary>
+    /// Creates a builder that renders Telegram-compatible MarkdownV2.
+    /// </summary>
+    public static TelegramTextBuilder Create()
+    {
+        return new TelegramTextBuilder(TelegramMarkdownV2TextRenderer.Instance);
+    }
+
+    /// <summary>
+    /// Creates a MarkdownV2 formatted-text value from reviewed static markup.
+    /// This bypasses escaping and structural validation and must never receive user-controlled input.
+    /// </summary>
+    public static TelegramFormattedText UnsafeMarkup(string markup)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markup);
+        return new TelegramFormattedText(markup, TelegramParseMode.MarkdownV2);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Formatting/TelegramTextBuilder.cs
+++ b/src/TeleFlow.Telegram.Client/Formatting/TelegramTextBuilder.cs
@@ -1,0 +1,497 @@
+using System.Text;
+
+namespace TeleFlow.Telegram.Formatting;
+
+/// <summary>
+/// Composes safe formatted text for one explicit Telegram Bot API parse mode.
+/// The builder escapes plain values and keeps rendered fragments separate from
+/// application strings, preventing accidental double escaping during composition.
+/// </summary>
+public sealed class TelegramTextBuilder
+{
+    private readonly TelegramTextRenderer _renderer;
+    private readonly StringBuilder _content = new();
+
+    internal TelegramTextBuilder(TelegramTextRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+        _renderer = renderer;
+    }
+
+    /// <summary>
+    /// Appends plain text after escaping it for the selected parse mode.
+    /// </summary>
+    public TelegramTextBuilder Text(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        _content.Append(_renderer.EscapeText(text));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a line break.
+    /// </summary>
+    public TelegramTextBuilder LineBreak()
+    {
+        _content.Append('\n');
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a formatted value that uses the same parse mode as this builder.
+    /// </summary>
+    public TelegramTextBuilder Append(TelegramFormattedText text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        if (text.ParseMode != _renderer.ParseMode)
+        {
+            throw new InvalidOperationException(
+                $"Formatted text with parse mode '{text.ParseMode}' cannot be appended to a builder using '{_renderer.ParseMode}'.");
+        }
+
+        _content.Append(text.Text);
+        return this;
+    }
+
+    /// <summary>
+    /// Appends bold text.
+    /// </summary>
+    public TelegramTextBuilder Bold(string text)
+    {
+        return AppendWrapped(text, _renderer.Bold);
+    }
+
+    /// <summary>
+    /// Appends bold nested content.
+    /// </summary>
+    public TelegramTextBuilder Bold(Action<TelegramTextBuilder> content)
+    {
+        return AppendNested(content, _renderer.Bold);
+    }
+
+    /// <summary>
+    /// Appends italic text.
+    /// </summary>
+    public TelegramTextBuilder Italic(string text)
+    {
+        return AppendWrapped(text, _renderer.Italic);
+    }
+
+    /// <summary>
+    /// Appends italic nested content.
+    /// </summary>
+    public TelegramTextBuilder Italic(Action<TelegramTextBuilder> content)
+    {
+        return AppendNested(content, _renderer.Italic);
+    }
+
+    /// <summary>
+    /// Appends underlined text.
+    /// </summary>
+    public TelegramTextBuilder Underline(string text)
+    {
+        return AppendWrapped(text, _renderer.Underline);
+    }
+
+    /// <summary>
+    /// Appends underlined nested content.
+    /// </summary>
+    public TelegramTextBuilder Underline(Action<TelegramTextBuilder> content)
+    {
+        return AppendNested(content, _renderer.Underline);
+    }
+
+    /// <summary>
+    /// Appends strike-through text.
+    /// </summary>
+    public TelegramTextBuilder Strikethrough(string text)
+    {
+        return AppendWrapped(text, _renderer.Strikethrough);
+    }
+
+    /// <summary>
+    /// Appends strike-through nested content.
+    /// </summary>
+    public TelegramTextBuilder Strikethrough(Action<TelegramTextBuilder> content)
+    {
+        return AppendNested(content, _renderer.Strikethrough);
+    }
+
+    /// <summary>
+    /// Appends spoiler text.
+    /// </summary>
+    public TelegramTextBuilder Spoiler(string text)
+    {
+        return AppendWrapped(text, _renderer.Spoiler);
+    }
+
+    /// <summary>
+    /// Appends spoiler nested content.
+    /// </summary>
+    public TelegramTextBuilder Spoiler(Action<TelegramTextBuilder> content)
+    {
+        return AppendNested(content, _renderer.Spoiler);
+    }
+
+    /// <summary>
+    /// Appends inline code. Nested Telegram entities are intentionally not supported inside code.
+    /// </summary>
+    public TelegramTextBuilder Code(string text)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        _content.Append(_renderer.Code(text));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a preformatted block. Nested Telegram entities are intentionally not supported inside the block.
+    /// </summary>
+    public TelegramTextBuilder Pre(string text, string? language = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+
+        if (language is { Length: 0 })
+        {
+            throw new ArgumentException("Preformatted language must be null or non-empty.", nameof(language));
+        }
+
+        _content.Append(_renderer.Pre(text, language));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a link with an escaped label and target.
+    /// </summary>
+    public TelegramTextBuilder Link(Uri uri, string label)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        ArgumentException.ThrowIfNullOrEmpty(label);
+
+        if (!uri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("Telegram links must use an absolute URI.", nameof(uri));
+        }
+
+        _content.Append(_renderer.Link(uri.OriginalString, label));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a Telegram user mention with an escaped label.
+    /// </summary>
+    public TelegramTextBuilder Mention(long userId, string label)
+    {
+        if (userId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(userId), userId, "Telegram user id must be positive.");
+        }
+
+        ArgumentException.ThrowIfNullOrEmpty(label);
+        _content.Append(_renderer.Mention(userId, label));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a block quote. Nested entities are intentionally not supported inside the quote.
+    /// </summary>
+    public TelegramTextBuilder BlockQuote(string text, bool expandable = false)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        _content.Append(_renderer.BlockQuote(text, expandable));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a custom emoji with a required fallback emoji.
+    /// Telegram may show the fallback in notifications, forwards, and unsupported clients.
+    /// </summary>
+    public TelegramTextBuilder CustomEmoji(string customEmojiId, string fallbackEmoji)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(customEmojiId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fallbackEmoji);
+        _content.Append(_renderer.CustomEmoji(customEmojiId, fallbackEmoji));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds an immutable value for framework helpers or explicit generated-client arguments.
+    /// </summary>
+    public TelegramFormattedText Build()
+    {
+        var text = _content.ToString();
+
+        if (text.Length == 0)
+        {
+            throw new InvalidOperationException("Formatted text must not be empty.");
+        }
+
+        return new TelegramFormattedText(text, _renderer.ParseMode);
+    }
+
+    private TelegramTextBuilder AppendWrapped(string text, Func<string, string> format)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        _content.Append(format(_renderer.EscapeText(text)));
+        return this;
+    }
+
+    private TelegramTextBuilder AppendNested(
+        Action<TelegramTextBuilder> content,
+        Func<string, string> format)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var nested = new TelegramTextBuilder(_renderer);
+        content(nested);
+        var nestedText = nested._content.ToString();
+
+        if (nestedText.Length == 0)
+        {
+            throw new InvalidOperationException("Formatted nested content must not be empty.");
+        }
+
+        _content.Append(format(nestedText));
+        return this;
+    }
+}
+
+/// <summary>
+/// Renders the shared safe formatting vocabulary for one Telegram parse mode.
+/// It is intentionally local to the client package and has no framework or transport dependency.
+/// </summary>
+internal abstract class TelegramTextRenderer
+{
+    public abstract TelegramParseMode ParseMode { get; }
+
+    public abstract string EscapeText(string text);
+
+    public abstract string Bold(string text);
+
+    public abstract string Italic(string text);
+
+    public abstract string Underline(string text);
+
+    public abstract string Strikethrough(string text);
+
+    public abstract string Spoiler(string text);
+
+    public abstract string Code(string text);
+
+    public abstract string Pre(string text, string? language);
+
+    public abstract string Link(string uri, string label);
+
+    public abstract string Mention(long userId, string label);
+
+    public abstract string BlockQuote(string text, bool expandable);
+
+    public abstract string CustomEmoji(string customEmojiId, string fallbackEmoji);
+}
+
+/// <summary>
+/// Renders safe Telegram HTML fragments for normal Bot API text messages.
+/// </summary>
+internal sealed class TelegramHtmlTextRenderer : TelegramTextRenderer
+{
+    public static TelegramHtmlTextRenderer Instance { get; } = new();
+
+    public override TelegramParseMode ParseMode => TelegramParseMode.Html;
+
+    public override string EscapeText(string text)
+    {
+        return text
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+    }
+
+    public override string Bold(string text) => $"<b>{text}</b>";
+
+    public override string Italic(string text) => $"<i>{text}</i>";
+
+    public override string Underline(string text) => $"<u>{text}</u>";
+
+    public override string Strikethrough(string text) => $"<s>{text}</s>";
+
+    public override string Spoiler(string text) => $"<tg-spoiler>{text}</tg-spoiler>";
+
+    public override string Code(string text) => $"<code>{EscapeText(text)}</code>";
+
+    public override string Pre(string text, string? language)
+    {
+        var escapedText = EscapeText(text);
+
+        if (language is null)
+        {
+            return $"<pre>{escapedText}</pre>";
+        }
+
+        ValidateLanguage(language);
+        return $"<pre><code class=\"language-{EscapeAttribute(language)}\">{escapedText}</code></pre>";
+    }
+
+    public override string Link(string uri, string label)
+    {
+        return $"<a href=\"{EscapeAttribute(uri)}\">{EscapeText(label)}</a>";
+    }
+
+    public override string Mention(long userId, string label)
+    {
+        return Link($"tg://user?id={userId}", label);
+    }
+
+    public override string BlockQuote(string text, bool expandable)
+    {
+        return expandable
+            ? $"<blockquote expandable>{EscapeText(text)}</blockquote>"
+            : $"<blockquote>{EscapeText(text)}</blockquote>";
+    }
+
+    public override string CustomEmoji(string customEmojiId, string fallbackEmoji)
+    {
+        return $"<tg-emoji emoji-id=\"{EscapeAttribute(customEmojiId)}\">{EscapeText(fallbackEmoji)}</tg-emoji>";
+    }
+
+    private static string EscapeAttribute(string value)
+    {
+        return value
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal);
+    }
+
+    private static void ValidateLanguage(string language)
+    {
+        if (language.Any(static character =>
+                !char.IsAsciiLetterOrDigit(character) &&
+                character is not '-' and not '_'))
+        {
+            throw new ArgumentException(
+                "Preformatted language may contain only ASCII letters, digits, '-' and '_'.",
+                nameof(language));
+        }
+    }
+}
+
+/// <summary>
+/// Renders safe Telegram MarkdownV2 fragments for normal Bot API text messages.
+/// </summary>
+internal sealed class TelegramMarkdownV2TextRenderer : TelegramTextRenderer
+{
+    private const string ReservedCharacters = "_*[]()~`>#+-=|{}.!\\";
+
+    public static TelegramMarkdownV2TextRenderer Instance { get; } = new();
+
+    public override TelegramParseMode ParseMode => TelegramParseMode.MarkdownV2;
+
+    public override string EscapeText(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+
+        foreach (var character in text)
+        {
+            if (ReservedCharacters.Contains(character))
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+
+    public override string Bold(string text) => $"*{text}*";
+
+    public override string Italic(string text) => $"_{text}_";
+
+    public override string Underline(string text) => $"__{text}__";
+
+    public override string Strikethrough(string text) => $"~{text}~";
+
+    public override string Spoiler(string text) => $"||{text}||";
+
+    public override string Code(string text) => $"`{EscapeCode(text)}`";
+
+    public override string Pre(string text, string? language)
+    {
+        if (language is not null)
+        {
+            ValidateLanguage(language);
+        }
+
+        return language is null
+            ? $"```\n{EscapeCode(text)}\n```"
+            : $"```{language}\n{EscapeCode(text)}\n```";
+    }
+
+    public override string Link(string uri, string label)
+    {
+        return $"[{EscapeText(label)}]({EscapeLinkTarget(uri)})";
+    }
+
+    public override string Mention(long userId, string label)
+    {
+        return Link($"tg://user?id={userId}", label);
+    }
+
+    public override string BlockQuote(string text, bool expandable)
+    {
+        var lines = text
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n');
+        var builder = new StringBuilder(text.Length + lines.Length * 2);
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            builder.Append("> ");
+            builder.Append(EscapeText(lines[index]));
+
+            if (index == lines.Length - 1 && expandable)
+            {
+                builder.Append("||");
+            }
+
+            if (index < lines.Length - 1)
+            {
+                builder.Append('\n');
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    public override string CustomEmoji(string customEmojiId, string fallbackEmoji)
+    {
+        return $"![{EscapeText(fallbackEmoji)}](tg://emoji?id={EscapeLinkTarget(customEmojiId)})";
+    }
+
+    private static string EscapeCode(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("`", "\\`", StringComparison.Ordinal);
+    }
+
+    private static string EscapeLinkTarget(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace(")", "\\)", StringComparison.Ordinal);
+    }
+
+    private static void ValidateLanguage(string language)
+    {
+        if (language.Any(static character =>
+                !char.IsAsciiLetterOrDigit(character) &&
+                character is not '-' and not '_'))
+        {
+            throw new ArgumentException(
+                "Preformatted language may contain only ASCII letters, digits, '-' and '_'.",
+                nameof(language));
+        }
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/TelegramFormattedTextTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramFormattedTextTests.cs
@@ -1,0 +1,139 @@
+using TeleFlow.Telegram;
+using TeleFlow.Telegram.Formatting;
+
+namespace TeleFlow.ArchitectureTests;
+
+public sealed class TelegramFormattedTextTests
+{
+    [Fact]
+    public void TelegramHtmlBuilder_EscapesPlainTextAndAttributes()
+    {
+        var text = TelegramHtml.Create()
+            .Text("A < & >")
+            .Bold("x < y")
+            .Link(new Uri("https://example.com/?a=1&b=2"), "A & B")
+            .CustomEmoji("123", "💎")
+            .Build();
+
+        Assert.Equal(TelegramParseMode.Html, text.ParseMode);
+        Assert.Equal(
+            "A &lt; &amp; &gt;<b>x &lt; y</b><a href=\"https://example.com/?a=1&amp;b=2\">A &amp; B</a><tg-emoji emoji-id=\"123\">💎</tg-emoji>",
+            text.Text);
+    }
+
+    [Fact]
+    public void TelegramHtmlBuilder_ComposesNestedContentWithoutDoubleEscaping()
+    {
+        var text = TelegramHtml.Create()
+            .Bold(content => content
+                .Text("Active ")
+                .Spoiler("secret & more"))
+            .Build();
+
+        Assert.Equal("<b>Active <tg-spoiler>secret &amp; more</tg-spoiler></b>", text.Text);
+    }
+
+    [Fact]
+    public void TelegramMarkdownV2Builder_EscapesReservedTextCharacters()
+    {
+        var text = TelegramMarkdownV2.Create()
+            .Text("_*[]()~`>#+-=|{}.!\\")
+            .Bold("A * B")
+            .Text(" ")
+            .Link(new Uri("https://example.com/a_(b)"), "Open [profile]")
+            .Text(" ")
+            .CustomEmoji("123", "💎")
+            .Build();
+
+        Assert.Equal(TelegramParseMode.MarkdownV2, text.ParseMode);
+        Assert.Equal(
+            "\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!\\\\*A \\* B* [Open \\[profile\\]](https://example.com/a_(b\\)) ![💎](tg://emoji?id=123)",
+            text.Text);
+    }
+
+    [Fact]
+    public void TelegramMarkdownV2Builder_FormatsCodeAndPreformattedText()
+    {
+        var text = TelegramMarkdownV2.Create()
+            .Code("a`b\\c")
+            .LineBreak()
+            .Pre("x`y\\z", language: "csharp")
+            .Build();
+
+        Assert.Equal("`a\\`b\\\\c`\n```csharp\nx\\`y\\\\z\n```", text.Text);
+    }
+
+    [Fact]
+    public void TelegramFormattedTextBuilder_FormatsBlockQuotesAndMentions()
+    {
+        var html = TelegramHtml.Create()
+            .BlockQuote("First\nSecond", expandable: true)
+            .Mention(42, "User & Co")
+            .Build();
+        var markdown = TelegramMarkdownV2.Create()
+            .BlockQuote("First\nSecond", expandable: true)
+            .Mention(42, "User & Co")
+            .Build();
+
+        Assert.Equal(
+            "<blockquote expandable>First\nSecond</blockquote><a href=\"tg://user?id=42\">User &amp; Co</a>",
+            html.Text);
+        Assert.Equal(
+            "> First\n> Second||[User & Co](tg://user?id=42)",
+            markdown.Text);
+    }
+
+    [Fact]
+    public void TelegramFormattedTextBuilder_RejectsCrossModeComposition()
+    {
+        var html = TelegramHtml.Create()
+            .Bold("HTML")
+            .Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            TelegramMarkdownV2.Create().Append(html));
+
+        Assert.Contains("parse mode", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TelegramFormattedTextBuilder_RequiresContent()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            TelegramHtml.Create().Build());
+
+        Assert.Contains("empty", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(" csharp")]
+    [InlineData("c sharp")]
+    [InlineData("c#")]
+    public void TelegramFormattedTextBuilder_RejectsUnsafePreformattedLanguage(string language)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            TelegramHtml.Create().Pre("code", language));
+
+        Assert.Contains("language", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void TelegramFormattedTextBuilder_RejectsMissingCustomEmojiValues(string value)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TelegramHtml.Create().CustomEmoji(value, "💎"));
+        Assert.Throws<ArgumentException>(() =>
+            TelegramHtml.Create().CustomEmoji("123", value));
+    }
+
+    [Fact]
+    public void TelegramHtml_UnsafeMarkup_IsExplicitAndPreserved()
+    {
+        var text = TelegramHtml.UnsafeMarkup("<b>Trusted template</b>");
+
+        Assert.Equal(TelegramParseMode.Html, text.ParseMode);
+        Assert.Equal("<b>Trusted template</b>", text.Text);
+    }
+}

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -14,6 +14,7 @@ using TeleFlow.Framework.Callbacks;
 using TeleFlow.Framework.Dispatching;
 using TeleFlow.Framework.Updates;
 using TeleFlow.Telegram;
+using TeleFlow.Telegram.Formatting;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Methods;
 using TeleFlow.Telegram.Schema.Types;
@@ -3087,6 +3088,40 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task MessageAnswerAsync_UsesFormattedTextModeInsteadOfClientDefault()
+    {
+        var fakeClient = CreateRecordingMessageClient<SendMessage>();
+        fakeClient.Defaults.ParseMode = TelegramParseMode.MarkdownV2;
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateScopedMessageUpdateContext(serviceProvider);
+        var text = TelegramHtml.Create().Bold("formatted").Build();
+
+        await context.GetMessageContext().Message.AnswerAsync(text);
+
+        var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
+        Assert.Equal("<b>formatted</b>", sendMessage.Text);
+        Assert.Equal(TelegramParseMode.Html.Value, sendMessage.ParseMode);
+    }
+
+    [Fact]
+    public async Task MessageReplyAsync_UsesFormattedTextModeAndReplyTarget()
+    {
+        var fakeClient = CreateRecordingMessageClient<SendMessage>();
+        fakeClient.Defaults.ParseMode = TelegramParseMode.Html;
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateScopedMessageUpdateContext(serviceProvider);
+        var text = TelegramMarkdownV2.Create().Bold("formatted").Build();
+
+        await context.GetMessageContext().Message.ReplyAsync(text);
+
+        var sendMessage = Assert.IsType<SendMessage>(fakeClient.Methods.Single());
+        Assert.Equal(10L, sendMessage.ReplyParameters?.MessageId);
+        Assert.Equal(TelegramParseMode.MarkdownV2.Value, sendMessage.ParseMode);
+    }
+
+    [Fact]
     public async Task MessageReplyTextAsync_RemainsObsoleteAliasForReplyAsync()
     {
         var fakeClient = new RecordingTelegramClient
@@ -3837,6 +3872,51 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task CallbackFormattedEditText_UsesExplicitModeForEphemeralMessageTargets()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                EditEphemeralMessageText => true,
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+        fakeClient.Defaults.ParseMode = TelegramParseMode.MarkdownV2;
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = new UpdateContext(
+            serviceProvider,
+            new TelegramUpdatePayload(
+                new Update
+                {
+                    UpdateId = 1,
+                    CallbackQuery = new CallbackQuery
+                    {
+                        Id = "callback-1",
+                        From = new User { Id = 5, IsBot = false, FirstName = "User" },
+                        Message = MaybeInaccessibleMessage.From(
+                            new Message
+                            {
+                                MessageId = 0,
+                                EphemeralMessageId = 40,
+                                ReceiverUser = new User { Id = 5, IsBot = false, FirstName = "User" },
+                                Date = 1,
+                                Chat = new Chat { Id = 100, Type = "supergroup" }
+                            }),
+                        ChatInstance = "chat-instance"
+                    }
+                }));
+        var text = TelegramHtml.Create().Bold("formatted").Build();
+
+        await context.GetCallbackQueryContext().Callback.EditTextAsync(text);
+
+        var edit = Assert.IsType<EditEphemeralMessageText>(fakeClient.Methods.Single());
+        Assert.Equal("<b>formatted</b>", edit.Text);
+        Assert.Equal(TelegramParseMode.Html.Value, edit.ParseMode);
+    }
+
+    [Fact]
     public async Task CallbackEditText_CanSendInlineKeyboardWithTypedCallbackData()
     {
         var fakeClient = new RecordingTelegramClient
@@ -3874,6 +3954,30 @@ public sealed class TelegramRuntimeIntegrationTests
         var edit = Assert.IsType<EditMessageText>(fakeClient.Methods.Single());
         Assert.Equal("inline-42", edit.InlineMessageId);
         Assert.Equal("del:99", edit.ReplyMarkup?.InlineKeyboard[0][0].CallbackData);
+    }
+
+    [Fact]
+    public async Task CallbackEditTextAsync_UsesFormattedTextMode()
+    {
+        var fakeClient = new RecordingTelegramClient
+        {
+            Handler = method => method switch
+            {
+                EditMessageText => MessageBoolean.From(true),
+                _ => throw new InvalidOperationException("Unexpected method.")
+            }
+        };
+        fakeClient.Defaults.ParseMode = TelegramParseMode.Html;
+
+        using var serviceProvider = CreateTelegramServiceProvider(clientOverride: fakeClient);
+        var context = CreateCallbackQueryUpdateContext(serviceProvider);
+        var text = TelegramMarkdownV2.Create().Bold("formatted").Build();
+
+        await context.GetCallbackQueryContext().Callback.EditTextAsync(text);
+
+        var edit = Assert.IsType<EditMessageText>(fakeClient.Methods.Single());
+        Assert.Equal("*formatted*", edit.Text);
+        Assert.Equal(TelegramParseMode.MarkdownV2.Value, edit.ParseMode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add safe HTML and MarkdownV2 builders that produce `TelegramFormattedText` with an explicit parse mode
- support escaped text, nested style composition, code/pre blocks, links, user mentions, block quotes, and custom emoji fallbacks
- forward formatted text through `MessageActions` and `CallbackQueryActions`, including callback edits of ephemeral messages, without changing existing `string` overload semantics
- add English and Russian documentation with API boundaries and direct-client guidance for entities and Rich Messages

## Touched Runtime Path

- `MessageActions` and `CallbackQueryActions` receive narrow formatted-text overloads only.
- Existing raw `string` calls still use their previous client-default behavior. No handler routing, generated registration, or transport behavior changes.

## Verification

- [x] Tests added or updated for behavior changes.
- [x] Documentation updated for the public API and constraints.
- [x] Focused formatted-text tests passed: 17/17.
- [x] Full `TeleFlow.ArchitectureTests` passed: 788/788.
- [x] `pwsh -NoProfile -File .\eng\verify-strict-analyzers.ps1 -Configuration Release -NoRestore` passed.
- [x] `python -m mkdocs build --strict` passed.
- [x] `git diff --check` passed.

## Risk

The feature is additive. It deliberately covers normal `text` plus `parse_mode` only; advanced `MessageEntity` and Bot API Rich Message request shapes stay on the direct generated-client path.

Closes #152