### PR TITLE
fix(schema): support value-type API response results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ TeleFlow follows SemVer for published NuGet packages and documented public behav
 
 ## Unreleased
 
+## 1.0.0-alpha.14.1 - 2026-08-14
+
+### Fixed
+
+- Fixed `TelegramApiResponse<TResult>` JSON metadata for value-type results such as `bool`. Raw response envelopes now serialize and deserialize valid `false` results without `System.Text.Json` rejecting the generated contract.
+
+This hotfix remains aligned with Telegram Bot API 10.2. Update all TeleFlow packages used by an application to `1.0.0-alpha.14.1` together.
+
 ## 1.0.0-alpha.14 - 2026-08-05
 
 ### Added

--- a/src/TeleFlow.Telegram.Schema/Responses/TelegramApiResponse.g.cs
+++ b/src/TeleFlow.Telegram.Schema/Responses/TelegramApiResponse.g.cs
@@ -22,7 +22,6 @@ public sealed partial record class TelegramApiResponse<TResult>
     public required bool Ok { get; init; }
 
     [JsonPropertyName("result")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TResult? Result { get; init; }
 
     [JsonPropertyName("description")]

--- a/src/TeleFlow.Telegram.Schema/telegram-bot-api.manifest.json
+++ b/src/TeleFlow.Telegram.Schema/telegram-bot-api.manifest.json
@@ -2,8 +2,8 @@
   "manifestVersion": 1,
   "source": {
     "url": "https://core.telegram.org/bots/api",
-    "capturedAtUtc": "2026-08-05T19:54:03.4531767+00:00",
-    "sha256": "c85465cbc2da0c1639cbb82fd1f7e3bed7898b3613625dc439f805b9a500e236"
+    "capturedAtUtc": "2026-08-13T23:01:07.513274+00:00",
+    "sha256": "01ceb0320c34eea5f80d34b59e82194e41ddf75ab164d003f02ba6c9d015890a"
   },
   "telegramBotApi": {
     "version": "10.2",
@@ -13,6 +13,6 @@
   },
   "pipeline": {
     "schemaVersion": 10,
-    "generatorVersion": 11
+    "generatorVersion": 12
   }
 }

--- a/tests/TeleFlow.ArchitectureTests/TelegramSchemaTests.cs
+++ b/tests/TeleFlow.ArchitectureTests/TelegramSchemaTests.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using TeleFlow.Telegram.Schema.Abstractions;
 using TeleFlow.Telegram.Schema.Constants;
 using TeleFlow.Telegram.Schema.Methods;
+using TeleFlow.Telegram.Schema.Responses;
 using TeleFlow.Telegram.Schema.Types;
 using IoFile = System.IO.File;
 
@@ -579,6 +580,24 @@ public sealed class TelegramSchemaTests
             var contents = IoFile.ReadAllText(file);
             Assert.DoesNotContain("public object Value { get; }", contents, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public void TelegramApiResponse_ValueTypeResult_RoundTripsWithoutInvalidJsonMetadata()
+    {
+        var response = new TelegramApiResponse<bool>
+        {
+            Ok = true,
+            Result = false
+        };
+
+        var json = JsonSerializer.Serialize(response, JsonOptions);
+        var roundTrip = JsonSerializer.Deserialize<TelegramApiResponse<bool>>(json, JsonOptions);
+
+        Assert.Equal("{\"ok\":true,\"result\":false}", json);
+        Assert.NotNull(roundTrip);
+        Assert.True(roundTrip.Ok);
+        Assert.False(roundTrip.Result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- refresh the generated Telegram response envelope with generator contract version 12;
- allow value-type results such as `bool` without invalid `System.Text.Json` metadata;
- preserve legitimate `false` results during serialization;
- prepare aligned package hotfix `1.0.0-alpha.14.1`.

## Root cause

`TelegramApiResponse<TResult>.Result` used `JsonIgnoreCondition.WhenWritingNull`. With an unconstrained generic, `TResult?` is still a non-nullable value type for `TResult = bool`, so `System.Text.Json` rejected the generated contract before serialization or deserialization.

`WhenWritingDefault` is intentionally not used because Telegram may return a legitimate `false` result which must remain in the envelope.

## Touched public surface

- generated `TelegramApiResponse<TResult>` JSON metadata only;
- no client request path, routing path, transport retry path, or handler dispatch path changed.

## Verification

- generator `./eng/verify.ps1`: 7 passed
- TeleFlow `./eng/verify-release.ps1 -PackageVersion 1.0.0-alpha.14.1 -Configuration Release`: 868 passed
- strict analyzers: 0 warnings, 0 errors
- package output and metadata verification passed
- schema guardrails: 793 generated files checked
- formatting, whitespace, and `git diff --check` passed

## Dependency

Generated from TelegramSchemaGenerator main after IWFTech/TelegramSchemaGenerator#24 was merged.