### PR TITLE
fix(transport): isolate incompatible Telegram updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
+### Added
+
+- Added `ITelegramUpdateDecodeFailurePolicy` with explicit `Stop` and `Skip` decisions shared by long polling and webhooks. Applications can durably quarantine a raw update before allowing transport acknowledgement.
+
+### Changed
+
+- Refreshed the generated Telegram schema and client surface for Telegram Bot API 10.2.
+- Long polling now decodes `getUpdates` results one update at a time, retries only transient transport/API failures, and stops by default on deterministic schema decode failures.
+- Raw and framework webhook transports now distinguish malformed requests from valid Telegram updates that do not match the installed schema.
+
+### Fixed
+
+- Removed the invalid generated `"one"` literal constraint from rich-message ordered-list item types. All Telegram-documented list label types (`a`, `A`, `i`, `I`, and `1`) now deserialize correctly.
+
 ## 1.0.0-alpha.13 - 2026-07-31
 
 ### Added

--- a/docs/en/features/errors-and-diagnostics.md
+++ b/docs/en/features/errors-and-diagnostics.md
@@ -107,8 +107,8 @@ TeleFlow uses log levels deliberately:
 | --- | --- |
 | `Information` | Runtime lifecycle events such as polling start, connected, stopped, and coarse transport status. |
 | `Debug` | Per-update diagnostics: handler matching, handler completion, route misses, filter rejections, webhook update acceptance, and request timings. |
-| `Warning` | Recoverable or expected runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure, and rate-limit rejection. |
-| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures, and update processing failures. |
+| `Warning` | Recoverable or expected runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure, rate-limit rejection, and schema decode failures explicitly skipped by application policy. |
+| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures, update processing failures, and schema decode failures stopped by policy. |
 
 Normal successful update processing is not logged at `Information`.
 
@@ -136,6 +136,9 @@ By default, framework logs do not include:
 - arbitrary user-provided values.
 
 Safe metadata can include update id, update type, handler, route, module, scene, exception type, HTTP status code, Telegram method name, retry-after, limiter type, and developer-controlled policy name.
+
+Schema decode diagnostics include `update_id`, JSON path, transport decision,
+and a SHA-256 payload fingerprint. They never include the raw update payload.
 
 Logging providers remain application infrastructure. If an application configures a provider or sink with its own unsafe processing rules, that is outside TeleFlow's runtime contract.
 

--- a/docs/en/reference/options-and-extension-points.md
+++ b/docs/en/reference/options-and-extension-points.md
@@ -131,10 +131,14 @@ services.AddTelegramRequestExecutor<MyExecutor>();
 services.AddTelegramHttpTransport(httpClient);
 services.AddTelegramJsonOptions(options => { });
 services.AddDeepLinkPayloadSerializer<MySerializer>();
+services.AddTelegramUpdateDecodeFailurePolicy<MyDurableQuarantinePolicy>();
 ```
 
 ## Guidance
 
 Replace extension points only when the application owns the behavior. Keep defaults until there is a concrete reason to change them.
+
+The default update decode policy is `Stop`. Replace it only when the
+application can durably quarantine the raw update before returning `Skip`.
 
 Use lifecycle tasks for short application startup and shutdown work. Do not register `ITeleFlowStartupTask` or `ITeleFlowShutdownTask` directly in `IServiceCollection`; TeleFlow ignores direct lifecycle service registrations and fails clearly during application build. Register tasks through `AddTeleFlowStartupTask<TTask>()` and `AddTeleFlowShutdownTask<TTask>()` so they are resolved from the correct lifecycle scope.

--- a/docs/en/reference/update-failure-contract.md
+++ b/docs/en/reference/update-failure-contract.md
@@ -51,10 +51,60 @@ same recovery decision that applies to the selected route.
 | An error handler returns `Unhandled` and no later handler handles the error | Failure propagates | Offset does not advance | Endpoint failure propagates |
 | Handler, middleware, or error handler throws | Failure propagates | Offset does not advance | Endpoint failure propagates |
 | Application cancellation | Processing stops | Offset does not advance | Cancellation semantics apply |
+| A valid update does not match the installed schema and decode policy returns `Stop` | Processing does not start | Offset does not advance; polling stops without retrying the deterministic failure | `500 Internal Server Error` |
+| Decode policy durably quarantines the update and returns `Skip` | Processing does not start | Offset advances past that update | `200 OK` |
+| Decode policy throws or is cancelled | Failure propagates | Offset does not advance | Endpoint failure propagates |
 
 For webhooks, TeleFlow does not manufacture a success response after an
 unhandled failure. ASP.NET Core returns the failure response and Telegram's
 delivery mechanism decides whether to redeliver it.
+
+## Telegram Schema Decode Failures
+
+Long polling and webhooks decode syntactically valid Telegram updates through
+the same `ITelegramUpdateDecodeFailurePolicy`. The default policy returns
+`Stop`. TeleFlow does not assume that an update is disposable merely because
+the installed schema cannot understand it.
+
+Applications that prioritize availability can replace the policy:
+
+```csharp
+public sealed class DurableQuarantinePolicy(IUpdateQuarantineStore store)
+    : ITelegramUpdateDecodeFailurePolicy
+{
+    public async ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+        TelegramUpdateDecodeFailure failure,
+        CancellationToken ct)
+    {
+        await store.UpsertAsync(
+            failure.UpdateId,
+            failure.Transport,
+            failure.RawPayloadJson,
+            failure.PayloadSha256,
+            failure.Exception.JsonPath,
+            ct);
+
+        return TelegramUpdateDecodeFailureDecision.Skip;
+    }
+}
+
+services.AddTelegramUpdateDecodeFailurePolicy<DurableQuarantinePolicy>();
+```
+
+`Skip` explicitly acknowledges data loss. Return it only after the raw payload
+and diagnostics have been committed durably. If quarantine storage fails,
+throw or return `Stop`; the transport will not acknowledge the update. The
+policy can run again before a later polling request confirms the new offset, so
+its write must be idempotent by bot identity and `update_id`.
+
+The raw payload can contain message text, user data, payment data, or callback
+content. TeleFlow never writes it to logs. Application quarantine storage must
+apply suitable access control and retention.
+
+Malformed webhook JSON and payloads without a valid `update_id` are rejected as
+invalid requests and do not enter this policy. A direct generated call such as
+`ITelegramClient.SendAsync(new GetUpdates())` also remains strict and atomic;
+per-update isolation belongs to the long-polling and webhook transport paths.
 
 ## Error Handlers Are The Explicit Recovery Point
 
@@ -106,6 +156,10 @@ honours bounded `429 retry_after` responses. Raw `getUpdates` has its own
 transient-failure backoff because it is an idempotent read. TeleFlow does not
 blindly retry all outgoing `network` or `5xx` failures: Telegram may have
 already completed a write before the client lost the response.
+
+Response-envelope and schema decode failures are deterministic and are not
+classified as transient polling failures. Retrying the same bytes with
+exponential backoff cannot repair a stale schema.
 
 ## Middleware Is A Different Boundary
 

--- a/docs/en/transports/long-polling.md
+++ b/docs/en/transports/long-polling.md
@@ -45,6 +45,13 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
 
 Long polling retries transient `getUpdates` failures with configurable backoff. If the Telegram client surfaces `TelegramRetryAfterException`, polling waits for the Telegram-provided retry delay instead of using the generic backoff delay. Handler failures are not swallowed. The offset advances only after successful update processing.
 
+Transient failures are network failures, Telegram `5xx`, and `retry_after`.
+Response-envelope and update schema decode failures are deterministic and are
+not retried. Updates in one successful `getUpdates` response are decoded
+individually, so an application can durably quarantine one incompatible update
+through `ITelegramUpdateDecodeFailurePolicy` without discarding valid neighbors.
+The default policy stops polling and preserves the offset.
+
 The exact acknowledgement outcome for handled route failures, middleware
 failures, cancellation, and automatic callback answers is defined by the
 [update failure and delivery contract](../reference/update-failure-contract.md).

--- a/docs/en/transports/raw-transports.md
+++ b/docs/en/transports/raw-transports.md
@@ -55,6 +55,14 @@ await foreach (var polled in polling.GetUpdatesAsync(cancellationToken: cancella
 
 `RunAsync(...)` advances the Telegram offset only after the handler completes successfully. `GetUpdatesAsync(...)` advances the offset only after `AcknowledgeAsync(...)`. If the update is not acknowledged, TeleFlow fails before requesting the next update. This prevents accidental update loss in queue/gateway scenarios.
 
+The default schema-decode policy is fail-closed: a valid Telegram update that
+cannot be decoded stops polling and does not enter transient retry backoff. To
+keep a gateway available, register an
+`ITelegramUpdateDecodeFailurePolicy` that durably quarantines
+`RawPayloadJson` and returns `Skip` only after the commit succeeds. The same
+policy is shared with raw and framework webhooks. See the
+[update failure contract](../reference/update-failure-contract.md).
+
 ## Raw Webhooks
 
 Install:
@@ -78,6 +86,11 @@ app.MapTelegramWebhook(
         options.SecretToken = webhookSecret;
     });
 ```
+
+Malformed JSON is rejected as an invalid request. A syntactically valid update
+with a known `update_id` but an incompatible schema enters the shared decode
+policy. `Stop` returns `500`; `Skip` returns `200` only after the policy
+completes successfully.
 
 ## Raw vs Framework
 

