### PR TITLE
docs(release): prepare 1.0.0-alpha.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
+## 1.0.0-alpha.13 - 2026-07-31
+
 ### Added
 
 - Added `[SenderChatType(...)]` for messages sent on behalf of a channel or another chat.
@@ -27,6 +29,14 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 - Telegram update diagnostics now classify subscription updates instead of reporting them as unknown.
 - Fluent `DATETIME(...)` now formats `DateOnly` and `TimeOnly` without exceptions and maps combined `short` and `long` styles to culture-specific .NET patterns.
 - Dynamic HTML localization arguments now encode quote delimiters and cannot escape quoted markup attributes.
+
+### Breaking Changes
+
+- `[FromBot(false)]` is no longer supported. Use parameterless `[FromUser]` for handlers that accept any non-bot Telegram user.
+- `[FromUser(userId)]` now matches only non-bot users. Handlers that intentionally accept a bot account by id must use `[FromBot(botId)]`.
+- `TelegramChatType.Sender` has been removed because it is not a valid Telegram `Chat.type`. Use `[SenderChatType(...)]` with the actual sender-chat type when matching messages sent on behalf of a chat.
+
+This release remains aligned with Telegram Bot API 10.2. Update all TeleFlow packages used by an application to `1.0.0-alpha.13` together.
 
 ## 1.0.0-alpha.12 - 2026-07-22
 


### PR DESCRIPTION
## Summary

- move the completed `Unreleased` changes into the `1.0.0-alpha.13` changelog entry;
- document migration requirements for the new `[FromUser]` / `[FromBot]` semantics and removal of `TelegramChatType.Sender`;
- record Telegram Bot API 10.2 alignment and require applications to upgrade the package set together.

## Release contents

- formatted Telegram text builders and escaping helpers;
- optional locale-resolution and Fluent localization packages;
- explicit sender-user, sender-bot, and sender-chat filter semantics;
- canonical Unicode matching for exact and template command routes;
- CI coverage report and pull-request workflow improvements.

## Verification

- `pwsh -NoProfile -File .\eng\verify-release.ps1 -PackageVersion 1.0.0-alpha.13 -Configuration Release -OutputDirectory .\artifacts\release-packages\1.0.0-alpha.13-verified`
- Release build and strict analyzers: 0 warnings, 0 errors
- full test suite passed
- 15 runtime/tooling NuGet packages and 14 symbol packages produced
- package metadata and expected package set validation passed
- new i18n package dependency graph inspected
- `git diff --check`