--- a/docs/en/transports/webhooks.md
+++ b/docs/en/transports/webhooks.md
@@ -62,6 +62,12 @@ builder.Services.AddWebhook(options =>
 
 The raw webhook layer validates the secret token and can reject invalid payloads.
 
+Malformed JSON and payloads without a valid `update_id` are rejected as invalid
+requests. If a syntactically valid Telegram update cannot be decoded by the
+installed schema, `ITelegramUpdateDecodeFailurePolicy` decides delivery:
+`Stop` returns `500`, while `Skip` returns `200` only after the policy completes.
+The default is `Stop`; use `Skip` only after durable quarantine.
+
 ## Deployment Checklist
 
 - Configure Telegram webhook URL outside the request handler.

--- a/docs/ru/features/errors-and-diagnostics.md
+++ b/docs/ru/features/errors-and-diagnostics.md
@@ -107,8 +107,8 @@ TeleFlow использует log levels осознанно:
 | --- | --- |
 | `Information` | Runtime lifecycle events: polling start, connected, stopped и coarse transport status. |
 | `Debug` | Per-update diagnostics: handler matching, handler completion, route misses, filter rejections, webhook update acceptance и request timings. |
-| `Warning` | Recoverable или ожидаемые runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure и rate-limit rejection. |
-| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures и update processing failures. |
+| `Warning` | Recoverable или ожидаемые runtime rejections: retry-after, invalid webhook secret, invalid webhook payload, callback payload decode failure, rate-limit rejection и schema decode failures, которые application policy явно пропустила. |
+| `Error` | Unhandled handler failures, Telegram request failures, webhook processing failures, update processing failures и schema decode failures, остановленные policy. |
 
 Обычная успешная обработка update не логируется на `Information`.
 
@@ -136,6 +136,9 @@ Framework logs используют статические framework-owned messa
 - arbitrary user-provided values.
 
 Безопасные metadata: update id, update type, handler, route, module, scene, exception type, HTTP status code, Telegram method name, retry-after, limiter type и developer-controlled policy name.
+
+Schema decode diagnostics содержат `update_id`, JSON path, решение transport и
+SHA-256 fingerprint payload. Raw update payload в лог не попадает.
 
 Logging providers остаются infrastructure приложения. Если приложение подключает provider или sink со своими unsafe processing rules, это находится вне runtime contract TeleFlow.
 

--- a/docs/ru/reference/options-and-extension-points.md
+++ b/docs/ru/reference/options-and-extension-points.md
@@ -131,10 +131,14 @@ services.AddTelegramRequestExecutor<MyExecutor>();
 services.AddTelegramHttpTransport(httpClient);
 services.AddTelegramJsonOptions(options => { });
 services.AddDeepLinkPayloadSerializer<MySerializer>();
+services.AddTelegramUpdateDecodeFailurePolicy<MyDurableQuarantinePolicy>();
 ```
 
 ## Рекомендации
 
 Replacement points заменяй только когда приложение владеет behavior. Держи defaults, пока нет конкретной причины их менять.
+
+Default update decode policy возвращает `Stop`. Заменяй её только когда
+приложение умеет durable-сохранить raw update до возврата `Skip`.
 
 Lifecycle tasks используй для короткой startup/shutdown работы приложения. Не регистрируй `ITeleFlowStartupTask` или `ITeleFlowShutdownTask` напрямую в `IServiceCollection`: TeleFlow не использует direct lifecycle service registrations и понятно падает во время application build. Регистрируй tasks через `AddTeleFlowStartupTask<TTask>()` и `AddTeleFlowShutdownTask<TTask>()`, чтобы они создавались из правильного lifecycle scope.

--- a/docs/ru/reference/update-failure-contract.md
+++ b/docs/ru/reference/update-failure-contract.md
@@ -47,10 +47,61 @@ execution**. Auto-answer выполняется после handler, но это 
 | Error handler вернул `Unhandled`, и дальше никто не обработал ошибку | Ошибка идёт выше | Offset не продвигается | Ошибка endpoint идёт выше |
 | Handler, middleware или error handler бросил exception | Ошибка идёт выше | Offset не продвигается | Ошибка endpoint идёт выше |
 | Application cancellation | Обработка останавливается | Offset не продвигается | Работает cancellation semantics |
+| Валидный update не соответствует установленной schema, а decode policy вернула `Stop` | Обработка не начинается | Offset не продвигается; polling останавливается без retry детерминированной ошибки | `500 Internal Server Error` |
+| Decode policy durable-сохранила update в quarantine и вернула `Skip` | Обработка не начинается | Offset продвигается через этот update | `200 OK` |
+| Decode policy бросила exception или была отменена | Ошибка идёт выше | Offset не продвигается | Ошибка endpoint идёт выше |
 
 Для webhook TeleFlow не подделывает успешный response после unhandled failure.
 ASP.NET Core возвращает failure response, а решение о повторной доставке остаётся
 у механизма доставки Telegram.
+
+## Ошибки Декодирования Telegram Schema
+
+Long polling и webhooks передают синтаксически валидные Telegram updates в одну
+`ITelegramUpdateDecodeFailurePolicy`. Default policy возвращает `Stop`.
+TeleFlow не считает update одноразовым только потому, что установленная schema
+не смогла его понять.
+
+Приложение, для которого availability важнее остановки, может заменить policy:
+
+```csharp
+public sealed class DurableQuarantinePolicy(IUpdateQuarantineStore store)
+    : ITelegramUpdateDecodeFailurePolicy
+{
+    public async ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+        TelegramUpdateDecodeFailure failure,
+        CancellationToken ct)
+    {
+        await store.UpsertAsync(
+            failure.UpdateId,
+            failure.Transport,
+            failure.RawPayloadJson,
+            failure.PayloadSha256,
+            failure.Exception.JsonPath,
+            ct);
+
+        return TelegramUpdateDecodeFailureDecision.Skip;
+    }
+}
+
+services.AddTelegramUpdateDecodeFailurePolicy<DurableQuarantinePolicy>();
+```
+
+`Skip` явно подтверждает потерю update. Возвращай его только после commit raw
+payload и diagnostics в durable storage. Если quarantine storage недоступен,
+бросай exception или возвращай `Stop`: transport не подтвердит update. Policy
+может быть вызвана повторно до следующего polling request, который подтвердит
+новый offset, поэтому запись должна быть idempotent по bot identity и
+`update_id`.
+
+Raw payload может содержать текст сообщения, данные пользователя, платёжные
+данные или callback content. TeleFlow никогда не пишет его в логи. Application
+quarantine должна иметь подходящие access control и retention.
+
+Невалидный webhook JSON и payload без корректного `update_id` считаются
+невалидными запросами и не попадают в эту policy. Прямой generated-вызов вроде
+`ITelegramClient.SendAsync(new GetUpdates())` тоже остаётся строгим и атомарным;
+изоляция отдельных updates принадлежит long-polling и webhook transport paths.
 
 ## Error Handlers Это Явная Точка Recovery
 
@@ -101,6 +152,10 @@ bounded `429 retry_after`. Raw `getUpdates` имеет собственный tr
 потому что это idempotent read. TeleFlow не retry-ит вслепую все outgoing
 `network` или `5xx` failures: Telegram мог уже выполнить write до того, как
 client потерял response.
+
+Ошибки response envelope и schema decode детерминированы и не считаются
+transient polling failures. Повторная десериализация тех же байтов с
+exponential backoff не исправляет устаревшую schema.
 
 ## Middleware Это Другая Граница
 

--- a/docs/ru/transports/long-polling.md
+++ b/docs/ru/transports/long-polling.md
@@ -45,6 +45,13 @@ options.AllowedUpdates = TelegramAllowedUpdates.Only(
 
 Long polling retry-ит transient `getUpdates` failures с настраиваемым backoff. Если Telegram client отдаёт `TelegramRetryAfterException`, polling ждёт Telegram-provided retry delay вместо обычной backoff delay. Handler failures не swallowing. Offset продвигается только после успешной обработки update.
 
+Transient failures здесь означают network failure, Telegram `5xx` и
+`retry_after`. Ошибки response envelope и update schema детерминированы и не
+retry-ятся. Updates из одного успешного `getUpdates` response декодируются по
+одному, поэтому приложение может durable-сохранить несовместимый update через
+`ITelegramUpdateDecodeFailurePolicy`, не теряя валидных соседей. Default policy
+останавливает polling и сохраняет offset.
+
 Точный исход acknowledgement для handled route failures, middleware failures,
 cancellation и automatic callback answers определён в
 [контракте ошибок и подтверждения update](../reference/update-failure-contract.md).

--- a/docs/ru/transports/raw-transports.md
+++ b/docs/ru/transports/raw-transports.md
@@ -55,6 +55,14 @@ await foreach (var polled in polling.GetUpdatesAsync(cancellationToken: cancella
 
 `RunAsync(...)` продвигает Telegram offset только после успешного завершения handler. `GetUpdatesAsync(...)` продвигает offset только после `AcknowledgeAsync(...)`. Если update не acknowledged, TeleFlow падает до запроса следующего update. Это защищает от случайной потери updates в queue/gateway сценариях.
 
+Default schema-decode policy работает fail-closed: валидный Telegram update,
+который не удалось декодировать, останавливает polling и не попадает в
+transient retry backoff. Для availability gateway зарегистрируй
+`ITelegramUpdateDecodeFailurePolicy`, которая durable-сохраняет
+`RawPayloadJson` и возвращает `Skip` только после успешного commit. Одна policy
+работает для raw/framework long polling и webhooks. Полный контракт описан в
+[контракте ошибок update](../reference/update-failure-contract.md).
+
 ## Raw webhooks
 
 Установка:
@@ -78,6 +86,11 @@ app.MapTelegramWebhook(
         options.SecretToken = webhookSecret;
     });
 ```
+
+Невалидный JSON отклоняется как invalid request. Синтаксически валидный update
+с известным `update_id`, но несовместимой schema попадает в общую decode policy.
+`Stop` возвращает `500`; `Skip` возвращает `200` только после успешного
+завершения policy.
 
 ## Raw vs framework
 

--- a/docs/ru/transports/webhooks.md
+++ b/docs/ru/transports/webhooks.md
@@ -62,6 +62,13 @@ builder.Services.AddWebhook(options =>
 
 Raw webhook layer валидирует secret token и может отклонять invalid payloads.
 
+Невалидный JSON и payload без корректного `update_id` отклоняются как invalid
+requests. Если синтаксически валидный Telegram update не декодируется
+установленной schema, доставкой управляет
+`ITelegramUpdateDecodeFailurePolicy`: `Stop` возвращает `500`, а `Skip`
+возвращает `200` только после успешного завершения policy. Default — `Stop`;
+используй `Skip` только после durable quarantine.
+
 ## Deployment checklist
 
 - Настраивай Telegram webhook URL вне request handler.

--- a/src/TeleFlow.Telegram.Client/ITelegramUpdateDecodeFailurePolicy.cs
+++ b/src/TeleFlow.Telegram.Client/ITelegramUpdateDecodeFailurePolicy.cs
@@ -1,0 +1,15 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Decides how Telegram transports handle an individual update that cannot be decoded by the installed schema.
+/// Returning <see cref="TelegramUpdateDecodeFailureDecision.Skip"/> acknowledges data loss and should happen only after durable quarantine succeeds.
+/// </summary>
+public interface ITelegramUpdateDecodeFailurePolicy
+{
+    /// <summary>
+    /// Returns the acknowledgement decision after any application-owned quarantine work completes.
+    /// </summary>
+    ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+        TelegramUpdateDecodeFailure failure,
+        CancellationToken cancellationToken = default);
+}

--- a/src/TeleFlow.Telegram.Client/Internal/ITelegramUpdateBatchReceiver.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/ITelegramUpdateBatchReceiver.cs
@@ -1,0 +1,13 @@
+using TeleFlow.Telegram.Schema.Methods;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Receives one getUpdates result while preserving per-update decode failures instead of failing the complete batch.
+/// </summary>
+internal interface ITelegramUpdateBatchReceiver
+{
+    Task<IReadOnlyList<TelegramUpdateDecodeResult>> ReceiveAsync(
+        GetUpdates request,
+        CancellationToken cancellationToken);
+}

--- a/src/TeleFlow.Telegram.Client/Internal/StopTelegramUpdateDecodeFailurePolicy.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/StopTelegramUpdateDecodeFailurePolicy.cs
@@ -1,0 +1,22 @@
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Preserves Telegram updates by stopping transport progress when an application has not installed an explicit quarantine policy.
+/// </summary>
+internal sealed class StopTelegramUpdateDecodeFailurePolicy : ITelegramUpdateDecodeFailurePolicy
+{
+    public static StopTelegramUpdateDecodeFailurePolicy Instance { get; } = new();
+
+    private StopTelegramUpdateDecodeFailurePolicy()
+    {
+    }
+
+    public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+        TelegramUpdateDecodeFailure failure,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(TelegramUpdateDecodeFailureDecision.Stop);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchReceiver.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchReceiver.cs
@@ -1,0 +1,24 @@
+using TeleFlow.Telegram.Schema.Methods;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Executes the specialized getUpdates request that decodes each result element independently.
+/// </summary>
+internal sealed class TelegramUpdateBatchReceiver(ITelegramRequestExecutor executor) : ITelegramUpdateBatchReceiver
+{
+    private readonly ITelegramRequestExecutor _executor = executor ?? throw new ArgumentNullException(nameof(executor));
+
+    public async Task<IReadOnlyList<TelegramUpdateDecodeResult>> ReceiveAsync(
+        GetUpdates request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var response = await _executor.ExecuteAsync(
+            new TelegramUpdateBatchRequest(request),
+            cancellationToken).ConfigureAwait(false);
+
+        return response.Items;
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchRequest.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchRequest.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using TeleFlow.Telegram.Schema.Methods;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Adapts getUpdates to a response contract that isolates schema failures to individual update elements.
+/// </summary>
+internal sealed class TelegramUpdateBatchRequest(GetUpdates request) :
+    ITelegramExecutableRequest<TelegramUpdateBatchResponse>
+{
+    private readonly GetUpdates _request = request ?? throw new ArgumentNullException(nameof(request));
+
+    public string MethodName => GetUpdates.MethodName;
+
+    public object Payload => _request;
+
+    public TelegramUpdateBatchResponse DeserializeResponse(
+        JsonSerializerOptions serializerOptions,
+        JsonElement result)
+    {
+        ArgumentNullException.ThrowIfNull(serializerOptions);
+
+        if (result.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("Telegram getUpdates result must be an array.");
+        }
+
+        var items = new List<TelegramUpdateDecodeResult>(result.GetArrayLength());
+        foreach (var payload in result.EnumerateArray())
+        {
+            if (payload.ValueKind != JsonValueKind.Object ||
+                !payload.TryGetProperty("update_id", out var updateIdElement) ||
+                updateIdElement.ValueKind != JsonValueKind.Number ||
+                !updateIdElement.TryGetInt64(out var updateId))
+            {
+                throw new JsonException("Telegram update payload does not contain a valid 'update_id'.");
+            }
+
+            items.Add(TelegramUpdateDecoder.Decode(
+                payload,
+                updateId,
+                serializerOptions,
+                MethodName));
+        }
+
+        return new TelegramUpdateBatchResponse(items);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchResponse.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateBatchResponse.cs
@@ -1,0 +1,7 @@
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Returns the ordered per-update outcomes produced by the specialized getUpdates decoder.
+/// </summary>
+internal sealed record TelegramUpdateBatchResponse(
+    IReadOnlyList<TelegramUpdateDecodeResult> Items) : ITelegramResponse;

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateDecodeResult.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateDecodeResult.cs
@@ -1,0 +1,34 @@
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Carries either a decoded Telegram update or the evidence required to apply an explicit poison-update policy.
+/// </summary>
+internal readonly record struct TelegramUpdateDecodeResult(
+    long UpdateId,
+    Update? Update,
+    string? RawPayloadJson,
+    string? PayloadSha256,
+    TelegramUpdateDecodeException? Exception)
+{
+    public bool IsSuccess => Update is not null;
+
+    public static TelegramUpdateDecodeResult Success(Update update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        return new TelegramUpdateDecodeResult(update.UpdateId, update, null, null, null);
+    }
+
+    public static TelegramUpdateDecodeResult Failure(
+        long updateId,
+        string rawPayloadJson,
+        string payloadSha256,
+        TelegramUpdateDecodeException exception)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawPayloadJson);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadSha256);
+        ArgumentNullException.ThrowIfNull(exception);
+        return new TelegramUpdateDecodeResult(updateId, null, rawPayloadJson, payloadSha256, exception);
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateDecoder.cs
+++ b/src/TeleFlow.Telegram.Client/Internal/TelegramUpdateDecoder.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using TeleFlow.Telegram.Schema.Types;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Decodes one known Telegram update envelope and captures raw payload evidence only when schema mapping fails.
+/// </summary>
+internal static class TelegramUpdateDecoder
+{
+    public static TelegramUpdateDecodeResult Decode(
+        JsonElement payload,
+        long updateId,
+        JsonSerializerOptions serializerOptions,
+        string? methodName = null)
+    {
+        ArgumentNullException.ThrowIfNull(serializerOptions);
+
+        try
+        {
+            var update = payload.Deserialize<Update>(serializerOptions)
+                ?? throw new JsonException("Telegram update payload deserialized to null.");
+
+            return TelegramUpdateDecodeResult.Success(update);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            var rawPayloadJson = payload.GetRawText();
+            var payloadSha256 = Convert.ToHexStringLower(
+                SHA256.HashData(Encoding.UTF8.GetBytes(rawPayloadJson)));
+            var jsonPath = exception is JsonException jsonException ? jsonException.Path : null;
+            var decodeException = new TelegramUpdateDecodeException(
+                $"Failed to deserialize Telegram update '{updateId}'.",
+                updateId,
+                payloadSha256,
+                jsonPath,
+                exception,
+                methodName);
+
+            return TelegramUpdateDecodeResult.Failure(
+                updateId,
+                rawPayloadJson,
+                payloadSha256,
+                decodeException);
+        }
+    }
+}

--- a/src/TeleFlow.Telegram.Client/Properties/AssemblyInfo.cs
+++ b/src/TeleFlow.Telegram.Client/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TeleFlow.Framework")]
+[assembly: InternalsVisibleTo("TeleFlow.Telegram.LongPolling")]
+[assembly: InternalsVisibleTo("TeleFlow.Telegram.Webhooks")]
+[assembly: InternalsVisibleTo("TeleFlow.ArchitectureTests")]

--- a/src/TeleFlow.Telegram.Client/TelegramClientServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramClientServiceCollectionExtensions.cs
@@ -143,6 +143,20 @@ public static class TelegramClientServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Replaces the default fail-closed policy used when an individual Telegram update cannot be decoded.
+    /// </summary>
+    public static IServiceCollection AddTelegramUpdateDecodeFailurePolicy<TPolicy>(
+        this IServiceCollection services)
+        where TPolicy : class, ITelegramUpdateDecodeFailurePolicy
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.RemoveAll<ITelegramUpdateDecodeFailurePolicy>();
+        services.AddSingleton<ITelegramUpdateDecodeFailurePolicy, TPolicy>();
+        return services;
+    }
+
     private static void AddTelegramClientDefaults(IServiceCollection services)
     {
         services.TryAddSingleton(TelegramJsonOptions.CreateDefault());
@@ -156,6 +170,8 @@ public static class TelegramClientServiceCollectionExtensions
         services.TryAddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.TryAddSingleton<ITelegramClient, TelegramClient>();
         services.TryAddSingleton<ITelegramRequestExecutor, TelegramRequestExecutor>();
+        services.TryAddSingleton<ITelegramUpdateBatchReceiver, TelegramUpdateBatchReceiver>();
+        services.TryAddSingleton<ITelegramUpdateDecodeFailurePolicy>(StopTelegramUpdateDecodeFailurePolicy.Instance);
     }
 
     private static void EnsureNotRegistered<TService>(IServiceCollection services, string apiName)

--- a/src/TeleFlow.Telegram.Client/TelegramRequestException.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramRequestException.cs
@@ -257,3 +257,38 @@ public sealed class TelegramDecodeException : TelegramRequestException
     {
     }
 }
+
+/// <summary>
+/// Reports that one syntactically valid Telegram update could not be mapped to the installed schema.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1032:Implement standard exception constructors",
+    Justification = "Telegram update decode exceptions intentionally keep update identity and payload diagnostics in the primary constructor.")]
+public sealed class TelegramUpdateDecodeException : TelegramRequestException
+{
+    public TelegramUpdateDecodeException(
+        string message,
+        long updateId,
+        string payloadSha256,
+        string? jsonPath = null,
+        Exception? innerException = null,
+        string? methodName = null)
+        : base(message, innerException, methodName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadSha256);
+
+        UpdateId = updateId;
+        PayloadSha256 = payloadSha256;
+        JsonPath = jsonPath;
+    }
+
+    /// <summary>Gets the Telegram update identifier.</summary>
+    public long UpdateId { get; }
+
+    /// <summary>Gets the lowercase SHA-256 fingerprint of the raw update payload.</summary>
+    public string PayloadSha256 { get; }
+
+    /// <summary>Gets the JSON path reported by the serializer, when available.</summary>
+    public string? JsonPath { get; }
+}

--- a/src/TeleFlow.Telegram.Client/TelegramUpdateDecodeFailure.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramUpdateDecodeFailure.cs
@@ -1,0 +1,59 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Describes one syntactically valid Telegram update that could not be mapped to the installed schema.
+/// Applications can persist the raw payload before explicitly allowing the transport to skip it.
+/// </summary>
+public sealed class TelegramUpdateDecodeFailure
+{
+    /// <summary>
+    /// Creates evidence for one update schema failure without exposing the raw payload through <see cref="ToString"/>.
+    /// </summary>
+    public TelegramUpdateDecodeFailure(
+        TelegramUpdateTransport transport,
+        long updateId,
+        string rawPayloadJson,
+        string payloadSha256,
+        TelegramUpdateDecodeException exception)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawPayloadJson);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payloadSha256);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception.UpdateId != updateId)
+        {
+            throw new ArgumentException("The decode exception belongs to a different Telegram update.", nameof(exception));
+        }
+
+        if (!string.Equals(exception.PayloadSha256, payloadSha256, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("The decode exception contains a different payload fingerprint.", nameof(exception));
+        }
+
+        Transport = transport;
+        UpdateId = updateId;
+        RawPayloadJson = rawPayloadJson;
+        PayloadSha256 = payloadSha256;
+        Exception = exception;
+    }
+
+    /// <summary>Gets the transport that received the incompatible update.</summary>
+    public TelegramUpdateTransport Transport { get; }
+
+    /// <summary>Gets the Telegram update identifier used for acknowledgement ordering.</summary>
+    public long UpdateId { get; }
+
+    /// <summary>Gets the complete raw JSON update for durable quarantine.</summary>
+    public string RawPayloadJson { get; }
+
+    /// <summary>Gets the lowercase SHA-256 fingerprint of <see cref="RawPayloadJson"/>.</summary>
+    public string PayloadSha256 { get; }
+
+    /// <summary>Gets the structured schema decode exception.</summary>
+    public TelegramUpdateDecodeException Exception { get; }
+
+    public override string ToString()
+    {
+        return $"Telegram update {UpdateId} failed schema decoding on {Transport}; payload_sha256={PayloadSha256}.";
+    }
+}

--- a/src/TeleFlow.Telegram.Client/TelegramUpdateDecodeFailureDecision.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramUpdateDecodeFailureDecision.cs
@@ -1,0 +1,10 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Controls whether a transport stops or acknowledges a Telegram update that could not be decoded.
+/// </summary>
+public enum TelegramUpdateDecodeFailureDecision
+{
+    Stop,
+    Skip
+}

--- a/src/TeleFlow.Telegram.Client/TelegramUpdateTransport.cs
+++ b/src/TeleFlow.Telegram.Client/TelegramUpdateTransport.cs
@@ -1,0 +1,10 @@
+namespace TeleFlow.Telegram;
+
+/// <summary>
+/// Identifies the Telegram update transport that encountered an update payload it could not decode.
+/// </summary>
+public enum TelegramUpdateTransport
+{
+    LongPolling,
+    Webhook
+}

--- a/src/TeleFlow.Telegram.LongPolling/Internal/TypedTelegramUpdateBatchReceiver.cs
+++ b/src/TeleFlow.Telegram.LongPolling/Internal/TypedTelegramUpdateBatchReceiver.cs
@@ -1,0 +1,22 @@
+using TeleFlow.Telegram.Schema.Methods;
+
+namespace TeleFlow.Telegram.Internal;
+
+/// <summary>
+/// Preserves the public direct-construction path by adapting an arbitrary Telegram client to successful update batches.
+/// The dependency-injection path uses the raw per-update receiver instead.
+/// </summary>
+internal sealed class TypedTelegramUpdateBatchReceiver(ITelegramClient client) : ITelegramUpdateBatchReceiver
+{
+    private readonly ITelegramClient _client = client ?? throw new ArgumentNullException(nameof(client));
+
+    public async Task<IReadOnlyList<TelegramUpdateDecodeResult>> ReceiveAsync(
+        GetUpdates request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var updates = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return updates.Select(TelegramUpdateDecodeResult.Success).ToArray();
+    }
+}

--- a/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
+++ b/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClient.cs
@@ -6,9 +6,13 @@ using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram;
 
+/// <summary>
+/// Receives Telegram updates through getUpdates, preserves acknowledgement ordering, and applies explicit schema decode failure policy.
+/// </summary>
 public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClient
 {
-    private readonly ITelegramClient _telegramClient;
+    private readonly ITelegramUpdateBatchReceiver _batchReceiver;
+    private readonly ITelegramUpdateDecodeFailurePolicy _decodeFailurePolicy;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<TelegramLongPollingClient> _logger;
 
@@ -16,12 +20,27 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
         ITelegramClient telegramClient,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory)
+        : this(
+            new TypedTelegramUpdateBatchReceiver(telegramClient),
+            StopTelegramUpdateDecodeFailurePolicy.Instance,
+            timeProvider,
+            loggerFactory)
     {
-        ArgumentNullException.ThrowIfNull(telegramClient);
+    }
+
+    internal TelegramLongPollingClient(
+        ITelegramUpdateBatchReceiver batchReceiver,
+        ITelegramUpdateDecodeFailurePolicy decodeFailurePolicy,
+        TimeProvider timeProvider,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(batchReceiver);
+        ArgumentNullException.ThrowIfNull(decodeFailurePolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        _telegramClient = telegramClient;
+        _batchReceiver = batchReceiver;
+        _decodeFailurePolicy = decodeFailurePolicy;
         _timeProvider = timeProvider;
         _logger = loggerFactory.CreateLogger<TelegramLongPollingClient>();
     }
@@ -70,7 +89,15 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
 
             for (var index = 0; index < updates.Count; index++)
             {
-                var update = updates[index];
+                var item = updates[index];
+                if (!item.IsSuccess)
+                {
+                    await HandleDecodeFailureAsync(item, cancellationToken).ConfigureAwait(false);
+                    offset = item.UpdateId + 1;
+                    continue;
+                }
+
+                var update = item.Update!;
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
@@ -142,7 +169,15 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
 
             for (var index = 0; index < updates.Count; index++)
             {
-                var update = updates[index];
+                var item = updates[index];
+                if (!item.IsSuccess)
+                {
+                    await HandleDecodeFailureAsync(item, cancellationToken).ConfigureAwait(false);
+                    offset = item.UpdateId + 1;
+                    continue;
+                }
+
+                var update = item.Update!;
                 var polledUpdate = new TelegramPolledUpdate(update, index + 1, updates.Count);
 
                 var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
@@ -179,7 +214,7 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
         }
     }
 
-    private async Task<IReadOnlyList<Update>> GetUpdatesBatchAsync(
+    private async Task<IReadOnlyList<TelegramUpdateDecodeResult>> GetUpdatesBatchAsync(
         long? offset,
         TelegramRawLongPollingOptions options,
         IReadOnlyList<string>? allowedUpdates,
@@ -192,7 +227,7 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
         {
             try
             {
-                var updates = await _telegramClient.SendAsync(
+                var updates = await _batchReceiver.ReceiveAsync(
                     new GetUpdates
                     {
                         Offset = offset,
@@ -249,6 +284,48 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
             : new ValueTask(Task.Delay(delay, _timeProvider, cancellationToken));
     }
 
+    private async ValueTask HandleDecodeFailureAsync(
+        TelegramUpdateDecodeResult item,
+        CancellationToken cancellationToken)
+    {
+        var exception = item.Exception
+            ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain an exception.");
+        var failure = new TelegramUpdateDecodeFailure(
+            TelegramUpdateTransport.LongPolling,
+            item.UpdateId,
+            item.RawPayloadJson
+                ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain raw payload evidence."),
+            item.PayloadSha256
+                ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain a payload hash."),
+            exception);
+
+        var decision = await _decodeFailurePolicy
+            .DecideAsync(failure, cancellationToken)
+            .ConfigureAwait(false);
+
+        switch (decision)
+        {
+            case TelegramUpdateDecodeFailureDecision.Stop:
+                LogUpdateDecodeStopped(
+                    _logger,
+                    exception,
+                    item.UpdateId,
+                    exception.JsonPath,
+                    exception.PayloadSha256);
+                throw exception;
+            case TelegramUpdateDecodeFailureDecision.Skip:
+                LogUpdateDecodeSkipped(
+                    _logger,
+                    item.UpdateId,
+                    exception.JsonPath,
+                    exception.PayloadSha256);
+                return;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported Telegram update decode failure decision '{decision}'.");
+        }
+    }
+
     private static string[]? CopyAllowedUpdates(IReadOnlyList<string>? allowedUpdates)
     {
         return allowedUpdates is null ? null : allowedUpdates.ToArray();
@@ -258,7 +335,6 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
     {
         return exception is TelegramNetworkException or
             TelegramServerException or
-            TelegramDecodeException or
             TelegramRetryAfterException;
     }
 
@@ -338,4 +414,25 @@ public sealed partial class TelegramLongPollingClient : ITelegramLongPollingClie
         ILogger logger,
         Exception exception,
         TimeSpan delay);
+
+    [LoggerMessage(
+        EventId = 9,
+        Level = LogLevel.Error,
+        Message = "Telegram update decoding failed and polling was stopped. update_id={UpdateId}, json_path={JsonPath}, payload_sha256={PayloadSha256}.")]
+    private static partial void LogUpdateDecodeStopped(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string? jsonPath,
+        string payloadSha256);
+
+    [LoggerMessage(
+        EventId = 10,
+        Level = LogLevel.Warning,
+        Message = "Telegram update decoding failed and the update was skipped by application policy. update_id={UpdateId}, json_path={JsonPath}, payload_sha256={PayloadSha256}.")]
+    private static partial void LogUpdateDecodeSkipped(
+        ILogger logger,
+        long updateId,
+        string? jsonPath,
+        string payloadSha256);
 }

--- a/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClientServiceCollectionExtensions.cs
+++ b/src/TeleFlow.Telegram.LongPolling/TelegramLongPollingClientServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using TeleFlow.Telegram.Internal;
 
 namespace TeleFlow.Telegram;
 
@@ -13,7 +14,20 @@ public static class TelegramLongPollingClientServiceCollectionExtensions
 
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
-        services.TryAddSingleton<ITelegramLongPollingClient, TelegramLongPollingClient>();
+        services.TryAddSingleton<ITelegramUpdateDecodeFailurePolicy>(StopTelegramUpdateDecodeFailurePolicy.Instance);
+        services.TryAddSingleton<ITelegramLongPollingClient>(static provider =>
+        {
+            var client = provider.GetRequiredService<ITelegramClient>();
+            var batchReceiver = client is TelegramClient
+                ? provider.GetRequiredService<ITelegramUpdateBatchReceiver>()
+                : new TypedTelegramUpdateBatchReceiver(client);
+
+            return new TelegramLongPollingClient(
+                batchReceiver,
+                provider.GetRequiredService<ITelegramUpdateDecodeFailurePolicy>(),
+                provider.GetRequiredService<TimeProvider>(),
+                provider.GetRequiredService<ILoggerFactory>());
+        });
 
         return services;
     }

--- a/src/TeleFlow.Telegram.Schema/Types/InputRichBlockListItem.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/InputRichBlockListItem.g.cs
@@ -10,14 +10,13 @@
 
 #nullable enable
 using System.Text.Json.Serialization;
-using System.Text.Json;
 
 namespace TeleFlow.Telegram.Schema.Types;
 
 /// <summary>
 /// An item of a list to be sent.
 /// </summary>
-public sealed partial record class InputRichBlockListItem : IJsonOnDeserialized
+public sealed partial record class InputRichBlockListItem
 {
     /// <summary>
     /// The content of the item
@@ -50,18 +49,8 @@ public sealed partial record class InputRichBlockListItem : IJsonOnDeserialized
     /// <summary>
     /// For ordered lists, the type of the item label; must be one of “a” for lowercase letters, “A” for uppercase letters, “i” for lowercase Roman numerals, “I” for uppercase Roman numerals, or “1” for decimal numbers
     /// </summary>
-    public const string? TypeValue = "one";
-
     [JsonPropertyName("type")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Type { get; init; } = TypeValue;
+    public string? Type { get; init; }
 
-    void IJsonOnDeserialized.OnDeserialized()
-    {
-        if (Type != TypeValue)
-        {
-            throw new JsonException("Expected Telegram literal 'one' for field 'type' on InputRichBlockListItem.");
-        }
-
-    }
 }

--- a/src/TeleFlow.Telegram.Schema/Types/RichBlockListItem.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Types/RichBlockListItem.g.cs
@@ -10,14 +10,13 @@
 
 #nullable enable
 using System.Text.Json.Serialization;
-using System.Text.Json;
 
 namespace TeleFlow.Telegram.Schema.Types;
 
 /// <summary>
 /// An item of a list.
 /// </summary>
-public sealed partial record class RichBlockListItem : IJsonOnDeserialized
+public sealed partial record class RichBlockListItem
 {
     /// <summary>
     /// Label of the item
@@ -57,18 +56,8 @@ public sealed partial record class RichBlockListItem : IJsonOnDeserialized
     /// <summary>
     /// For ordered lists, the type of the item label; must be one of “a” for lowercase letters, “A” for uppercase letters, “i” for lowercase Roman numerals, “I” for uppercase Roman numerals, or “1” for decimal numbers
     /// </summary>
-    public const string? TypeValue = "one";
-
     [JsonPropertyName("type")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Type { get; init; } = TypeValue;
+    public string? Type { get; init; }
 
-    void IJsonOnDeserialized.OnDeserialized()
-    {
-        if (Type != TypeValue)
-        {
-            throw new JsonException("Expected Telegram literal 'one' for field 'type' on RichBlockListItem.");
-        }
-
-    }
 }

--- a/src/TeleFlow.Telegram.Schema/telegram-bot-api.manifest.json
+++ b/src/TeleFlow.Telegram.Schema/telegram-bot-api.manifest.json
@@ -2,8 +2,8 @@
   "manifestVersion": 1,
   "source": {
     "url": "https://core.telegram.org/bots/api",
-    "capturedAtUtc": "2026-07-21T13:29:10.9121648+00:00",
-    "sha256": "16cb4bf69fba792c47d9ad0dcd1300e8ebd1172dd399cb415d0b6fee3ddb201a"
+    "capturedAtUtc": "2026-08-05T19:54:03.4531767+00:00",
+    "sha256": "c85465cbc2da0c1639cbb82fd1f7e3bed7898b3613625dc439f805b9a500e236"
   },
   "telegramBotApi": {
     "version": "10.2",
@@ -12,7 +12,7 @@
     "changelogUrl": "https://core.telegram.org/bots/api-changelog#july-14-2026"
   },
   "pipeline": {
-    "schemaVersion": 9,
+    "schemaVersion": 10,
     "generatorVersion": 11
   }
 }

--- a/src/TeleFlow.Telegram.Webhooks/Internal/TelegramRawWebhookEndpoint.cs
+++ b/src/TeleFlow.Telegram.Webhooks/Internal/TelegramRawWebhookEndpoint.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using TeleFlow.Telegram.Internal;
 using TeleFlow.Telegram.Schema.Types;
 
 namespace TeleFlow.Telegram.Webhooks.Internal;
@@ -19,6 +20,8 @@ internal sealed partial class TelegramRawWebhookEndpoint
     private const int UpdateReceivedEventId = 3;
     private const int UpdateProcessedEventId = 4;
     private const int UpdateProcessingFailedEventId = 5;
+    private const int UpdateDecodeStoppedEventId = 6;
+    private const int UpdateDecodeSkippedEventId = 7;
 
     private static readonly TelegramJsonOptions DefaultJsonOptions = TelegramJsonOptions.CreateDefault();
 
@@ -51,14 +54,13 @@ internal sealed partial class TelegramRawWebhookEndpoint
         }
 
         var jsonOptions = context.RequestServices.GetService<TelegramJsonOptions>() ?? DefaultJsonOptions;
-        Update? update;
+        JsonDocument? document;
 
         try
         {
-            update = await JsonSerializer.DeserializeAsync<Update>(
+            document = await JsonDocument.ParseAsync(
                 context.Request.Body,
-                jsonOptions.SerializerOptions,
-                context.RequestAborted).ConfigureAwait(false);
+                cancellationToken: context.RequestAborted).ConfigureAwait(false);
         }
         catch (JsonException)
         {
@@ -70,52 +72,127 @@ internal sealed partial class TelegramRawWebhookEndpoint
             return Results.StatusCode(_options.InvalidPayloadStatusCode);
         }
 
-        if (update is null)
+        using (document)
         {
-            if (_logger is not null)
+            var payload = document.RootElement;
+            if (!TryGetUpdateId(payload, out var updateId))
             {
-                LogInvalidPayloadRejected(_logger, _options.InvalidPayloadStatusCode);
+                if (_logger is not null)
+                {
+                    LogInvalidPayloadRejected(_logger, _options.InvalidPayloadStatusCode);
+                }
+
+                return Results.StatusCode(_options.InvalidPayloadStatusCode);
             }
 
-            return Results.StatusCode(_options.InvalidPayloadStatusCode);
-        }
+            var decodeResult = TelegramUpdateDecoder.Decode(
+                payload,
+                updateId,
+                jsonOptions.SerializerOptions);
 
-        string? updateType = null;
-        string GetUpdateType()
-        {
-            return updateType ??= TelegramWebhookUpdateLogFormatter.GetUpdateType(update);
-        }
+            if (!decodeResult.IsSuccess)
+            {
+                return await HandleDecodeFailureAsync(context, decodeResult).ConfigureAwait(false);
+            }
 
-        if (_logger?.IsEnabled(LogLevel.Debug) == true)
-        {
-            LogUpdateReceived(_logger, update.UpdateId, GetUpdateType());
-        }
-
-        var bot = context.RequestServices.GetRequiredService<ITelegramClient>();
-        try
-        {
-            var result = await _handler(update, bot, context.RequestAborted).ConfigureAwait(false);
+            var update = decodeResult.Update!;
+            string? updateType = null;
+            string GetUpdateType()
+            {
+                return updateType ??= TelegramWebhookUpdateLogFormatter.GetUpdateType(update);
+            }
 
             if (_logger?.IsEnabled(LogLevel.Debug) == true)
             {
-                LogUpdateProcessed(_logger, update.UpdateId, GetUpdateType());
+                LogUpdateReceived(_logger, update.UpdateId, GetUpdateType());
             }
 
-            return result;
-        }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            if (_logger?.IsEnabled(LogLevel.Error) == true)
+            var bot = context.RequestServices.GetRequiredService<ITelegramClient>();
+            try
             {
-                LogUpdateProcessingFailed(_logger, exception, update.UpdateId, GetUpdateType());
-            }
+                var result = await _handler(update, bot, context.RequestAborted).ConfigureAwait(false);
 
-            throw;
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    LogUpdateProcessed(_logger, update.UpdateId, GetUpdateType());
+                }
+
+                return result;
+            }
+            catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                if (_logger?.IsEnabled(LogLevel.Error) == true)
+                {
+                    LogUpdateProcessingFailed(_logger, exception, update.UpdateId, GetUpdateType());
+                }
+
+                throw;
+            }
         }
+    }
+
+    private async Task<IResult> HandleDecodeFailureAsync(
+        HttpContext context,
+        TelegramUpdateDecodeResult item)
+    {
+        var exception = item.Exception
+            ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain an exception.");
+        var failure = new TelegramUpdateDecodeFailure(
+            TelegramUpdateTransport.Webhook,
+            item.UpdateId,
+            item.RawPayloadJson
+                ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain raw payload evidence."),
+            item.PayloadSha256
+                ?? throw new InvalidOperationException("A failed Telegram update decode result did not contain a payload hash."),
+            exception);
+        var policy = context.RequestServices.GetService<ITelegramUpdateDecodeFailurePolicy>()
+            ?? StopTelegramUpdateDecodeFailurePolicy.Instance;
+        var decision = await policy
+            .DecideAsync(failure, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        switch (decision)
+        {
+            case TelegramUpdateDecodeFailureDecision.Stop:
+                if (_logger is not null)
+                {
+                    LogUpdateDecodeStopped(
+                        _logger,
+                        exception,
+                        item.UpdateId,
+                        exception.JsonPath,
+                        exception.PayloadSha256);
+                }
+
+                return Results.StatusCode(StatusCodes.Status500InternalServerError);
+            case TelegramUpdateDecodeFailureDecision.Skip:
+                if (_logger is not null)
+                {
+                    LogUpdateDecodeSkipped(
+                        _logger,
+                        item.UpdateId,
+                        exception.JsonPath,
+                        exception.PayloadSha256);
+                }
+
+                return Results.Ok();
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported Telegram update decode failure decision '{decision}'.");
+        }
+    }
+
+    private static bool TryGetUpdateId(JsonElement payload, out long updateId)
+    {
+        updateId = default;
+        return payload.ValueKind == JsonValueKind.Object &&
+            payload.TryGetProperty("update_id", out var updateIdElement) &&
+            updateIdElement.ValueKind == JsonValueKind.Number &&
+            updateIdElement.TryGetInt64(out updateId);
     }
 
     private bool IsSecretTokenAccepted(HttpContext context)
@@ -173,4 +250,25 @@ internal sealed partial class TelegramRawWebhookEndpoint
         Exception exception,
         long updateId,
         string updateType);
+
+    [LoggerMessage(
+        EventId = UpdateDecodeStoppedEventId,
+        Level = LogLevel.Error,
+        Message = "Telegram webhook update decoding failed and the request was rejected for retry. update_id={UpdateId}, json_path={JsonPath}, payload_sha256={PayloadSha256}.")]
+    private static partial void LogUpdateDecodeStopped(
+        ILogger logger,
+        Exception exception,
+        long updateId,
+        string? jsonPath,
+        string payloadSha256);
+
+    [LoggerMessage(
+        EventId = UpdateDecodeSkippedEventId,
+        Level = LogLevel.Warning,
+        Message = "Telegram webhook update decoding failed and the update was acknowledged by application policy. update_id={UpdateId}, json_path={JsonPath}, payload_sha256={PayloadSha256}.")]
+    private static partial void LogUpdateDecodeSkipped(
+        ILogger logger,
+        long updateId,
+        string? jsonPath,
+        string payloadSha256);
 }

--- a/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/PublicSurfaceTests.cs
@@ -38,7 +38,8 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.TelegramMigrateToChatException",
         "TeleFlow.Telegram.TelegramServerException",
         "TeleFlow.Telegram.TelegramNetworkException",
-        "TeleFlow.Telegram.TelegramDecodeException"
+        "TeleFlow.Telegram.TelegramDecodeException",
+        "TeleFlow.Telegram.TelegramUpdateDecodeException"
     ];
 
     private static readonly string[] Phase1bClientTypeNames =
@@ -52,7 +53,11 @@ public sealed class PublicSurfaceTests
         "TeleFlow.Telegram.TelegramDeepLinks",
         "TeleFlow.Telegram.IDeepLinkPayloadSerializer",
         "TeleFlow.Telegram.Base64UrlJsonDeepLinkPayloadSerializer",
-        "TeleFlow.Telegram.TelegramClientServiceCollectionExtensions"
+        "TeleFlow.Telegram.TelegramClientServiceCollectionExtensions",
+        "TeleFlow.Telegram.ITelegramUpdateDecodeFailurePolicy",
+        "TeleFlow.Telegram.TelegramUpdateDecodeFailure",
+        "TeleFlow.Telegram.TelegramUpdateDecodeFailureDecision",
+        "TeleFlow.Telegram.TelegramUpdateTransport"
     ];
 
     private static readonly string[] Phase1cClientTypeNames =

--- a/tests/TeleFlow.ArchitectureTests/RawLongPollingTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/RawLongPollingTests.cs
@@ -58,7 +58,7 @@ public sealed class RawLongPollingTests
             new TelegramNetworkException("network failed", methodName: "getUpdates"),
             new TelegramServerException("server failed", methodName: "getUpdates", httpStatusCode: 502),
             Array.Empty<Update>(),
-            new TelegramDecodeException("decode failed", methodName: "getUpdates"),
+            new TelegramNetworkException("network failed after recovery", methodName: "getUpdates"),
             new List<Update> { CreateMessageUpdate(1) });
         using var cancellation = new CancellationTokenSource();
         var polling = CreatePollingClient(telegramClient, timeProvider);
@@ -86,6 +86,90 @@ public sealed class RawLongPollingTests
             [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)],
             timeProvider.Delays);
         Assert.Equal([null, null, null, null, null], telegramClient.GetUpdatesRequests.Select(static request => request.Offset).ToArray());
+    }
+
+    [Fact]
+    public async Task RunAsync_DefaultPolicyStopsOnIndividualDecodeFailureWithoutRetry()
+    {
+        var transport = new QueueTelegramTransport(CreatePoisonBatchResponse());
+        using var provider = CreateTransportProvider(transport);
+        var polling = provider.GetRequiredService<ITelegramLongPollingClient>();
+        var processedUpdates = new List<long>();
+
+        var exception = await Assert.ThrowsAsync<TelegramUpdateDecodeException>(() =>
+            polling.RunAsync((update, _) =>
+            {
+                processedUpdates.Add(update.UpdateId);
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(2, exception.UpdateId);
+        Assert.Equal("$.message.date", exception.JsonPath);
+        Assert.Equal([1L], processedUpdates);
+        Assert.Single(transport.Requests);
+    }
+
+    [Fact]
+    public async Task RunAsync_SkipPolicyProcessesRemainingUpdatesAndAdvancesOffset()
+    {
+        var transport = new QueueTelegramTransport(
+            CreatePoisonBatchResponse(),
+            CreateBatchResponse(CreateUpdateJson(4)));
+        using var provider = CreateTransportProvider<SkippingDecodeFailurePolicy>(transport);
+        var polling = provider.GetRequiredService<ITelegramLongPollingClient>();
+        var failurePolicy = provider.GetRequiredService<ITelegramUpdateDecodeFailurePolicy>();
+        var processedUpdates = new List<long>();
+        using var cancellation = new CancellationTokenSource();
+
+        await polling.RunAsync((update, _) =>
+        {
+            processedUpdates.Add(update.UpdateId);
+            if (update.UpdateId == 4)
+            {
+                cancellation.Cancel();
+            }
+
+            return Task.CompletedTask;
+        }, cancellationToken: cancellation.Token);
+
+        var failure = Assert.Single(Assert.IsType<SkippingDecodeFailurePolicy>(failurePolicy).Failures);
+        Assert.Equal(TelegramUpdateTransport.LongPolling, failure.Transport);
+        Assert.Equal(2, failure.UpdateId);
+        Assert.Contains("\"date\":\"invalid\"", failure.RawPayloadJson, StringComparison.Ordinal);
+        Assert.Matches("^[0-9a-f]{64}$", failure.PayloadSha256);
+        Assert.Equal([1L, 3L, 4L], processedUpdates);
+        Assert.Equal(2, transport.Requests.Count);
+        Assert.Contains(
+            "\"offset\":4",
+            Assert.IsType<TelegramJsonTransportContent>(transport.Requests[1].Content).Json,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotAdvanceOffsetWhenDecodeFailureHandlerThrows()
+    {
+        var transport = new QueueTelegramTransport(CreatePoisonOnlyResponse());
+        using var provider = CreateTransportProvider<ThrowingDecodeFailurePolicy>(transport);
+        var polling = provider.GetRequiredService<ITelegramLongPollingClient>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            polling.RunAsync(static (_, _) => Task.CompletedTask));
+
+        Assert.Equal("quarantine failed", exception.Message);
+        Assert.Single(transport.Requests);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotAdvanceOffsetWhenDecodeFailurePolicyCancels()
+    {
+        var transport = new QueueTelegramTransport(CreatePoisonOnlyResponse());
+        using var provider = CreateTransportProvider<CancellingDecodeFailurePolicy>(transport);
+        var polling = provider.GetRequiredService<ITelegramLongPollingClient>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            polling.RunAsync(static (_, _) => Task.CompletedTask));
+
+        Assert.Single(transport.Requests);
     }
 
     [Fact]
@@ -178,6 +262,19 @@ public sealed class RawLongPollingTests
         Assert.IsType<TelegramLongPollingClient>(provider.GetRequiredService<ITelegramLongPollingClient>());
     }
 
+    [Fact]
+    public void AddTelegramLongPollingClient_ProvidesFailClosedPolicyForManuallyRegisteredClient()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITelegramClient>(new SequencedTelegramClient(Array.Empty<Update>()));
+        services.AddTelegramLongPollingClient();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<ITelegramUpdateDecodeFailurePolicy>());
+        Assert.IsType<TelegramLongPollingClient>(provider.GetRequiredService<ITelegramLongPollingClient>());
+    }
+
     private static TelegramLongPollingClient CreatePollingClient(
         ITelegramClient telegramClient,
         TimeProvider? timeProvider = null)
@@ -186,6 +283,51 @@ public sealed class RawLongPollingTests
             telegramClient,
             timeProvider ?? TimeProvider.System,
             NullLoggerFactory.Instance);
+    }
+
+    private static ServiceProvider CreateTransportProvider(QueueTelegramTransport transport)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITelegramTransport>(transport);
+        services.AddTelegramClient(options => options.Token = "test-token");
+        services.AddTelegramLongPollingClient();
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider CreateTransportProvider<TFailurePolicy>(QueueTelegramTransport transport)
+        where TFailurePolicy : class, ITelegramUpdateDecodeFailurePolicy
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITelegramTransport>(transport);
+        services.AddTelegramClient(options => options.Token = "test-token");
+        services.AddTelegramUpdateDecodeFailurePolicy<TFailurePolicy>();
+        services.AddTelegramLongPollingClient();
+        return services.BuildServiceProvider();
+    }
+
+    private static TelegramTransportResponse CreatePoisonBatchResponse()
+    {
+        return CreateBatchResponse(
+            CreateUpdateJson(1),
+            CreateUpdateJson(2, "\"invalid\""),
+            CreateUpdateJson(3));
+    }
+
+    private static TelegramTransportResponse CreatePoisonOnlyResponse()
+    {
+        return CreateBatchResponse(CreateUpdateJson(2, "\"invalid\""));
+    }
+
+    private static TelegramTransportResponse CreateBatchResponse(params string[] updates)
+    {
+        return new TelegramTransportResponse(
+            200,
+            $"{{\"ok\":true,\"result\":[{string.Join(',', updates)}]}}");
+    }
+
+    private static string CreateUpdateJson(long updateId, string date = "0")
+    {
+        return $"{{\"update_id\":{updateId},\"message\":{{\"message_id\":10,\"date\":{date},\"chat\":{{\"id\":100,\"type\":\"private\"}},\"text\":\"hello\"}}}}";
     }
 
     private static Update CreateMessageUpdate(long updateId)
@@ -233,6 +375,56 @@ public sealed class RawLongPollingTests
             return result is Exception exception
                 ? Task.FromException<TResult>(exception)
                 : Task.FromResult((TResult)result);
+        }
+    }
+
+    private sealed class QueueTelegramTransport(params TelegramTransportResponse[] responses) : ITelegramTransport
+    {
+        private readonly Queue<TelegramTransportResponse> _responses = new(responses);
+
+        public List<TelegramTransportRequest> Requests { get; } = [];
+
+        public Task<TelegramTransportResponse> SendAsync(
+            TelegramTransportRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed class SkippingDecodeFailurePolicy : ITelegramUpdateDecodeFailurePolicy
+    {
+        public List<TelegramUpdateDecodeFailure> Failures { get; } = [];
+
+        public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+            TelegramUpdateDecodeFailure failure,
+            CancellationToken cancellationToken = default)
+        {
+            Failures.Add(failure);
+            return ValueTask.FromResult(TelegramUpdateDecodeFailureDecision.Skip);
+        }
+    }
+
+    private sealed class ThrowingDecodeFailurePolicy : ITelegramUpdateDecodeFailurePolicy
+    {
+        public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+            TelegramUpdateDecodeFailure failure,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromException<TelegramUpdateDecodeFailureDecision>(
+                new InvalidOperationException("quarantine failed"));
+        }
+    }
+
+    private sealed class CancellingDecodeFailurePolicy : ITelegramUpdateDecodeFailurePolicy
+    {
+        public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+            TelegramUpdateDecodeFailure failure,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromException<TelegramUpdateDecodeFailureDecision>(
+                new OperationCanceledException(cancellationToken));
         }
     }
 

--- a/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramRuntimeIntegrationTests.cs
@@ -1738,6 +1738,23 @@ public sealed class TelegramRuntimeIntegrationTests
     }
 
     [Fact]
+    public async Task Client_DirectGetUpdatesCall_RemainsStrictAndAtomicOnSchemaFailure()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            CreateJsonResponse(
+                """{"ok":true,"result":[{"update_id":1,"message":{"message_id":10,"date":"invalid","chat":{"id":100,"type":"private"}}}]}"""));
+
+        using var serviceProvider = CreateTelegramServiceProvider(handler);
+        var client = serviceProvider.GetRequiredService<ITelegramClient>();
+
+        var exception = await Assert.ThrowsAsync<TelegramDecodeException>(() =>
+            client.SendAsync(new GetUpdates()));
+
+        Assert.Equal("getUpdates", exception.MethodName);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
     public async Task Executor_WrapsHttpRequestExceptionAsNetworkException()
     {
         var handler = new ThrowingHttpMessageHandler(
@@ -1966,7 +1983,7 @@ public sealed class TelegramRuntimeIntegrationTests
             new TelegramNetworkException("network failed", methodName: "getUpdates"),
             new TelegramServerException("server failed", methodName: "getUpdates", httpStatusCode: 502),
             Array.Empty<Update>(),
-            new TelegramDecodeException("decode failed", methodName: "getUpdates"),
+            new TelegramNetworkException("network failed after recovery", methodName: "getUpdates"),
             new List<Update> { CreateMessageUpdate(1) });
         var dispatcher = new RecordingDispatcher(cancelAfter: 1);
         using var cancellation = new CancellationTokenSource();
@@ -1994,6 +2011,29 @@ public sealed class TelegramRuntimeIntegrationTests
             timeProvider.Delays);
         Assert.Equal([1L], dispatcher.UpdateIds);
         Assert.Equal(5, telegramClient.GetUpdatesRequests.Count);
+    }
+
+    [Fact]
+    public async Task LongPolling_DoesNotRetryDeterministicGetUpdatesDecodeFailure()
+    {
+        var telegramClient = new SequencedTelegramClient(
+            new TelegramDecodeException("decode failed", methodName: "getUpdates"));
+        var dispatcher = new RecordingDispatcher();
+        using var cancellation = new CancellationTokenSource();
+
+        var application = CreateTelegramApplication(
+            services =>
+            {
+                services.AddSingleton<ITelegramClient>(telegramClient);
+                services.AddSingleton<IUpdateDispatcher>(dispatcher);
+            },
+            services => services.AddLongPolling(),
+            cancellation);
+
+        await Assert.ThrowsAsync<TelegramDecodeException>(() => application.RunAsync(cancellation.Token));
+
+        Assert.Empty(dispatcher.UpdateIds);
+        Assert.Single(telegramClient.GetUpdatesRequests);
     }
 
     [Fact]

--- a/tests/TeleFlow.ArchitectureTests/TelegramSchemaTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramSchemaTests.cs
@@ -359,6 +359,64 @@ public sealed class TelegramSchemaTests
         Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ChatMemberOwner>(invalidJson));
     }
 
+    [Theory]
+    [InlineData("a")]
+    [InlineData("A")]
+    [InlineData("i")]
+    [InlineData("I")]
+    [InlineData("1")]
+    public void RichBlockListItems_AcceptEveryDocumentedOrderedLabelType(string labelType)
+    {
+        var received = JsonSerializer.Deserialize<RichBlockListItem>(
+            $$"""{"label":"item","blocks":[],"type":"{{labelType}}"}""");
+        var outgoing = JsonSerializer.Deserialize<InputRichBlockListItem>(
+            $$"""{"blocks":[],"type":"{{labelType}}"}""");
+
+        Assert.Equal(labelType, received?.Type);
+        Assert.Equal(labelType, outgoing?.Type);
+    }
+
+    [Fact]
+    public void UpdateDto_DeserializesRichMessageOrderedListFromProductionIncidentShape()
+    {
+        const string json = """
+            {
+              "update_id": 12925763,
+              "message": {
+                "message_id": 114031,
+                "date": 1785956961,
+                "chat": {
+                  "id": -1003805009428,
+                  "type": "supergroup"
+                },
+                "rich_message": {
+                  "blocks": [
+                    {
+                      "type": "list",
+                      "items": [
+                        {
+                          "label": "1",
+                          "blocks": [],
+                          "value": 1,
+                          "type": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+
+        var update = JsonSerializer.Deserialize<Update>(json);
+        var list = Assert.IsType<RichBlockList>(Assert.Single(update!.Message!.RichMessage!.Blocks).RichBlockList);
+        var item = Assert.Single(list.Items);
+
+        Assert.Equal(12925763, update.UpdateId);
+        Assert.Equal("1", item.Type);
+        Assert.Equal(1, item.Value);
+    }
+
     [Fact]
     public void SendMessage_SerializesTelegramWireNames()
     {

--- a/tests/TeleFlow.ArchitectureTests/TelegramWebhookTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramWebhookTests.cs
@@ -83,6 +83,95 @@ public sealed class TelegramWebhookTests
     }
 
     [Fact]
+    public async Task RawWebhookEndpoint_DefaultPolicyReturnsServerErrorForSchemaDecodeFailure()
+    {
+        var invoked = false;
+        await using var app = CreateApp((_, _, _) =>
+        {
+            invoked = true;
+            return Task.FromResult<IResult>(Results.Ok());
+        });
+
+        var context = await InvokeAsync(app, PoisonUpdateJson);
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_SkipPolicyAcknowledgesOnlyAfterFailureHandlerSucceeds()
+    {
+        var invoked = false;
+        var failurePolicy = new RecordingDecodeFailurePolicy(TelegramUpdateDecodeFailureDecision.Skip);
+        await using var app = CreateApp(
+            (_, _, _) =>
+            {
+                invoked = true;
+                return Task.FromResult<IResult>(Results.Ok());
+            },
+            decodeFailurePolicy: failurePolicy);
+
+        var context = await InvokeAsync(app, PoisonUpdateJson);
+
+        var failure = Assert.Single(failurePolicy.Failures);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal(TelegramUpdateTransport.Webhook, failure.Transport);
+        Assert.Equal(124, failure.UpdateId);
+        Assert.Contains("\"date\": \"invalid\"", failure.RawPayloadJson, StringComparison.Ordinal);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_DecodeFailureDiagnosticsDoNotLogRawPayload()
+    {
+        var loggerFactory = new RecordingLoggerFactory();
+        var failurePolicy = new RecordingDecodeFailurePolicy(TelegramUpdateDecodeFailureDecision.Skip);
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            loggerFactory: loggerFactory,
+            decodeFailurePolicy: failurePolicy);
+
+        var context = await InvokeAsync(app, PoisonUpdateJson);
+
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        var warning = Assert.Single(
+            loggerFactory.Entries,
+            entry => entry.Level == LogLevel.Warning && entry.EventId.Id == 7);
+        Assert.Contains("update_id=124", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("payload_sha256=", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("private poison payload", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_DoesNotAcknowledgeWhenFailureHandlerThrows()
+    {
+        var failurePolicy = new ThrowingDecodeFailurePolicy();
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            decodeFailurePolicy: failurePolicy);
+        var context = CreateHttpContext(app.Services, PoisonUpdateJson);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            GetSingleRoute(app).RequestDelegate!(context));
+
+        Assert.Equal("quarantine failed", exception.Message);
+    }
+
+    [Fact]
+    public async Task RawWebhookEndpoint_MissingUpdateIdRemainsInvalidPayload()
+    {
+        var failurePolicy = new RecordingDecodeFailurePolicy(TelegramUpdateDecodeFailureDecision.Skip);
+        await using var app = CreateApp(
+            static (_, _, _) => Task.FromResult<IResult>(Results.Ok()),
+            decodeFailurePolicy: failurePolicy);
+
+        var context = await InvokeAsync(app, "{\"message\":{}}");
+
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.Empty(failurePolicy.Failures);
+    }
+
+    [Fact]
     public async Task RawWebhookEndpoint_RejectsMissingSecretToken()
     {
         var invoked = false;
@@ -296,12 +385,28 @@ public sealed class TelegramWebhookTests
         }
         """;
 
+    private const string PoisonUpdateJson = """
+        {
+          "update_id": 124,
+          "message": {
+            "message_id": 1,
+            "date": "invalid",
+            "chat": {
+              "id": 42,
+              "type": "private"
+            },
+            "text": "private poison payload"
+          }
+        }
+        """;
+
     private static WebApplication CreateApp(
         TelegramRawWebhookHandler handler,
         string path = "/telegram",
         FakeTelegramClient? bot = null,
         Action<TelegramRawWebhookOptions>? configure = null,
-        RecordingLoggerFactory? loggerFactory = null)
+        RecordingLoggerFactory? loggerFactory = null,
+        ITelegramUpdateDecodeFailurePolicy? decodeFailurePolicy = null)
     {
         var builder = WebApplication.CreateBuilder();
 
@@ -309,6 +414,11 @@ public sealed class TelegramWebhookTests
         if (loggerFactory is not null)
         {
             builder.Services.AddSingleton<ILoggerFactory>(loggerFactory);
+        }
+
+        if (decodeFailurePolicy is not null)
+        {
+            builder.Services.AddSingleton(decodeFailurePolicy);
         }
 
         var app = builder.Build();
@@ -368,6 +478,31 @@ public sealed class TelegramWebhookTests
             CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
+        }
+    }
+
+    private sealed class RecordingDecodeFailurePolicy(TelegramUpdateDecodeFailureDecision decision) :
+        ITelegramUpdateDecodeFailurePolicy
+    {
+        public List<TelegramUpdateDecodeFailure> Failures { get; } = [];
+
+        public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+            TelegramUpdateDecodeFailure failure,
+            CancellationToken cancellationToken = default)
+        {
+            Failures.Add(failure);
+            return ValueTask.FromResult(decision);
+        }
+    }
+
+    private sealed class ThrowingDecodeFailurePolicy : ITelegramUpdateDecodeFailurePolicy
+    {
+        public ValueTask<TelegramUpdateDecodeFailureDecision> DecideAsync(
+            TelegramUpdateDecodeFailure failure,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromException<TelegramUpdateDecodeFailureDecision>(
+                new InvalidOperationException("quarantine failed"));
         }
     }
 }


### PR DESCRIPTION
## Problem

A valid Telegram Bot API 10.2 rich-message update used ordered-list type `"1"`, but the generated schema required the invalid literal `"one"`. Long polling then classified the deterministic schema failure as transient and retried the same update forever, blocking all later updates.

Generator correction: IWFTech/TelegramSchemaGenerator#22.

## Changes

- refresh the generated rich-list models without the invalid discriminator;
- decode `getUpdates` results one update at a time in the built-in transport path;
- stop retrying deterministic schema decode failures as transient request failures;
- add `ITelegramUpdateDecodeFailurePolicy` with fail-closed `Stop` and explicit `Skip` decisions;
- apply the same policy to syntactically valid webhook updates that do not match the installed schema;
- preserve malformed webhook payload handling as `400` and direct `ITelegramClient.SendAsync(new GetUpdates())` as strict/atomic;
- log only update id, JSON path, and SHA-256 fingerprint, never the raw update payload;
- document acknowledgement, cancellation, quarantine, and idempotency semantics in English and Russian.

## Touched hot paths

- `TelegramUpdateBatchRequest` and `TelegramUpdateDecoder`: per-element `getUpdates` decoding. Successful results use a readonly struct carrier; raw JSON and SHA-256 are created only on schema failure.
- `TelegramLongPollingClient`: ordered policy decision before offset advancement. Existing handler dispatch and successful-update acknowledgement order remain unchanged.
- `TelegramRawWebhookEndpoint`: parse envelope, identify `update_id`, then apply the shared decode policy. Normal handler execution remains unchanged.

## Failure contract

| Condition | Default result | Explicit `Skip` |
|---|---|---|
| Long-poll schema mismatch | throw once; do not advance offset | acknowledge only after policy completes |
| Webhook schema mismatch | HTTP 500 | HTTP 200 only after policy completes |
| Policy throws or is cancelled | no acknowledgement | no acknowledgement |
| Malformed webhook JSON/envelope | HTTP 400 | policy is not called |

## Verification

- Release build: 0 warnings, 0 errors
- Strict analyzers: passed
- Fast suite: 863 passed
- Package smoke: 4 passed
- Style and whitespace formatting: passed
- `git diff --check`: passed